### PR TITLE
Fix command stack tts update

### DIFF
--- a/mod/src/blue_command_stack.c9f9d0.lua
+++ b/mod/src/blue_command_stack.c9f9d0.lua
@@ -9,7 +9,7 @@ function onObjectLeaveContainer(container, leave_object)
 end
 
 function updateStack()
-    local tokenObjs = self.getObjects()
+    local tokenObjs = self.getChildren()
     if #tokenObjs == 0 then
         self.setColorTint({65/255,88/255,114/255})
         self.setScale({1,1,1})

--- a/mod/src/blue_command_tray.ac8fe2.lua
+++ b/mod/src/blue_command_tray.ac8fe2.lua
@@ -44,9 +44,12 @@ function onLoad(save_state)
 end
 
 function splitTokens()
+    print('Split is temporary disabled due to a TTS update/bug. Do this manually instead.')
+    do return end
+
     splitButton.AssetBundle.playTriggerEffect(0)
 
-    local commandStackObjs = commandStack.getObjects()
+    local commandStackObjs = commandStack.getChildren()
     local commandStackPos = commandStack.getPosition()
     if #commandStackObjs != 0 then
         for i, obj in pairs(commandStackObjs) do
@@ -134,7 +137,10 @@ end
 function shuffleTokens()
     shuffleButton.AssetBundle.playTriggerEffect(0)
     commandStack.call("updateStack")
-    if #commandStack.getObjects() > 0 then
+
+    -- TEMPORARY: As of 2020-04-20 update, this always is false otherwise.
+    -- if #commandStack.getChildren() > 0 then
+    if true then
         commandStack.shuffle()
         if Player[strColor].seated then
             broadcastToColor("Shuffling Command Stack", strColor, {1,1,1})

--- a/mod/src/blue_list_builder.60e426.lua
+++ b/mod/src/blue_list_builder.60e426.lua
@@ -838,7 +838,7 @@ function clearZone()
 
     local commandStack = getObjectFromGUID(commandTokenTrayData[colorSide].stack)
 
-    local commandStackObjs = commandStack.getObjects()
+    local commandStackObjs = commandStack.getChildren()
 
     for _, obj in pairs(commandStackObjs) do
         local drawnObj = commandStack.takeObject()

--- a/mod/src/red_command_stack.e2202d.lua
+++ b/mod/src/red_command_stack.e2202d.lua
@@ -9,7 +9,7 @@ function onObjectLeaveContainer(container, leave_object)
 end
 
 function updateStack()
-    local tokenObjs = self.getObjects()
+    local tokenObjs = self.getChildren()
     if #tokenObjs == 0 then
         self.setColorTint({65/255,88/255,114/255})
         self.setScale({1,1,1})

--- a/mod/src/red_command_tray.552739.lua
+++ b/mod/src/red_command_tray.552739.lua
@@ -44,9 +44,12 @@ function onLoad(save_state)
 end
 
 function splitTokens()
+    print('Split is temporary disabled due to a TTS update/bug. Do this manually instead.')
+    do return end
+
     splitButton.AssetBundle.playTriggerEffect(0)
 
-    local commandStackObjs = commandStack.getObjects()
+    local commandStackObjs = commandStack.getChildren()
     local commandStackPos = commandStack.getPosition()
     if #commandStackObjs != 0 then
         for i, obj in pairs(commandStackObjs) do
@@ -133,7 +136,10 @@ end
 function shuffleTokens()
     shuffleButton.AssetBundle.playTriggerEffect(0)
     commandStack.call("updateStack")
-    if #commandStack.getObjects() > 0 then
+
+    -- TEMPORARY: As of 2020-04-20 update, this always is false otherwise.
+    -- if #commandStack.getChildren() > 0 then
+    if true then
         commandStack.shuffle()
         if Player[strColor].seated then
             broadcastToColor("Shuffling Command Stack", strColor, {1,1,1})

--- a/mod/src/red_list_builder.8708be.lua
+++ b/mod/src/red_list_builder.8708be.lua
@@ -835,7 +835,7 @@ function clearZone()
 
     local commandStack = getObjectFromGUID(commandTokenTrayData[colorSide].stack)
 
-    local commandStackObjs = commandStack.getObjects()
+    local commandStackObjs = commandStack.getChildren()
 
     for _, obj in pairs(commandStackObjs) do
         local drawnObj = commandStack.takeObject()


### PR DESCRIPTION
Hot fixes for the latest TTS update: https://steamcommunity.com/app/286160/eventcomments/2138588424846932840.

Notably, command stack needed to be changed to use `.getChildren()` - it still seems to not work properly for `splitTokens()`, so that functionality has been temporarily disabled as a result. Will stage on test mod for further testing and to see if the TTS devs rollback/hotfix.

https://steamcommunity.com/sharedfiles/filedetails/changelog/1921621370