### PR TITLE
Allow spawning range ruler from any mini

### DIFF
--- a/mod/src/includes/RangeRulers.ttslua
+++ b/mod/src/includes/RangeRulers.ttslua
@@ -1,18 +1,20 @@
 require('!/data/RangeRulerLinks')
 
 function showRangeOnHoveredModel(hoverObject)
+  clearRangeRulers()
   if hoverObject then
     if hoverObject.interactable then
-      unitData = {}
       if selectedUnitObj == hoverObject then
-        clearRangeRulers()
         selectedUnitObj = nil
         return
+      else
+        spawnRangeRuler(hoverObject)
+        selectedUnitObj = hoverObject
       end
     end
+  else
+    selectedUnitObj = nil
   end
-  clearRangeRulers()
-  spawnRangeRuler(hoverObject)
 end
 
 -- Refactor this to work with the refactored spawnRangeRuler()
@@ -36,12 +38,26 @@ function spawnRangeRuler(rangeSourceObject, projectorBundleOverride)
   if projectorBundleOverride ~= nil then
     rulerBundleToSpawn = projectorBundleOverride
   else
-    local newUnitData = rangeSourceObject.getTable("unitData")
-    if not newUnitData then 
-      return 
+    -- Get unit data from leader if leader hovered
+    local unitData = rangeSourceObject.getTable("unitData")
+
+    -- If leader not hovered, get leader GUID from mini data to get unit data
+    if not unitData then
+      local miniData = rangeSourceObject.getTable("miniData")
+      if not miniData then
+        return
+      end
+      unitLeader = getObjectFromGUID(miniData.leaderGUID)
+      if not unitLeader then
+        return 
+      end
+      unitData = unitLeader.getTable("unitData")
+      if not unitData then
+        return 
+      end
     end
 
-    local baseSize = newUnitData.baseSize
+    local baseSize = unitData.baseSize
     local rulerBundleTable = getRangeRulerLinks()
     rulerBundleToSpawn = rulerBundleTable[baseSize] 
   end

--- a/mod/src/includes/RangeRulers.ttslua
+++ b/mod/src/includes/RangeRulers.ttslua
@@ -43,11 +43,7 @@ function spawnRangeRuler(rangeSourceObject, projectorBundleOverride)
 
     -- If leader not hovered, get leader GUID from mini data to get unit data
     if not unitData then
-      local miniData = rangeSourceObject.getTable("miniData")
-      if not miniData then
-        return
-      end
-      unitLeader = getObjectFromGUID(miniData.leaderGUID)
+      local unitLeader = getObjectFromGUID(rangeSourceObject.getVar("leaderGUID"))
       if not unitLeader then
         return 
       end

--- a/mod/src/includes/SpawnList.ttslua
+++ b/mod/src/includes/SpawnList.ttslua
@@ -190,7 +190,7 @@ local function initListSpawner(params)
       -- SET NAME
       local displayName = pMiniTable.displayName or objEntry.name
       objEntry.obj.setName(strColor.. " "..displayName)
-      selectedMiniScript = selectedMiniScript .. "colorSide = '"..pMiniTable.colorSide.."'\nminiName = \""..objEntry.name.."\"\n"
+      selectedMiniScript = selectedMiniScript .. "colorSide = '"..pMiniTable.colorSide.."'\nminiName = \""..objEntry.name.."\"\nleaderGUID = \"" .. leaderGUID .. "\"\n"
 
       if i == leaderInt then
         -- DESCRIPTION
@@ -220,7 +220,6 @@ local function initListSpawner(params)
           "\"\n" .. globals.modelMiniScript
       else
         objEntry.obj.use_snap_points = false
-        objEntry.obj.setTable("miniData", {leaderGUID = leaderGUID})
       end
 
       -- SET SCRIPT

--- a/mod/src/includes/SpawnList.ttslua
+++ b/mod/src/includes/SpawnList.ttslua
@@ -181,6 +181,8 @@ local function initListSpawner(params)
     -- detect leader units
     local leaderInt = pMiniTable.leaderIndex
 
+    local leaderGUID = pMiniTable.miniObjs[leaderInt].obj.getGUID()
+
     for i, objEntry in pairs(pMiniTable.miniObjs) do
       -- init mini script
       local selectedMiniScript = ""
@@ -218,6 +220,7 @@ local function initListSpawner(params)
           "\"\n" .. globals.modelMiniScript
       else
         objEntry.obj.use_snap_points = false
+        objEntry.obj.setTable("miniData", {leaderGUID = leaderGUID})
       end
 
       -- SET SCRIPT

--- a/mod/src/includes/SpawnList.ttslua
+++ b/mod/src/includes/SpawnList.ttslua
@@ -190,7 +190,10 @@ local function initListSpawner(params)
       -- SET NAME
       local displayName = pMiniTable.displayName or objEntry.name
       objEntry.obj.setName(strColor.. " "..displayName)
-      selectedMiniScript = selectedMiniScript .. "colorSide = '"..pMiniTable.colorSide.."'\nminiName = \""..objEntry.name.."\"\nleaderGUID = \"" .. leaderGUID .. "\"\n"
+      selectedMiniScript = selectedMiniScript .. "colorSide = '"..pMiniTable.colorSide.."'\nminiName = \""..objEntry.name.."\"\n"
+
+      -- SET LEADER GUID
+      selectedMiniScript = selectedMiniScript .. "leaderGUID = \"" .. leaderGUID .. "\"\n"
 
       if i == leaderInt then
         -- DESCRIPTION


### PR DESCRIPTION
Addresses Issue #493 

Achieved by giving each mini a pointer to the GUID of their unit leader, then if the range ruler is not spawned on a leader, that GUID is used to get the unit data required to spawn the rulers. This leader GUID reference may prove useful for other features too.

Additionally, there is a behavioural change, where the rulers now toggle when repeatedly triggered on the same mini, rather than clearing it and respawining it instantly

![image](https://user-images.githubusercontent.com/39471681/177026125-dfe42b33-c7d3-4e6f-b151-6ce2b3447d49.png)
