### PR TITLE
Add R2D2 Command Cards.

### DIFF
--- a/mod/src/~global.lua
+++ b/mod/src/~global.lua
@@ -981,7 +981,7 @@ function onLoad()
     }
     listBuilder.commandCards.r2d2 = {
         varName = "r2d2",
-        cards = {"Blast Off!", "Push", "Assault"}
+        cards = {"Blast Off!", "Impromptu Immolation", "Smoke Screen"}
     }
     listBuilder.commandCards.c3po = {
         varName = "c3po",


### PR DESCRIPTION
Closes #118.

I added both of the new R2D2 command cards to the mod, following https://github.com/swlegion/tts/wiki/Creating-Minis-and-Cards (made a few tweaks including a reference to the "back" image for command cards).

Staged at https://steamcommunity.com/sharedfiles/filedetails/?id=1921621370.

Assets:

![r2-command-cards](https://user-images.githubusercontent.com/168174/70670501-f784c100-1c2d-11ea-9e09-e5df951f9e95.png)

List Builder:

![list-builder-options-r2](https://user-images.githubusercontent.com/168174/70670500-f784c100-1c2d-11ea-94d9-88b522643d85.png)

Command Hand:

![command-hand-r2](https://user-images.githubusercontent.com/168174/70670499-f784c100-1c2d-11ea-96d0-ef0543b1a1bc.png)