### PR TITLE
Fixes issue with corps units spawning the incorrect movement tools / range bands

### DIFF
--- a/mod/src/blockrectangle.a57c41.lua
+++ b/mod/src/blockrectangle.a57c41.lua
@@ -457,6 +457,8 @@ function nextUnit()
 
                 highlightUnit(selectedUnitObj.getTable("miniGUIDs"),{0,1,0})
                 highlightCard(getObjectFromGUID(selectedUnitObj.getVar("cardGUID")))
+                getSelectedUnitObjVariables()
+                setTemplateVariables()
                 out = true
             end
         end


### PR DESCRIPTION
When a unit is activation data is set based on its base size and movement characteristics. Cycling through units with the NEXT button to a unit with a different base size / movement type will maintain the details of the initially selected unit.
This change resets the template / base details of each unit as you cycle through with NEXT.

Fixes https://github.com/swlegion/tts/issues/83