### PR TITLE
Hide the chess clocks UI by default.

### DIFF
--- a/mod/src/StarWarsLegion.xml
+++ b/mod/src/StarWarsLegion.xml
@@ -1,4 +1,5 @@
 <VerticalLayout
+  active="false"
   color="black"
   id="legionDisplay"
   height="10"

--- a/mod/src/StarWarsLegion/GAME_CONTROLLER.623b03.lua
+++ b/mod/src/StarWarsLegion/GAME_CONTROLLER.623b03.lua
@@ -1031,9 +1031,5 @@ end
 
 function enableExperimentalFeatures()
     ga_event("Global", "enableExperimentalFeatures")
-    printToAll("Enabled Experiments! Do not file bug reports or requests about these features.")
-    local blueListBuilder = getObjectFromGUID("60e426")
-    local redListBuilder = getObjectFromGUID("8708be")
-    blueListBuilder.UI.show("mainPanel")
-    redListBuilder.UI.show("mainPanel")
+    Global.UI.show("legionDisplay")
 end


### PR DESCRIPTION
This feature is still niche (i.e. likely less than a fraction of a percent of users) and takes up valuable real-estate.

It can be enabled manually in the PC console UI.