### PR TITLE
More accurate move distance calculations

### DIFF
--- a/mod/src/StarWarsLegion.lua
+++ b/mod/src/StarWarsLegion.lua
@@ -83,24 +83,26 @@ function onload(saveData)
         end
     end
 
+    -- math available here: https://docs.google.com/spreadsheets/d/1LD6spROJFw29c5L-lN1RJwqk7XplQShOj1Z8QQkBGf4/edit?usp=sharing
+    -- formula is: ((tool - notch + base) * 0.5) /25.4
     templateInfo.aStart = {}
-    templateInfo.aStart.small = 	{1.968995, 3, 4}
-    templateInfo.aStart.medium = 	{2.234375, 3.26538, 4.26538}
-    templateInfo.aStart.large =		{2.640625, 3.67163, 4.67163}
-    templateInfo.aStart.huge =		{3.21875, 4.249755, 5.249755}
-    templateInfo.aStart.laat =      {4.21875 - 0.59055, 5.249755 - 0.59055, 6.249755 - 0.59055}
-    templateInfo.aStart.long =		{4.71875, 5.749755, 6.749755}
-    templateInfo.aStart.epic =		{4.21875, 5.249755, 6.249755}
+    templateInfo.aStart.small = 	{2.007874016, 2.992125984, 3.976377953}
+    templateInfo.aStart.medium = 	{2.342519685, 3.326771654, 4.311023622}
+    templateInfo.aStart.large =		{2.736220472, 3.720472441, 4.704724409}
+    templateInfo.aStart.huge =		{3.326771654, 4.311023622, 5.295275591}
+    templateInfo.aStart.laat =      {3.720472441, 4.704724409, 5.688976378}
+    templateInfo.aStart.long =		{4.803149606, 5.787401575, 6.771653543}
+    templateInfo.aStart.epic =		{4.311023622, 5.295275591, 6.279527559}
 
+    --probably just remove these at some point
     templateInfo.bStart = {}
-    templateInfo.bStart.small = 	{1.968995, 3, 4}
-    templateInfo.bStart.medium =	{2.234375, 3.26538, 4.26538}
-    templateInfo.bStart.large =		{2.640625, 3.67163, 4.67163}
-    templateInfo.bStart.huge =		{3.21875, 4.249755, 5.249755}
-    templateInfo.bStart.long =		{4.71875, 5.749755, 6.749755}
-
-    templateInfo.bStart.laat = templateInfo.aStart.laat
-    templateInfo.bStart.epic = templateInfo.aStart.epic
+    templateInfo.bStart.small = 	templateInfo.aStart.small
+    templateInfo.bStart.medium =	templateInfo.aStart.medium
+    templateInfo.bStart.large =		templateInfo.aStart.large
+    templateInfo.bStart.huge =		templateInfo.aStart.huge
+    templateInfo.bStart.long =		templateInfo.aStart.long
+    templateInfo.bStart.laat =      templateInfo.aStart.laat
+    templateInfo.bStart.epic =      templateInfo.aStart.epic
 
 
 


### PR DESCRIPTION
I have dialed in the move distances to match the projector measurements which I calculated here: https://docs.google.com/spreadsheets/d/1LD6spROJFw29c5L-lN1RJwqk7XplQShOj1Z8QQkBGf4/edit?usp=sharing

The formula is: ((tool - notch + base) * 0.5) /25.4
- The notch obviously doesn't apply to small based troopers
- the "/25.4" is the conversion from mm to in (tts is in inches but bases and move tools are in mm)

Observations:
- This makes the projectors and movement results REALLY REALLY REALLY CLOSE.  
- Are they exactly perfect?  No, even just spawning a move tool can nudge stuff around ever so slightly, which is its own bug to deal with (but I will probably do that next).  
- Individual models may not have perfectly up to date and consistent colliders.  
- The speed-1 move tool seems a bit too short.
- The variance in terrain colliders adds more imprecision.
- I think we're well within margin of error at this point and probably more accurate than how most people play IRL.  But there is some subset of OCD players in the community that are going to lose their minds.  However, they didn't care that the mod was treating a speed 2 move as 6" so they can uninstall.