### PR TITLE
Rename NPM package to swlegion-tts-mod.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "tts",
+  "name": "swlegion-tts-mod",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tts",
+  "name": "swlegion-tts-mod",
   "scripts": {
     "embed": "npx ts-node script/index.ts embed mod/src mod/StarWarsLegion.json",
     "extract": "npx ts-node script/index.ts extract mod/StarWarsLegion.json mod/src"


### PR DESCRIPTION
... this fixes GitHub showing this package as "used", when it is not.