### PR TITLE
Uncomment initiation unit method call

### DIFF
--- a/mod/src/blockrectangle.a57c41.lua
+++ b/mod/src/blockrectangle.a57c41.lua
@@ -224,12 +224,9 @@ end
 
 ------------------------------------------------- STANDBY ------------------------------------------------------------
 function initialize()
-
     activated = false
-    --getEligibleUnit()
-
+    getEligibleUnit()
     createStandbyButtons()
-
 end
 
 function createStandbyButtons()


### PR DESCRIPTION
Code was commented out which initialized a unit to be selected by a chosen token.

Fixes https://github.com/swlegion/tts/issues/93