### PR TITLE
Cherry Pick: Read aStart instead of bStart for Payloads.

### DIFF
--- a/mod/src/includes/data/BombCarts.ttslua
+++ b/mod/src/includes/data/BombCarts.ttslua
@@ -128,7 +128,7 @@ function spawnMoveTemplate()
   ]]
 
   local aStart = templateInfo.aStart[baseSize][selectedSpeed]
-  local bStart = templateInfo.bStart[baseSize][selectedSpeed]
+  local bStart = templateInfo.aStart[baseSize][selectedSpeed]
 
   local q = math.rad(baseRot.y)
   local a = aStart * math.cos(q)


### PR DESCRIPTION
Cherry pick of #481.