### PR TITLE
Properly check command type when activating.

### DIFF
--- a/mod/src/StarWarsLegion/Blank_Order_Tokens/Blank_Order_Token.e1211f.lua
+++ b/mod/src/StarWarsLegion/Blank_Order_Tokens/Blank_Order_Token.e1211f.lua
@@ -123,11 +123,14 @@ function assign_unit_to_this_token(token, color, alt_click)
         if object.getGUID() ~= self.getGUID() then
             if object.getVar("unitName") and object.getTable("miniGUIDs") then
                 local unit_name = object.getVar("unitName")
+                -- We don't lookup the unit rank, because some other effect in
+                -- the game could have already changed the unit leader's rank
+                -- (such as covert ops, promote).
+                local unit_rank = object.getTable("unitData").commandType
                 local unit_faction = object.getVar("faction")
-                local unit_command_type = unit_info_table[unit_name].commandType
                 local unit_token_name = unit_info_table[unit_name].tokenName
 
-                update_token(unit_name, unit_faction, unit_command_type, unit_token_name, color)
+                update_token(unit_name, unit_faction, unit_rank, unit_token_name, color)
             end
         end
     end

--- a/mod/src/StarWarsLegion/Order_Token.a57c41.lua
+++ b/mod/src/StarWarsLegion/Order_Token.a57c41.lua
@@ -94,7 +94,6 @@ function getEligibleUnit()
     local allUnits = nil
     local allUnits = battlefieldZone.getObjects()
 
-
     if allUnits != nil then
         local closestDistance = 9999999999999
 
@@ -103,8 +102,8 @@ function getEligibleUnit()
             -- check eligibility
 
             local miniData = unit.getTable("unitData")
-            if miniData != nil then
-                if unitData.commandType == miniData.tokenCommandType and unit.getVar("colorSide") == colorSide then
+            if miniData != nil and miniData.commandType != nil then
+                if unitData.tokenCommandType == miniData.commandType and unit.getVar("colorSide") == colorSide then
                     -- add to eligible units
                     eligibleUnitsNumber = eligibleUnitsNumber + 1
                     eligibleUnits[eligibleUnitsNumber] = unit


### PR DESCRIPTION
Closes https://github.com/swlegion/tts/issues/383.

I also fixed the "Assign" button corner-case after "Covert Ops" or "Promote" was used.