### PR TITLE
Fix small spawning issues

### DIFF
--- a/mod/src/includes/SpawnList.ttslua
+++ b/mod/src/includes/SpawnList.ttslua
@@ -148,7 +148,7 @@ local function initListSpawner(params)
       z = adjustedPos.z,
     }
     local paddedBase = (base + padding) * 1.5
-    local basesPerRow = math.abs(math.floor(templateHalfWidth * 2.0 / paddedBase))
+    local basesPerRow = math.max(1, math.abs(math.floor(templateHalfWidth * 2.0 / paddedBase)))
     local newIndex = index
     local totalZOffset = initialZOffset(upgradeCount)
     if index > basesPerRow then

--- a/mod/src/includes/SpawnList.ttslua
+++ b/mod/src/includes/SpawnList.ttslua
@@ -357,9 +357,11 @@ local function initListSpawner(params)
       rotation = {0, rotation.y + 180, 0},
       smooth   = false,
     })
-    local unitIdState = math.fmod(index, 10)
+
+    local unitIdState = ((index - 1) % 10) + 1
+
     if unitIdState > 1 then
-      unitId.setState(unitIdState)
+      unitId = unitId.setState(unitIdState)
     end
 
     local miniData = {


### PR DESCRIPTION
1. Large base minis now spawn in the first spawn row instead of always in the second one. The issue was that the `basesPerRow` value equates to 0 for large bases. Set a minimum of 1 to `basesPerRow`


![image](https://user-images.githubusercontent.com/39471681/177025747-ad9eaf00-ef02-44b8-a400-c192f6b3118c.png)

![image](https://user-images.githubusercontent.com/39471681/177025763-3091f50f-08f1-4312-99e8-9f878787eba2.png)


2. UnitID tokens would not number above 5, and everythin after 5 would remain as 1. This was due to a strange behaviour of `math.fmod()` resulting in negative values, e.g. `fmod(6,10) -> -4`. A change to the `%` modulo operator addresses this and also allows for covering the 10th index case, unlike `fmod`

3. UnitID tinting was only applied to unitID tokens that hadn't had their state changed. Added a reassignment of the unitId token upon state change to carry the new object GUID through

![image](https://user-images.githubusercontent.com/39471681/177025826-a3838169-0fe8-450f-8431-61171fc1d143.png)

![image](https://user-images.githubusercontent.com/39471681/177025837-c0eb5290-97b8-436d-8c03-63698c7c7979.png)

