### PR TITLE
Fix R2D2s command hand.

### DIFF
--- a/mod/src/~global.lua
+++ b/mod/src/~global.lua
@@ -1010,7 +1010,7 @@ function onLoad()
     }
     listBuilder.commandCards.republicR2d2 = {
         varName = "republicR2d2",
-        cards = {"Blast Off!", "Push", "Assault"}
+        cards = {"Blast Off!", "Impromptu Immolation", "Smoke Screen"}
     }
     listBuilder.commandCards.republicC3po = {
         varName = "republicC3po",


### PR DESCRIPTION
Small fix: the list builder only had the right command cards for Rebels, not GAR.