### PR TITLE
Update homebrew.json

### DIFF
--- a/contrib/cards/homebrew.json
+++ b/contrib/cards/homebrew.json
@@ -1,5113 +1,5283 @@
 {
-  "units": {
-    "Empire": {
-      "Operative": [
-        {
-          "name": "Gar Saxon",
-          "title": "Ferocius and Merciless Warrior",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751698926/DEEC78B093B0018CAB33C87DC0888B05EF646E68/",
-          "size": "small",
-          "type": "Mandalorian Trooper",
-          "points": 120,
-          "speed": 3,
-          "upgrades": {
-            "Training": 2,
-            "Comms": 1,
-            "Gear": 1,
-            "Armament": 2
+    "units": {
+      "Empire": {
+        "Operative": [
+          {
+            "name": "Gar Saxon",
+            "title": "Ferocius and Merciless Warrior",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751698926/DEEC78B093B0018CAB33C87DC0888B05EF646E68/",
+            "size": "small",
+            "type": "Mandalorian Trooper",
+            "points": 120,
+            "speed": 3,
+            "upgrades": {
+              "Training": 2,
+              "Comms": 1,
+              "Gear": 1,
+              "Armament": 2
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982271779/BBF522FC361772E237872CCC9E983F4A7CD58838/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982271948/1595F95FC7DB45109C0C2BCBE8A06B0F487FD04E/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "A Man of Opportunities",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751699409/6A9728D6816A10B7B0EADBC2193008793FB4A3F8/",
+                "pip": 1
+              },
+              {
+                "name": "Jetpack Charge",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751699906/29D9FAE52580C82BC543ACF392E46E98D23533AB/",
+                "pip": 2
+              },
+              {
+                "name": "Viceroy of Mandalore",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751700204/E379AF4A3824F8CFFB8EFAED55B651116AFE5125/",
+                "pip": 3
+              }
+            ]
+          }
+        ],
+        "Special Forces": [
+          {
+            "name": "Imperial Supercommandos",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751938598/EA4F3008844B6528784403937811449891C14FCE/",
+            "size": "small",
+            "type": "Mandalorian Trooper",
+            "points": 76,
+            "speed": 2,
+            "upgrades": {
+              "Personnel": 1,
+              "Training": 2,
+              "Comms": 1,
+              "Armament": 2
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982273795/D117C3122139FF5A93AAB4E5DCD2455FF70508F1/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982273931/809947D430BEB447CD2FA3E99DD31AF57C3E8F84/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982274574/BFFC62F32FE65628DB446AAA3674E5C49F92DE2F/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982273931/809947D430BEB447CD2FA3E99DD31AF57C3E8F84/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982275923/F4BDE2E8B1C496AFAB7DCF11728CA5AD58EC55FE/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982273931/809947D430BEB447CD2FA3E99DD31AF57C3E8F84/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982276438/B609AA7C947FFDBFFFDE022D21A4029EF4428282/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982273931/809947D430BEB447CD2FA3E99DD31AF57C3E8F84/"
+              }
+            ]
+          }
+        ],
+        "Support": [
+          {
+            "name": "AT-LDT",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751888859/BEC4E39876A92E0FFC2504196992E2072E99BDE8/",
+            "size": "large",
+            "type": "Ground Vehicle",
+            "points": 70,
+            "speed": 1,
+            "upgrades": {
+              "Comms": 1,
+              "Ordnance": 1,
+              "Generator": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1055478574361579189/41CE0402F950AB518DB08E026AF96F46804E5AAB/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1055478574361579329/ABE5D81D7D16FF3DF9D9EA1247787AF86A112C61/"
+              }
+            ]
           },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982271779/BBF522FC361772E237872CCC9E983F4A7CD58838/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982271948/1595F95FC7DB45109C0C2BCBE8A06B0F487FD04E/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "A Man of Opportunities",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751699409/6A9728D6816A10B7B0EADBC2193008793FB4A3F8/",
-              "pip": 1
+          {
+            "name": "Phase II Darktroopers",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751974310/FADC3793016675ADF27F22082439F243F5CFF323/",
+            "size": "medium",
+            "type": "Droid Trooper",
+            "points": 110,
+            "speed": 1,
+            "upgrades": {
+              "Ordnance": 2,
+              "Comms": 1,
+              "Gear": 1
             },
-            {
-              "name": "Jetpack Charge",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751699906/29D9FAE52580C82BC543ACF392E46E98D23533AB/",
-              "pip": 2
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455180041796/806FD35D077836E2B21585294CA1F31F3D20C5EF/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455180028599/BF2A5BE67D0934FF1785E154F766FBA82950A84B/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455180096325/2AB8CE3FE8B9FFFEC50C420D918E23A0DCF200B1/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455180028599/BF2A5BE67D0934FF1785E154F766FBA82950A84B/"
+              }
+            ]
+          }
+        ],
+        "Heavy": [
+          {
+            "name": "XX-7 Heavy Turbo Laser",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751922250/1D0ACF27CE08CFA865080B62DD8C0E12B87CA802/",
+            "size": "huge",
+            "type": "Emplacement Trooper",
+            "points": 90,
+            "speed": 0,
+            "upgrades": {
+              "Comms": 1,
+              "Generator": 1
             },
-            {
-              "name": "Viceroy of Mandalore",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751700204/E379AF4A3824F8CFFB8EFAED55B651116AFE5125/",
-              "pip": 3
-            }
-          ]
-        }
-      ],
-      "Special Forces": [
-        {
-          "name": "Imperial Supercommandos",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751938598/EA4F3008844B6528784403937811449891C14FCE/",
-          "size": "small",
-          "type": "Mandalorian Trooper",
-          "points": 76,
-          "speed": 2,
-          "upgrades": {
-            "Personnel": 1,
-            "Training": 2,
-            "Comms": 1,
-            "Armament": 2
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028454512723115814/E2D62C42F65FA7C8D53DF84C32E2AF7A706CF227/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028454512723115925/1BBA13C56E26EC363E68E2E0A87AD0D00B3B2F9E/"
+              }
+            ]
+          }
+        ]
+      },
+      "First Order": {
+        "Commander": [
+          {
+            "name": "Captain Phasma",
+            "title": "Ruthless Leader",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081143260/D95314875641B7FB3C4EF84083544C623CD1A682/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 95,
+            "speed": 2,
+            "upgrades": {
+              "Command": 2,
+              "Training": 1,
+              "Armament": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804925773451/29E9C01AADB63D0F11307AC6DF9FE7F0C29178CD/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804925773688/AA999386C07D280297E4E55F78BE951C22CC4765/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Traitor!",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081145254/8867B053273BC9DBBB46FDC464881998DF372B1A/",
+                "pip": 1
+              },
+              {
+                "name": "So Good To Have You Back",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081145863/40A8C433BC0D8BBBFBC44BCCF8D9BBBF465CE231/",
+                "pip": 2
+              },
+              {
+                "name": "On My Command...",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081146194/C55577A1151D80D0A283097F5FFE5596258520D0/",
+                "pip": 3
+              }
+            ]
           },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982273795/D117C3122139FF5A93AAB4E5DCD2455FF70508F1/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982273931/809947D430BEB447CD2FA3E99DD31AF57C3E8F84/"
+          {
+            "name": "First Order Officer",
+            "title": "Cruel Superior",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081388976/28890DF10C50786D86509A5E6E9014EDFB18178A/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 50,
+            "speed": 2,
+            "upgrades": {
+              "Command": 1,
+              "Gear": 1
             },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982274574/BFFC62F32FE65628DB446AAA3674E5C49F92DE2F/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982273931/809947D430BEB447CD2FA3E99DD31AF57C3E8F84/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982275923/F4BDE2E8B1C496AFAB7DCF11728CA5AD58EC55FE/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982273931/809947D430BEB447CD2FA3E99DD31AF57C3E8F84/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982276438/B609AA7C947FFDBFFFDE022D21A4029EF4428282/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982273931/809947D430BEB447CD2FA3E99DD31AF57C3E8F84/"
-            }
-          ]
-        }
-      ],
-      "Support": [
-        {
-          "name": "AT-LDT",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751888859/BEC4E39876A92E0FFC2504196992E2072E99BDE8/",
-          "size": "large",
-          "type": "Ground Vehicle",
-          "points": 70,
-          "speed": 1,
-          "upgrades": {
-            "Comms": 1,
-            "Ordnance": 1,
-            "Generator": 1
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821664192111404/0E625C7A4614D3BE5DF4DF9D78BA558C2B78803C/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821664192111727/770A7C77419D31361A4E7DF14655D4339B5333BE/"
+              }
+            ]
           },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1055478574361579189/41CE0402F950AB518DB08E026AF96F46804E5AAB/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1055478574361579329/ABE5D81D7D16FF3DF9D9EA1247787AF86A112C61/"
-            }
-          ]
-        },
-        {
-          "name": "Phase II Darktroopers",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751974310/FADC3793016675ADF27F22082439F243F5CFF323/",
-          "size": "medium",
-          "type": "Droid Trooper",
-          "points": 110,
-          "speed": 1,
-          "upgrades": {
-            "Ordnance": 2,
-            "Comms": 1,
-            "Gear": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455180041796/806FD35D077836E2B21585294CA1F31F3D20C5EF/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455180028599/BF2A5BE67D0934FF1785E154F766FBA82950A84B/"
+          {
+            "name": "General Hux",
+            "title": "First Order High Commander",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081169876/CB65E6B92A868A8379B108FF8AF217970564DECC/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 75,
+            "speed": 2,
+            "upgrades": {
+              "Command": 2,
+              "Flaw": 1
             },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455180096325/2AB8CE3FE8B9FFFEC50C420D918E23A0DCF200B1/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455180028599/BF2A5BE67D0934FF1785E154F766FBA82950A84B/"
-            }
-          ]
-        }
-      ],
-      "Heavy": [
-        {
-          "name": "XX-7 Heavy Turbo Laser",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751922250/1D0ACF27CE08CFA865080B62DD8C0E12B87CA802/",
-          "size": "huge",
-          "type": "Emplacement Trooper",
-          "points": 90,
-          "speed": 0,
-          "upgrades": {
-            "Comms": 1,
-            "Generator": 1
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324932753815007/08A3CB2CCDEDD302548596EF866CF64E5E0AFB75/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324932753720403/40A7224F1345DCD440F78BD1669290C07059002E/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Orbital Bombardment ",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081172704/D53673C6656A92D080288EBC0C0F6A7C6760626C/",
+                "pip": 1
+              },
+              {
+                "name": "Tied on the End of a String",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081174703/A647478FFD9A384A559221E190389D2AC56D902D/",
+                "pip": 2
+              },
+              {
+                "name": "Acquiesces to Disorder!",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081176167/0D2A9F919346BEDA9602EF0803ADADEEFB4F9F4C/",
+                "pip": 3
+              }
+            ],
+            "required": ["I Don't Care if You Win"]
+          }
+        ],
+        "Operative": [
+          {
+            "name": "Bazine Netal",
+            "title": "Skilled Mercenary and Spy",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081110689/34878CC455F7F58C190A27DEEFAAD326F411F137/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 85,
+            "speed": 2,
+            "upgrades": {
+              "Training": 2,
+              "Gear": 1,
+              "Grenades": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027325137554369094/426567AD530CBB53A36B4DA286606A8028036940/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821664190500251/60F46C12E0D02DE01D36B03BDF1E8ECAFD604F87/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "The Perfect Weapon",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081134318/95DFAC48AF2895CBD541779163F6F58781816CE8/",
+                "pip": 1
+              },
+              {
+                "name": "They Die Or Disappear",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081134688/F073799B09F8A31C076CA224E1B5BD6C8C75106A/",
+                "pip": 2
+              },
+              {
+                "name": "Inform The First Order",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081135367/1425B91FE3B59882B80BB27197F86C066C5DBF46/",
+                "pip": 3
+              }
+            ]
           },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028454512723115814/E2D62C42F65FA7C8D53DF84C32E2AF7A706CF227/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028454512723115925/1BBA13C56E26EC363E68E2E0A87AD0D00B3B2F9E/"
-            }
-          ]
-        }
-      ]
+          {
+            "name": "Kylo Ren",
+            "title": "Fallen Apprentice",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081182228/D92A0F8C9F86CF7DEA222B23C6172250083EAB29/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 140,
+            "speed": 2,
+            "upgrades": {
+              "Force": 2,
+              "Training": 1,
+              "Flaw": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804925562786/E8A84B89A9397EDE6466F969084F683316C98D64/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804925562981/94795F169138667E0322FE1E28F68E2B8B7F4C37/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Finish What You Started",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081184101/51986EF40283FA440878CF7C1DD65104FF4A65B9/",
+                "pip": 1
+              },
+              {
+                "name": "I'll Show You the Dark Side",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081186038/6DE22BF4C255C7D6213E01F2B101CB7EA969D68F/",
+                "pip": 2
+              },
+              {
+                "name": "Mind Probe",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081187404/50F791DA2817CC1E8C690138FE028CA17B1B51D5/",
+                "pip": 3
+              }
+            ],
+            "required": ["I'm Being Torn Apart"]
+          }
+        ],
+        "Corps": [
+          {
+            "name": "First Order Stormtroopers",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081335160/5F935176EDBFB5C657AFA3681E67CC2C9F20BC24/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 52,
+            "speed": 2,
+            "upgrades": {
+              "Heavy Weapon": 1,
+              "Personnel": 1,
+              "Training": 1,
+              "Gear": 1,
+              "Grenades": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804926496354/534247FC18865263C1D30BC8C906CB39C93B0394/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804926496614/9FECECAF48C7046C3714B33C4C16FFB773FCC94C/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804926504208/94BA6801EC3D5C7915A803C8DB037D55499DA148/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804926496614/9FECECAF48C7046C3714B33C4C16FFB773FCC94C/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804926505290/B0670893C896898E6BE4CAB01744CE00F1FFE52B/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804926496614/9FECECAF48C7046C3714B33C4C16FFB773FCC94C/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804926506313/1AF44B793BDE12347BA28238D08E48E507CFBD02/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804926496614/9FECECAF48C7046C3714B33C4C16FFB773FCC94C/"
+              }
+            ]
+          }
+        ],
+        "Special Forces": [
+          {
+            "name": "Elite Praetorian Guards",
+            "image": "http://cloud3.steamusercontent.com/ugc/1862817412081432797/70B4BE3AC3FDE23388AFCD4D48844DD102463B12/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 80,
+            "speed": 2,
+            "upgrades": {
+              "Heavy Weapon": 1,
+              "Training": 2,
+              "Gear": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817957003761532/B9A39E219D561F0CFF064BD65083EF2B03FE2408/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817957003761811/4348E66B49C37DBE90E2798DDBCDAC46ADB90020/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817957003762298/2506A4C1DB297710118290CFCEB8FBCE61A371CA/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817957003761811/4348E66B49C37DBE90E2798DDBCDAC46ADB90020/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817957003762782/37B88231894CD5B671EFD926554F8143F593FD86/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817957003761811/4348E66B49C37DBE90E2798DDBCDAC46ADB90020/"
+              }
+            ]
+          },
+          {
+            "name": "Jet Troopers",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081228934/0854F9987A9760340D1CFB61EA0360C669DB60A3/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 20,
+            "speed": 3,
+            "heavyWeaponTeam": true,
+            "upgrades": {
+              "Heavy Weapon": 1,
+              "Training": 1,
+              "Comms": 1,
+              "Gear": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698013227866981/5EA3E02AC241512021988DBE0EC44754960D7C1E/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698013227867246/FB14C11D0A31B44E68FDEF0CAF9D3CCE7D140EF7/"
+              }
+            ]
+          }
+        ],
+        "Support": [
+          {
+            "name": "125-Z Treadspeeder Bikes",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081161332/82657FF9895270D7FB5B46FFEC762DE81575BFC3/",
+            "size": "medium",
+            "type": "Repulsor Vehicle",
+            "points": 85,
+            "speed": 2,
+            "upgrades": {
+              "Comms": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770981171565/A72EE65BB1B64233BC73B5A19F8BEEB49B6D25C2/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770981171714/24D19968CC914CDDF4318CD7F4D6A4A8C6453857/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1776099479274350301/4B9837939C2036E21527782F78E06152B3BFD831/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770981179713/F1CAD4EA45F501FA427BFC3194823758D23CAB4C/"
+              }
+            ]
+          }
+        ],
+        "Heavy": [
+          {
+            "name": "AT-ST",
+            "displayName": "First Order AT-ST",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081421585/4B0F0B47465016ACD271DAEFE93F062C79776DDF/",
+            "size": "huge",
+            "type": "Ground Vehicle",
+            "points": 170,
+            "speed": 2,
+            "upgrades": {
+              "Pilot": 1,
+              "Hardpoint": 3,
+              "Comms": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817412080755222/3B92EACA1DE861874A44E0001F4686FB7BA30CA0/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817412080755364/E8C5A3482E6C2FFA2AF18518E3F78823CAD68236/"
+              }
+            ]
+          },
+          {
+            "name": "Light Infantry Utility Vehicle",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081200983/383E193D0A6B5D69AB817D4584828A40B0B25C77/",
+            "size": "huge",
+            "type": "Repulsor Vehicle",
+            "points": 75,
+            "speed": 2,
+            "upgrades": {
+              "Pilot": 1,
+              "Crew": 1,
+              "Hardpoint": 1,
+              "Comms": 1,
+              "Generator": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027325137553435779/3A8FDD7CE7E77EA1D206645EEC453C509B3BD6F2/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027325137553435979/8778AF380A0A56B19CD1EA4BC88266803292180E/"
+              }
+            ]
+          }
+        ]
+      },
+      "Rebel": {
+        "Commander": [
+          {
+            "name": "General Rieekan",
+            "title": "Founding Member of the Alliance",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640752085723/9E5DE6BB4E45204DC3A997830A4DC8068C69CABD/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 80,
+            "speed": 2,
+            "upgrades": {
+              "Command": 2,
+              "Gear": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698230624925896/947BD1C75A604FAD92CB77ECAB27AC5109EB7F00/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698230624926095/54D107149A5C01B99334D873DC0D2B172AB71DA7/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Rapid Response",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640752086080/BC550A52E3D05D8FFB63D4673FD71BCAD35FC13C/",
+                "pip": 1
+              },
+              {
+                "name": "Launch Patrols",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640752086446/2245AED04413455E4469534F5D70B03D02DD184C/",
+                "pip": 2
+              },
+              {
+                "name": "Armored Assault",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640752086781/B8BD73E178BA6F4492F8F9C5110E921BDB1ADA3A/",
+                "pip": 3
+              }
+            ]
+          }
+        ]
+      },
+      "Republic": {
+        "Commander": [
+          {
+            "name": "Mace Windu",
+            "title": "Master Jedi",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747447768/91A80BEC147782188809554C9E3E1C89E38D0A8C/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 200,
+            "speed": 2,
+            "upgrades": {
+              "Force": 3,
+              "Command": 1,
+              "Training": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455187825660/20318CF5820801C8D087056BFFF3B448DD1D24C0/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455187825926/3024C576BF271F52A8E09E226B9CE33A850279B5/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "This Party's Over",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747448183/4C67DCF52EA1A41CE347DFA72F1F249E6D2C990B/",
+                "pip": 1
+              },
+              {
+                "name": "High Jedi General",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747448594/5712552FEBB895EB97EFB122230A64DFC888F30D/",
+                "pip": 2
+              },
+              {
+                "name": "Shatterpoint",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747448920/DE303A6D36A7845AD8B10767827027D50EA8738E/",
+                "pip": 3
+              }
+            ]
+          },
+          {
+            "name": "Commander Cody",
+            "title": "Marshal Commander of the 212th",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747469835/A6730D0E28DBDA4AC78F4590BF0C5F1D46083322/",
+            "size": "small",
+            "type": "Clone Trooper",
+            "points": 110,
+            "speed": 2,
+            "upgrades": {
+              "Command": 1,
+              "Training": 1,
+              "Gear": 1,
+              "Armament": 1,
+              "Grenades": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893322692719/36CE1B78678368B94938143D4CEA2773F93F363A/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893322728253/2649AA8D8F66C02A791A73B8AFAD18C25B40A394/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Blast Him",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747470658/793EFE2139085E54F9F85AAC92274E621C66DC6E/",
+                "pip": 1
+              },
+              {
+                "name": "Good Man That Cody",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747471029/C0DD76F36655C93C8C105652951B3B74FCDC202D/",
+                "pip": 2
+              },
+              {
+                "name": "You Must Realize That You Are Doomed",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747471461/265DF114E68306DF604691C110042DDB00C84DAC/",
+                "pip": 3
+              }
+            ]
+          }
+        ],
+        "Operative": [
+          {
+            "name": "Ahsoka Tano",
+            "title": "Stubborn Padawan",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747500577/DCDE4281DCAD8EC68919759915AB4DF09EAB5546/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 110,
+            "speed": 2,
+            "upgrades": {
+              "Force": 2
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817412091474935/EE39ED83BE15C1003350940C488EAEB4D6E9A96D/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817412091472250/A731A2DF0028A305625B39844340B899A3D97A5A/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Twin Lightsabers",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747502894/3AE99D7998FF7322CA29DCF7BAE0B72D459F9110/",
+                "pip": 1
+              },
+              {
+                "name": "Anakin's Apprentice",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747503725/0A7361854FBF8757DA002A670DBAA45BDDFD76D4/",
+                "pip": 2
+              },
+              {
+                "name": "Independant Adept",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747504272/935C0A5511D2455D302753EC8DEE0A9AF0326CB6/",
+                "pip": 3
+              }
+            ]
+          },
+          {
+            "name": "Commander Colt",
+            "title": "Rancor Batallion",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747527226/26A8CE439ADC2BDB1C9EE783B4013366CC9F97A8/",
+            "size": "small",
+            "type": "Clone Trooper",
+            "points": 90,
+            "speed": 2,
+            "upgrades": {
+              "Training": 1,
+              "Comms": 1,
+              "Gear": 2,
+              "Grenades": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693415431516051/4EAB6085C2D2D6C176B3C9847E2F1F228CEFE7BB/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693415431516248/89D5E03C721391A7CBC7930180396F3B14E5273F/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Legacy Of A Legend",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747528124/18B118F66C532CAF69CC82877EC177C68A9A5278/",
+                "pip": 1
+              },
+              {
+                "name": "Shock Traps",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747528435/A7754C5F989DC2C48860EA1F8DDFC671FCD90338/",
+                "pip": 2
+              },
+              {
+                "name": "Shoulder to Shoulder",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747528812/CFDDAA0DDD1CB89C937F8B47D672B78CF44D19D5/",
+                "pip": 3
+              }
+            ]
+          }
+        ],
+        "Special Forces": [
+          {
+            "name": "Clone Paratroopers",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747550450/AB6335C9C96E10F6D70F161BCDFC89FDB2934C57/",
+            "size": "small",
+            "type": "Clone Trooper",
+            "points": 68,
+            "speed": 2,
+            "upgrades": {
+              "Heavy Weapon": 1,
+              "Personnel": 1,
+              "Training": 1,
+              "Comms": 1,
+              "Gear": 1,
+              "Grenades": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693290507071203/040CF6A943C83588994E5BD8C0DDB793F6DE9875/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693415425506623/121AA3B4552A900E92161C97E55443D4040D7886/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693290507016826/760576DD3D314CB88313B54E105FB561009F8502/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693290506836632/AE0366ABB62BED44CC56CB5F25D5C6478592EBBF/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
+              }
+            ]
+          },
+          {
+            "name": "Republic Commandos",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747569673/F45852AF875FCB41E9BB5B23FFACC1029A8E548C/",
+            "size": "small",
+            "type": "Clone Trooper",
+            "points": 100,
+            "speed": 2,
+            "upgrades": {
+              "Training": 1,
+              "Comms": 1,
+              "Gear": 1,
+              "Armament": 2,
+              "Grenades": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455182355861/149A0196C96C1D78830C56F479A27BF825E9C6AB/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455182206940/096195C231ECC170C0963163315EFADABC01D5D7/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455182228456/B086CF963F81B78DCBE9E0893013169CF6454817/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455182206940/096195C231ECC170C0963163315EFADABC01D5D7/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455182280894/C546CADEC6AD3A41EFFC07CCD86AAE1EFB325BC7/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455182206940/096195C231ECC170C0963163315EFADABC01D5D7/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455182431253/81E98F267170F435E05AA7ED621A04F6476DC3B0/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455182206940/096195C231ECC170C0963163315EFADABC01D5D7/"
+              }
+            ]
+          }
+        ],
+        "Heavy": [
+          {
+            "name": "AT-AP",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747585288/91E17B9FFBE325EE7E46C3F18DF4E613EF60E6A3/",
+            "size": "epic",
+            "type": "Ground Vehicle",
+            "points": 165,
+            "speed": 1,
+            "upgrades": {
+              "Pilot": 1,
+              "Hardpoint": 2,
+              "Comms": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756243525814/22DBD5FF8C4A887FF7DBFD977F190A7192C1D4B7/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756243525957/D334BA41B51D1DD235E2A5ED14F1EEACC9CD9EEF/"
+              }
+            ]
+          },
+          {
+            "name": "LA-AT/I Gunship",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747615420/DD22D969B4D59595325925BD059DBF83F295F406/",
+            "size": "epic",
+            "type": "Repulsor Vehicle",
+            "points": 190,
+            "speed": 2,
+            "upgrades": {
+              "Pilot": 1,
+              "Hardpoint": 2,
+              "Ordnance": 1,
+              "Comms": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028454854943442054/64C9040DF30E7980A9E9F22FD7A56D5C84052167/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028454854943501740/E509E21CEB3321071E6F56B006F24C1D919B6F3B/"
+              }
+            ]
+          }
+        ]
+      },
+      "Resistance": {
+        "Commander": [
+          {
+            "name": "Finn",
+            "title": "First Order Defector",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752987105/4E0911D06D60474448E5EF5CFB340A7CA015C62D/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 110,
+            "speed": 2,
+            "upgrades": {
+              "Command": 1,
+              "Comms": 1,
+              "Gear": 1,
+              "Armament": 1,
+              "Counterpart": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770985763040/56F6F436F140391F26FB16960E2D6CD57FB14B71/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770985763307/FB7EDB7C8D248BF873C1405012C99CC32C9FEBAA/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Big Deal",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752986056/CDC39A7E6D1022EC938F8F8A599EE7513650A574/",
+                "pip": 1
+              },
+              {
+                "name": "Come Get It",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752985107/DEB9D333DCC6E48F6855736D9E28A806719CE0E0/",
+                "pip": 2
+              },
+              {
+                "name": "I am with the Resistance",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752983093/53828D3EB704897C38DD09ECE6E0083DEB51146F/",
+                "pip": 3
+              }
+            ]
+          },
+          {
+            "name": "Poe Dameron",
+            "title": "Reckless Flyboy",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1022821770975464596/6EDA2DD86069BD1A0B3B2690B5397BC3FC01C228/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 100,
+            "speed": 2,
+            "upgrades": {
+              "Command": 1,
+              "Training": 1,
+              "Comms": 1,
+              "Gear": 1,
+              "Counterpart": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770984969371/73F6B8B3D8D4C55321CBCE3D8B75E5A7E5B25A94/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770984969603/8925F3262BB3FE97EC31D45DAE964400AE8A528F/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "We are the Spark",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1022821770975465215/89BB4AAD301785869E3A3C44CFB2745F511C8FE8/",
+                "pip": 1
+              },
+              {
+                "name": "Dead Heros",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1022821770975470651/B99A6006460BC0A2B198BBE3CE6BA403E3B1AB7A/",
+                "pip": 2
+              },
+              {
+                "name": "I Need a Pilot",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1022821770975471416/4ED3DFBB9E55FC22BA5F9A7E2B1D5B5229CE9C79/",
+                "pip": 3
+              }
+            ]
+          }
+        ],
+        "Operative": [
+          {
+            "name": "Rey",
+            "title": "Force Prodigy",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1022821770981203693/E3069DE71ED495326B84393B00F82E021420E753/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 125,
+            "speed": 2,
+            "upgrades": {
+              "Force": 1,
+              "Training": 1,
+              "Gear": 1,
+              "Armament": 1,
+              "Counterpart": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804925013057/F62D7D1921B435B28DDB56BD129BB39D1FB2C2FD/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324712401180346/5DD131A4135CF4C90A2D42D264F3FAB332155AB3/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "The Force Awakens",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1027324582151432669/7A2F43C29C19033B13852F63165D64A18D766544/",
+                "pip": 1
+              },
+              {
+                "name": "You Came back For Me",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1027324582151438024/BC43E151F85D06C17D0602947648984AA604E08F/",
+                "pip": 2
+              },
+              {
+                "name": "I Think I Can Handle Myself",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752998047/158965EE8DD63D9BD1A1F43BC7E51993538FC7E3/",
+                "pip": 3
+              }
+            ]
+          },
+          {
+            "name": "BB-8",
+            "title": "A Clever Little Droid",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1022824296871784130/E6058352DDF98D626EC56C53D97FBD31675E6898/",
+            "size": "small",
+            "type": "Droid Trooper",
+            "points": 45,
+            "speed": 2,
+            "upgrades": {
+              "Comms": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068157620585/9E7930221D8CD87F6338B9D4B58F4D3F824D08C0/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068157620780/493748852320ED988465533F8BC49FEA2672A9E8/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Happy Beeps",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157653789/55772CA9D24676C0367BBAC6F831F03E0340F4EB/",
+                "pip": 1
+              },
+              {
+                "name": "Keep an eye on this kid",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157657298/77DAA5AFFEDD096EC568637DC3777E4696DE7D9D/",
+                "pip": 1
+              },
+              {
+                "name": "Engineering Expertise",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157658855/8B72242F4B9650FC1DBE591F7FE32D574808DAA1/",
+                "pip": 2
+              },
+              {
+                "name": "Never Underestimate a Droid",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157658236/1E07FA41D1449A2991220D2733B1F51D2565C4F7/",
+                "pip": 2
+              },
+              {
+                "name": "A Mutual Understanding",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1022824296871786871/AF5D00FAB14B8C70B843DFB4BD18D6EFC9F8ADD1/",
+                "pip": 2
+              },
+              {
+                "name": "Impromptu Imposter",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157655413/18B1636E2055305E94F285684921B2FDAA773450/",
+                "pip": 2
+              },
+              {
+                "name": "Good Things Come Back",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1022824296871785786/4EA05DE445200A52D753CD1A023028FE0B5F0A0D/",
+                "pip": 3
+              },
+              {
+                "name": "Deus Ex Machina",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157655832/49730DEF4AAD9BF0481CA578387F21D074A104D8/",
+                "pip": 3
+              }
+            ]
+          },
+          {
+            "name": "R2-D2",
+            "title": "Hero Of A Thousand Devices",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1022821770981205050/4D72685715DF8671198FA4BC591397371BC96665/",
+            "size": "small",
+            "type": "Droid Trooper",
+            "points": 45,
+            "speed": 1,
+            "upgrades": {
+              "Counterpart": 1,
+              "Comms": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/776232727456806966/EFBA4A71BFE748A2868C14B82DA3A7B0D559874A/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/777357228032306302/F5CA6FC54A8625E261F123D73792DE36D74E1686/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Blast Off!",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564037063/A7AE3401CB3A51A58A8682BBCD8D6F6C104804AF/",
+                "pip": 1
+              },
+              {
+                "name": "Impromptu Immolation",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564035209/4C4829AE9D1B01B14F2D4FDE2C6D3935D8055954/",
+                "pip": 2
+              },
+              {
+                "name": "Smoke Screen",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564033033/7FC32081CE8646476E7B0C475F452AA629BA7713/",
+                "pip": 3
+              }
+            ]
+          }
+        ],
+        "Corps": [
+          {
+            "name": "Resistance Troopers",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1027324582151747849/0DC6B237D0C8CC16BE47236FF1B5268D403945C1/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 30,
+            "speed": 2,
+            "upgrades": {
+              "Heavy Weapon": 1,
+              "Personnel": 1,
+              "Gear": 1,
+              "Grenades": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804924627970/AE0B4993C8FA598D93829CF55F0E0A6415ACBBFB/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324582151454188/1EC7453DFA3870ADCA468AD5A9257330B58CF8F4/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324582151456311/376D681EDE4D18D355A359F47C49551B6AC5EBAA/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324582151456617/9EBFAB9697DE7A1435FF501C6F39BBCC3B244BCB/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324582151464621/CEB3271C1C9E43C30C41206E919ACA9AFFB45247/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324582151464893/EF78574A7DFC9EBC7EC9FB76B27BA5F846B8F97D/"
+              }
+            ]
+          },
+          {
+            "name": "Resistance Trench Fighters",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1017194020628449858/1DC8646D5B2D0F5ABF7828732E6DE923F301DE46/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 39,
+            "speed": 2,
+            "upgrades": {
+              "Heavy Weapon": 1,
+              "Personnel": 1,
+              "Training": 1,
+              "Gear": 1,
+              "Grenades": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248440350/60BC7FB4B3F6B327003DAB9B924C5EC98FA67C4B/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248444916/D62AC2DD70775BA5025900AC76975C4AB45A54CC/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248441473/F330E21469E4FF560B9E8892E784C14373697F16/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248440578/125E76600442E01E3AD18725563EA1BE4D63BEFA/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248442051/472D72BABB02CCA9F99639F83E21A9D3AF83BB14/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248440578/125E76600442E01E3AD18725563EA1BE4D63BEFA/"
+              }
+            ]
+          }
+        ],
+        "Special Forces": [
+          {
+            "name": "Salvaged B2 Battle droids",
+            "title": "Defenders of the Colossus",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1021698068155819425/F5A156E66B986DA76D65B649D689496C6A4BB79A/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 64,
+            "speed": 2,
+            "upgrades": {
+              "Heavy Weapon": 1,
+              "Comms": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/775105953849586118/94F967F21EA7E390A200C4BDA5581D07DBB37AC2/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/775105953849585789/91A639AB9F57BE393683DA53212E395886307C52/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/775105953849586430/E5941CF7A3631E6D4A28832AE489A4340C96B0B9/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/775105953849585789/91A639AB9F57BE393683DA53212E395886307C52/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/775105953849586226/9326AD8D3EC80CC53F4BF2D156014978DCD715D9/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/775105953849585789/91A639AB9F57BE393683DA53212E395886307C52/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/775105953849586324/B5D59E535AFA2BF99FCA3C584E28FA500ADB89BD/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/775105953849585789/91A639AB9F57BE393683DA53212E395886307C52/"
+              }
+            ]
+          }
+        ],
+        "Support": [
+          {
+            "name": "Orbak Riders",
+            "heavyWeaponTeam": true,
+            "image": "http://cloud-3.steamusercontent.com/ugc/1022821770986742661/33B78DBDC2B4A466B810D5299DB14745FAFB1E68/",
+            "size": "medium",
+            "type": "Creature Trooper",
+            "points": 45,
+            "speed": 2,
+            "upgrades": {
+              "Heavy Weapon": 1,
+              "Comms": 1,
+              "Gear": 2
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770976478153/4E00BD588837F87DDA2828DC092CEEE3BEDCC7A3/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770976472996/354C4EE85A60585BD0FB817AFEE21D00E93799BA/"
+              }
+            ]
+          },
+          {
+            "name": "Rose Tico",
+            "title": "Skilled Technician",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1021697620253184171/055BD7F8C30E5D043104316A572B1846227F6DC5/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 50,
+            "speed": 2,
+            "upgrades": {
+              "Comms": 1,
+              "Gear": 2,
+              "Counterpart": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697601906861807/C7CB31D9AFAFF6C7B2633663A2A33D939F4E8205/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697601906862116/99E8BDA93C81AD3875DFC214AA5E39DC4F5477A5/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Saving What We Love",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1021697620253191671/458068FD2D398FA6C7540EEFF383BD8E39509350/",
+                "pip": 3
+              }
+            ]
+          }
+        ],
+        "Heavy": [
+          {
+            "name": "V-4X-D Ski Speeder",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1021697620252781965/A29532E1391479BD4424DEE3CD7130CC5927AB08/",
+            "size": "epic",
+            "type": "Repulsor Vehicle",
+            "points": 140,
+            "speed": 3,
+            "upgrades": {
+              "Pilot": 1,
+              "Hardpoint": 1,
+              "Comms": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804931072163/80F5B756EF0C02455B5C31CD1A608DD51B9108BD/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804925084213/855D3C37D204F44B1840665B50CCCB73A7CD62D2/"
+              }
+            ]
+          },
+          {
+            "name": "V-232 Turret",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157670378/DB2D6E46CD982AE3C38EA63F93939CDC2EECA984/",
+            "size": "huge",
+            "type": "Ground Vehicle",
+            "points": 100,
+            "speed": 0,
+            "upgrades": {
+              "Comms": 1,
+              "Generator": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068157631207/B54652720E993614D7AD481BD4A1B8236561DCAA/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756247150301/5C9F0E6F01394012B925C60CC4D8548E66B05427/"
+              }
+            ]
+          }
+        ]
+      },
+      "Revans Sith Empire": {
+        "Commander": [
+          {
+            "name": "Darth Revan",
+            "title": "Fallen Lord",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281811934/A5A06CC61DE1B518F307931E848ED0F2F84DBE3C/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 220,
+            "speed": 2,
+            "upgrades": {
+              "Force": 3
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933832570/34E443C62233F9BFAB5A1A56848C92AF12D16DB0/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933823285/EE9DA185779FAC54191A9DC0353E57D542CF6EE9/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Slayer of Mandalore",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281812320/441136636E20A3C920D22041163506AC74BD9E34/",
+                "pip": 1
+              },
+              {
+                "name": "I am the Dark Lord of the Sith",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281812673/A864BC3FB16C88EF914102FA82EBE360D05B7016/",
+                "pip": 2
+              },
+              {
+                "name": "The Fallen Lords",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281813019/D00A57B0F11280E97F8A27269F9F39A031001D38/",
+                "pip": 3
+              }
+            ]
+          },
+          {
+            "name": "Darth Malak",
+            "title": "Treacherous Apprentice",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281873194/CE73E7B8BE4C4C155231F3BBEE4F857395F1C174/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 195,
+            "speed": 2,
+            "upgrades": {
+              "Force": 2
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933880695/1D163F620C1BF4639F889CE39C1DCB6E8ED159E9/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933876696/ED5A556257FEA5E3EA9AD18215604CB599E132C2/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "This is but a Taste of the Dark Side",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281873643/108B3E63FB5AAE3E70915C74CB0CEADB660F1899/",
+                "pip": 1
+              },
+              {
+                "name": "You Will Forever Stand Alone",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281874073/CC8FEB5E5D0934D8C0FA1A3E8752A656D6EE849E/",
+                "pip": 2
+              },
+              {
+                "name": "Wipe this planet from the face of the galaxy",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281874384/99D8B33D2B2422AFD4D24953C07B352DD585F493/",
+                "pip": 3
+              }
+            ]
+          }
+        ],
+        "Operative": [
+          {
+            "name": "Calo Nord",
+            "title": "Nefarious Bounty Hunter",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412068777865/AD645A6CA22119B08159D249FF1FAA79A9ABF568/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 90,
+            "speed": 2,
+            "upgrades": {
+              "Training": 2,
+              "Gear": 1,
+              "Grenades": 1,
+              "Armament": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817412068837885/8382AD2EDA22D520AF2FFAF89E3D4CF044EB2E71/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817412068838066/B01C1691D062FFBDAF364DFA926330D8F0C107C5/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Updated Contract",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412068780726/450A5AD57585FD96262A630B2C7CC574CA293F41/",
+                "pip": 1
+              },
+              {
+                "name": "I am hard to kill",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412068781019/5958B05B2457B2A3F1BFDA10269F84EDBA1DC7B4/",
+                "pip": 2
+              },
+              {
+                "name": "One. Two. Three.",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412068781429/29B9885FB2E1E129E6F684472C7281B09617EB46/",
+                "pip": 3
+              }
+            ]
+          }
+        ],
+        "Corps": [
+          {
+            "name": "Sith Troopers",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281907874/694CCAFD2FB6C6ADA01DAB52DCEFB6CE4DBAB1D0/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 44,
+            "speed": 2,
+            "upgrades": {
+              "Heavy Weapon": 1,
+              "Personnel": 1,
+              "Gear": 1,
+              "Grenades": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933591216/236BEBCCFA8E4701879F66DE28E7E61EB71696DA/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933675175/1561AB6D3E5FCD7952FC0B2A76BEF1B14D75D00D/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933538068/07579EBF0F9C9A7BD0DBC30EFE30BEEF1FB31D33/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933630508/AF5621F9AAF5556EADD9373D4C8F7DE5C3A6D95D/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
+              }
+            ]
+          }
+        ]
+      },
+      "Scum": {
+        "Commander": [
+          {
+            "name": "Tyber Zann",
+            "title": "Cold, Methodical, and Ruthless",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735070640/74612E44D0AF4F505937EE2E0DAF21C08EB4E15B/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 140,
+            "speed": 2,
+            "upgrades": {
+              "Command": 1,
+              "Training": 1,
+              "Illicit": 1,
+              "Gear": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365775807/337D2A5009DD4A91F0A469B418D4C77867FDF52D/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365776115/8606DE28865E723D2343D17F890A99959E25AC8F/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Orbital Bombardment",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735071380/B7CEA3F14638418D63BEFF3F7A611F5078D31667/",
+                "pip": 1
+              },
+              {
+                "name": "Corruption is My Weapon",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735071871/7524B10AD4DB25DAA1E5F5F0275A58DE9C3EC666/",
+                "pip": 2
+              },
+              {
+                "name": "Everyone Has a Price",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735072378/3A407CC85B615E03763D5F22E7116CA3FB217F0B/",
+                "pip": 3
+              }
+            ]
+          },
+          {
+            "name": "Urai Fen",
+            "title": "Loyal Lieutenant",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735039360/1B0C02842ADDAA687687E529BE8B33983CAD933F/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 90,
+            "speed": 2,
+            "upgrades": {
+              "Training": 2,
+              "Illicit": 1,
+              "Gear": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984835649865/8FC3F2E4E22555D72BDF283AD0E686537F33A043/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984835650100/057E08B03AAE7CA89B585D8916BB25023B63341A/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Strike and Fade",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735040340/32D15FA78098AB05AD6D98B51631935EC6DEC3C3/",
+                "pip": 1
+              },
+              {
+                "name": "The Consortium Commands It",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735041426/F309B5F10C9F44B3E9FE50A42FAD541185DEE9A5/",
+                "pip": 2
+              },
+              {
+                "name": "No Mission is too Dangerous",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735047596/1516182BE8ED3D0635F56F830C4FB85F869C477C/",
+                "pip": 3
+              }
+            ]
+          },
+          {
+            "name": "Defiler",
+            "title": "Under Cover Agent",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735208736/794BBDD282201AA4D82C0B728D90073E6CAF423C/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 90,
+            "speed": 2,
+            "upgrades": {
+              "Training": 1,
+              "Gear": 1,
+              "Armament": 1,
+              "Illicit": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515362210843/CDD5E72C8CE5B42739060E6ADC81DC64751294F0/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515362211007/246011C13B53F2A881968B8996802F50B33D075F/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "I Like Explosions",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735209433/1B7DC25C849E9B7D2657E40E71FF198B8588381F/",
+                "pip": 1
+              },
+              {
+                "name": "Nothing Stops Me",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735210006/8EAEC185C0C43B5D6099ED763E9B3D4FC5C493A5/",
+                "pip": 2
+              },
+              {
+                "name": "I Stand In the Shadows",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735210753/1BF727CB55BFAB8151A9F9A368C91C6B76248636/",
+                "pip": 3
+              }
+            ]
+          },
+          {
+            "name": "Pre Vizsla",
+            "title": "Defender of Tradition",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640671157/50ED9FE9885FBF3530E3BF5D7E2ECA85E331972F/",
+            "size": "small",
+            "type": "Mandalorian Trooper",
+            "points": 165,
+            "speed": 3,
+            "upgrades": {
+              "Command": 1,
+              "Training": 2,
+              "Illicit": 1,
+              "Gear": 1,
+              "Armament": 2
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886396178/07FB37CA0A11552BEF96C3DCA10AF232C65AF7B6/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886396372/35E5047903DC30F882B40719809ECF90DBC65A5A/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Blade Launcher",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640671650/36CC81AF419D113B28FC5AB7CF6B3210085DFB45/",
+                "pip": 1
+              },
+              {
+                "name": "Warlord of Mandalore",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640672041/2F91858F91AB3648DDEF429A5C1C584D129634C1/",
+                "pip": 2
+              },
+              {
+                "name": "Rise of the Death Watch",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640672498/BED2FE1183721CCB1A1B623A6C4DED69383DA739/",
+                "pip": 3
+              }
+            ]
+          },
+          {
+            "name": "Jabba The Hutt",
+            "title": "Vile Gangster",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741311873/1C5E99B44B0F2BAB89FF0F00315D88DCAC991BBE/",
+            "size": "large",
+            "type": "Trooper",
+            "points": 180,
+            "speed": 1,
+            "upgrades": {
+              "Command": 2,
+              "Counterpart": 1,
+              "Illicit": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984838965716/328A3D3A0AFDA83FC55E8DDCAF62845FFF80CF64/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984838965864/2C27448D99B31E0730B60E10427A6009A6AEF1C7/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Appetite for Violence",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741312832/9DD7CEC7F0A4BBEC81E368726BA5A07E4F81AD9D/",
+                "pip": 1
+              },
+              {
+                "name": "Sinister Belly Laugh",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741313391/27122DF6EB3315976464D7B481537EE5E1E58D94/",
+                "pip": 2
+              },
+              {
+                "name": "Big Shot Gangster",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741313883/86E8818123FD0C01DA7890E271BE897212D4733D/",
+                "pip": 3
+              }
+            ]
+          },
+          {
+            "name": "Hondo Ohnaka",
+            "title": "Self-Serving Pirate",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738473397/8A62072BB1AFA3D4BF14CC3BA56EB1C2F1614F46/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 90,
+            "speed": 2,
+            "upgrades": {
+              "Command": 1,
+              "Illicit": 3,
+              "Armament": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697601906780896/650CF3405CD4106C46B9CB7F0B8C3884B62CD278/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697601906781011/E61558EE4DCDF12D33E98940751D940381181C93/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "No Longer Profitable!",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738477182/571BC50F3C1ABB05DAF75F3BE004DCEBD4C27DD7/",
+                "pip": 1
+              },
+              {
+                "name": "Drive a Big Tank",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738476702/E723D8E97412E2B9E422741F4E2225D5B8A146C8/",
+                "pip": 2
+              },
+              {
+                "name": "Insolence! We are Pirates!",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738475852/69D3EE2DF1CDA15E4BDC49F143CE2DD621B8553F/",
+                "pip": 3
+              }
+            ]
+          }
+        ],
+        "Operative": [
+          {
+            "name": "Silri",
+            "title": "Dark Witch",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735151492/82278C71E894B0710E02376909241ECAAD41F8C7/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 150,
+            "speed": 2,
+            "upgrades": {
+              "Force": 1,
+              "Training": 2,
+              "Illicit": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984835654759/B33E7C3B1D34E7DDAC7B617DC466F12FF66774E1/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984835654931/3ACEDEC6F99A311A245C7492883DAB9720D05348/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "I Shall Rip Out Their Souls",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735165967/E52C14F2A96A0DDA785B12C9400F47E9E5E2F4A7/",
+                "pip": 1
+              },
+              {
+                "name": "Come Closer",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735165400/6E97DF5AC3BF3172E316DD409240AA04BD4C6DE4/",
+                "pip": 2
+              },
+              {
+                "name": "They Will Know Fear",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735164916/B6CDD990B416AE4B7897AB3A27E35ACD4A46DE07/",
+                "pip": 3
+              }
+            ]
+          },
+          {
+            "name": "Bo-Katan Kryze",
+            "title": "Death Watch Lieutenant",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640560685/8771A2D7895F003917A4CD9D170E7D5FBAA81D65/",
+            "size": "small",
+            "type": "Mandalorian Trooper",
+            "points": 120,
+            "speed": 3,
+            "upgrades": {
+              "Training": 2,
+              "Gear": 1,
+              "Armament": 2
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886421665/441B37D17213CA1B82174A8988ED23AA2D59336E/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886421832/BBE3592A7496E444E116271913178A8ED41F5323/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Poison Dart",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640561281/E6C9BE0EB9F4357B31FB1459E8615D85BBE6F660/",
+                "pip": 1
+              },
+              {
+                "name": "Fierce and Deadly",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640561707/6E91E487B7F9AD4225A336081B4AB58F4AAB3CD2/",
+                "pip": 2
+              },
+              {
+                "name": "Memorable and Funny Quote",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640562097/E3FFDCB0E1AC2EB8E690C90C0599AA093788759C/",
+                "pip": 3
+              }
+            ]
+          },
+          {
+            "name": "Dengar",
+            "title": "Payback",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743206950/10A169A5029EDFC4ACA82E73B8BA7D4777BB499D/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 105,
+            "speed": 2,
+            "upgrades": {
+              "Training": 1,
+              "Illicit": 1,
+              "Gear": 2
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982050300/7F58F09A4EBE2B1D4036CA35ECD771FAC087027F/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982050497/14DBD099731E973681F538C811E89F52971C6258/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Ello Darlin",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743207736/AC879456E5C89349EDE04DC810B7437A49F9017B/",
+                "pip": 1
+              },
+              {
+                "name": "Thats Not a Knife",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743208077/F604A72BAD8ADED41170B6134687C8792E272C0B/",
+                "pip": 2
+              },
+              {
+                "name": "Credits are Calling my Name",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743208459/015271D4636D4659598040A7A33AABA2A7373863/",
+                "pip": 3
+              }
+            ]
+          },
+          {
+            "name": "Greedo",
+            "title": "Mercenary of Misfortune",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741745161/DE21A067535ADD00F083F96CE00AEF706CDBC1B3/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 60,
+            "speed": 2,
+            "upgrades": {
+              "Training": 2,
+              "Gear": 1,
+              "Grenades": 1,
+              "Flaw": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697128192156760/0799D47F8ABA442104B92441C2EE558246DD447B/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697128192156907/44D809B717035663BCC53BBF8B6C34E47F27D953/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Maclunky!",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741745870/4D9A87A50635EFDD25A2E01B381D20FC3B23D0E7/",
+                "pip": 1
+              },
+              {
+                "name": "Oonta Goota?",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741746363/52B7999E4C27DFA029632DF034C633BD94B6ECE3/",
+                "pip": 2
+              },
+              {
+                "name": "E Chu Ta",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741747117/E0DD4D0E9489424A42EF020B57AFCB2E34CC3935/",
+                "pip": 3
+              }
+            ],
+            "required": ["I'll Bet You Have"]
+          },
+          {
+            "name": "IG-88",
+            "title": "Calculating Assassin",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743156483/4AB94765581EEA7C01F1C931649279C0820A18D6/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 130,
+            "speed": 1,
+            "upgrades": {
+              "Training": 1,
+              "Illicit": 1,
+              "Gear": 2,
+              "Grenades": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982048942/6855349E653C6F4E0433AF56E1554F75F307CBF3/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982049139/F1EB5D96934D784828CAD32E88CFD581446B6041/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Toxic Dioxis Despenser",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743157480/AC5FF98814A9D017737A5C5FEDE3FD7E401A7D4D/",
+                "pip": 1
+              },
+              {
+                "name": "Defensive Programming",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743157867/DBE4FB014B259FD7B2E4C6774D766C557735F320/",
+                "pip": 2
+              },
+              {
+                "name": "I Destroy, Therefore I Endure",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743158259/1693B7E0EECA04393914E8566B892A1E0052039F/",
+                "pip": 3
+              }
+            ]
+          }
+        ],
+        "Corps": [
+          {
+            "name": "Grenadier Squad",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735128053/8071373F43B26B004A85BB1423AE10D8BA9FA2D9/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 33,
+            "speed": 2,
+            "upgrades": {
+              "Personnel": 1,
+              "Illicit": 1,
+              "Comms": 1,
+              "Gear": 1,
+              "Grenades": 2
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365822891/9245AC0020E31C369AE4129B35D0BA467A01F2B4/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365823446/E94BC334A0B2F95CFB75FEDC3A0FEDF2FFD5A970/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365824294/5F43B720E0198A078E25BA472E7DDBCA8F51CBEC/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365824481/27693FC709ADF50440623C6347A11151608D5E2F/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365824294/5F43B720E0198A078E25BA472E7DDBCA8F51CBEC/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365824481/27693FC709ADF50440623C6347A11151608D5E2F/"
+              }
+            ]
+          },
+          {
+            "name": "Hutt Cartel Troopers",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741193364/B2A9024FE737F3E6CAC757C062FAE63B180020F4/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 40,
+            "speed": 2,
+            "upgrades": {
+              "Heavy Weapon": 1,
+              "Personnel": 1,
+              "Illicit": 1,
+              "Grenades": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132327065/C97ECB0137975A84387D1450B76E656DD3A34CC6/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132327244/97AF50B5FA4E76262E8F7A6BBCBF465FD8D13210/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132328895/00FFC141D583FDE6EB27DCEF374C6EA79E4BC8DC/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132233662/46758BE4190670991AEEB84884D2C0926704577E/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132328408/9323E551FA703709CF34056F60EB7B9808DBBC6F/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132233662/46758BE4190670991AEEB84884D2C0926704577E/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132327863/05220805319D5F586AF2C45288D1880BBCF5B1D4/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132233662/46758BE4190670991AEEB84884D2C0926704577E/"
+              }
+            ]
+          },
+          {
+            "name": "Weequay Pirates",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738627390/5CC1A1E67FA0FB421324802CFFF43AEBF54CC512/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 44,
+            "speed": 2,
+            "upgrades": {
+              "Heavy Weapon": 1,
+              "Personnel": 1,
+              "Illicit": 2,
+              "Grenades": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436112170/7B9627FA526DBD9262F7B82066DF7F5BDF1E5B76/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112951/28554A829163EDA67DDE90D1CF137C093FF8A9AC/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436113638/F31ACA002873CE6039E4A0438F29423E59383C71/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112951/28554A829163EDA67DDE90D1CF137C093FF8A9AC/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436114564/440659EBF9A36F6A6E2C7E4C7AE6B2C6A6DBFABD/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112951/28554A829163EDA67DDE90D1CF137C093FF8A9AC/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436115021/ECE24BA2DD41BC0C0EA4638CF553ABDE1969DC4C/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112951/28554A829163EDA67DDE90D1CF137C093FF8A9AC/"
+              }
+            ]
+          },
+          {
+            "name": "Hired Guns",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741999970/AEA964040C9423D7CB3BBFE8E6127BFF6D9B4B16/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 36,
+            "speed": 2,
+            "upgrades": {
+              "Heavy Weapon": 1,
+              "Personnel": 1,
+              "Illicit": 1,
+              "Armament": 1,
+              "Grenades": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138162716/6618383926180465FB60EC9786E27A680C85BFC9/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138162922/C28DD0F623633DABFC9748FFE85A4AFA8D6010DE/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138162195/FB52D7D4C013778E22F5FB391B8506E10F7C8126/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138163807/FF1D50425F0F472D96EA277636EC08E98F969A4F/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138164240/210C9B6E98EBF1F2648A855CDFFEA405E75AFB82/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138164385/1460EF2F670C31A209FB8FD428800D727F310A9F/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138164936/04CD0F0BF910DC7E078F67D680411F0B948714C2/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138165334/AEF9F43EDE77B3E981B4EE3CFA26869D27B45CE0/"
+              }
+            ]
+          }
+        ],
+        "Special Forces": [
+          {
+            "name": "Mercenary Assault Squad",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735112958/CA567516B908134719A9891C1855E81C88E39E7E/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 72,
+            "speed": 1,
+            "upgrades": {
+              "Heavy Weapon": 1,
+              "Training": 1,
+              "Illicit": 1,
+              "Gear": 1,
+              "Armament": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365876771/3C9BD90A0E8E6BA277A1133D1AF61B2D44C2DEB0/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365877132/5DEAE7FFFF586E0ACBFD5BB29AF4869E6D675044/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365880281/45B6B327A692DBFDE6D5E5F642EB7FEBBC2A0A4F/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365878394/8AD2A611C51D78184D8E4204A720C59EEC2C7755/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365879761/026D7FD22C9074A12068AE05CE293EBB833FC70E/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365878394/8AD2A611C51D78184D8E4204A720C59EEC2C7755/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365879295/EC66EBB1550D6D61DAC1AC96CAE92A0273B06A45/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365878394/8AD2A611C51D78184D8E4204A720C59EEC2C7755/"
+              }
+            ]
+          },
+          {
+            "name": "Infiltrators",
+            "title": "Strike Team",
+            "heavyWeaponTeam": true,
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638837280/E9F99045D6B7FA98055D860B700FB5402373070B/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 22,
+            "speed": 2,
+            "upgrades": {
+              "Heavy Weapon": 1,
+              "Training": 1,
+              "Illicit": 1,
+              "Comms": 1,
+              "Gear": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068156464007/651A73813208989A1D36777648388ABBF2F11376/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068156464181/1FABB24F11BA883FEB5A7CB16CB7EAE86CB50402/"
+              }
+            ]
+          },
+          {
+            "name": "Death Watch Fireteam",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736281138/4153C964147552CEAC2E3E23A51ED5358BC5C424/",
+            "size": "small",
+            "type": "Mandalorian Trooper",
+            "points": 54,
+            "speed": 3,
+            "upgrades": {
+              "Heavy Weapon": 1,
+              "Training": 1,
+              "Illicit": 1,
+              "Comms": 1,
+              "Gear": 1,
+              "Armament": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886427483/34A3605CA2B2D8280D40991583D41D7D1B3F0E31/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886427771/60D6CA1D97D822A2222E4FAF614931265B7B0AF2/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886435784/9A83A99579A78DF53A23E3FFB79C07798E4F3C5C/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886427771/60D6CA1D97D822A2222E4FAF614931265B7B0AF2/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886429750/5D62ADB1200B1AD16A0349AF87E757F40E720115/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886427771/60D6CA1D97D822A2222E4FAF614931265B7B0AF2/"
+              }
+            ]
+          },
+          {
+            "name": "Nite Owls",
+            "title": "Bo-Katan's Elite",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736216918/59B584E476FCEAE304E4E3152B4BF12843AE9214/",
+            "size": "small",
+            "type": "Mandalorian Trooper",
+            "points": 60,
+            "speed": 3,
+            "upgrades": {
+              "Training": 1,
+              "Illicit": 1,
+              "Comms": 1,
+              "Gear": 1,
+              "Armament": 1,
+              "Grenades": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357880094/FFFBDA79DE3B6192926EFCDFC257708C2A360562/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515357880292/78883B5B08CCDC0B7BC4EF36D45DAB06E9057FEB/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357881561/B365369415AE0FB6A96E69817D76D9BAD1366038/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515357880292/78883B5B08CCDC0B7BC4EF36D45DAB06E9057FEB/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357880886/06542D3BD6F03DC43D9E675680F86F2964B210F9/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515357880292/78883B5B08CCDC0B7BC4EF36D45DAB06E9057FEB/"
+              }
+            ]
+          },
+          {
+            "name": "Gamorrean Gaurds",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741407333/B5A53DE0F8D6ECC08CCD913669E3AB7D846F9320/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 75,
+            "speed": 2,
+            "upgrades": {
+              "Heavy Weapon": 1,
+              "Training": 1,
+              "Illicit": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407431269414/974FE237CC3CE17AEC2C321DBB69DE340A0D962F/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407431269590/C7A08ECB6A962EC390A208C771B6A8AF513AE685/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407431271048/84FBE9C70610660263F4FE0424E1C02C401A945B/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407431270422/909F25E16D76BF99AE8122963CEE8BAD7ECFD15A/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407431270243/80653030A9E58BF9637ED105E4F63598082B2D9E/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407431270422/909F25E16D76BF99AE8122963CEE8BAD7ECFD15A/"
+              }
+            ]
+          },
+          {
+            "name": "Beast Master",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741833198/7B472992DE2786ABF9B11852AC28F1BBE3EFF7BF/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 20,
+            "speed": 1,
+            "upgrades": {
+              "Training": 1,
+              "Comms": 1,
+              "Illicit": 1,
+              "Gear": 1,
+              "Counterpart": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696827920718216/511748ACB39B86DB07F412D61B8BC0706C09A5C5/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696827920718383/E67A519C2234A19CB159E833352376586A237A07/"
+              }
+            ]
+          },
+          {
+            "name": "IG-86 Sentinel Droids",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742381727/F1DAD4DF93EE4BE12C4E2E2BC1D7BADF29BAD32A/",
+            "size": "small",
+            "type": "Droid Trooper",
+            "points": 80,
+            "speed": 2,
+            "upgrades": {
+              "Heavy Weapon": 1,
+              "Training": 1,
+              "Illicit": 1,
+              "Gear": 1,
+              "Grenades": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407432785617/C21E190F258AC17A01C5D096C890DFA3B988759D/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432785832/186A72B65075EEA56ED2C3D1DC80718E987884B5/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407433051929/749E23C3D0FD9CE738CEA98802F52CA8B64ADABE/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432785832/186A72B65075EEA56ED2C3D1DC80718E987884B5/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407433051436/F1EA8C6D3CCB8278F7775C7AB78AD996DFC24291/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432785832/186A72B65075EEA56ED2C3D1DC80718E987884B5/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407433050963/ED218EC8188C166AFEE1E1DE86351BE786E764D7/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432785832/186A72B65075EEA56ED2C3D1DC80718E987884B5/"
+              }
+            ]
+          },
+          {
+            "name": "IG-86 Sentinel Droids",
+            "title": "Strike Team",
+            "displayName": "Sentinel Droids (Strike Team)",
+            "heavyWeaponTeam": true,
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742381186/83833409E9638CCAE4D3E135DD7DE7C3F50BF6B2/",
+            "size": "small",
+            "type": "Droid Trooper",
+            "points": 25,
+            "speed": 2,
+            "upgrades": {
+              "Heavy Weapon": 1,
+              "Training": 1,
+              "Illicit": 1,
+              "Comms": 1,
+              "Gear": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407432785617/C21E190F258AC17A01C5D096C890DFA3B988759D/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432785832/186A72B65075EEA56ED2C3D1DC80718E987884B5/"
+              }
+            ]
+          }
+        ],
+        "Support": [
+          {
+            "name": "Droideka MKII",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638672297/9A21A780F96BA78A849FD5FFF320FF4D0581259A/",
+            "size": "medium",
+            "type": "Ground Vehicle",
+            "points": 110,
+            "speed": 1,
+            "upgrades": {
+              "Comms": 1,
+              "Hardpoint": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365798378/BE8A6530AC8273FFE4549147A2F83C7A77BA5597/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365798566/72991BC6227C745C3157A2328EEFDF4F1671924D/"
+              }
+            ]
+          },
+          {
+            "name": "EWHB-12 Heavy Blaster team",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742525705/7188974BC1594CD7D0B2D6775629F3933FE40E62/",
+            "displayName": "EWHB-12 Team",
+            "size": "medium",
+            "type": "Emplacement Trooper",
+            "points": 60,
+            "speed": 1,
+            "upgrades": {
+              "Comms": 1,
+              "Illicit": 1,
+              "Generator": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756243818494/7211F52034FC36725841F968E5F2B991F8C10274/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756243792095/065CF347E346B773F8F93F81B0048E6A6A67A2C1/"
+              }
+            ]
+          }
+        ],
+        "Heavy": [
+          {
+            "name": "Cuddles",
+            "title": "Ferocious One",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735162413/20647BC13446FAA4A0951E6E9D5003D9904557E9/",
+            "size": "huge",
+            "type": "Creature Trooper",
+            "points": 135,
+            "speed": 1,
+            "upgrades": {
+              "Creature": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984835661685/1668BEEE179A260B9988D3C60872160FF93CEE51/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984835661821/7B52CEEC4169ACB4A32C0489D4A878BC72030DE2/"
+              }
+            ]
+          },
+          {
+            "name": "Canderous Class Assault Tank",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738556639132725/E48531757B6B7D582D3D3AD313D790E21FAD2655/",
+            "size": "epic",
+            "type": "Repulsor Vehicle",
+            "points": 180,
+            "speed": 1,
+            "upgrades": {
+              "Pilot": 1,
+              "Comms": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231133144508/4BB9CD650D4795CEB6C81CBB95AB31DA7365F7EF/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231133144655/86527E20BE4B11B688A7F14894775EBE347C475B/"
+              }
+            ]
+          },
+          {
+            "name": "Missile Attack Launcher",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738556639035496/5F41C143C5ADE4631FFDC497CD8053BF7F0F9E43/",
+            "size": "epic",
+            "type": "Repulsor Vehicle",
+            "points": 140,
+            "speed": 1,
+            "upgrades": {
+              "Pilot": 1,
+              "Ordnance": 2,
+              "Comms": 1,
+              "Hardpoint": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698013227951332/BDA59EEE85EBD5AE628E38AC9B0C539D59DC9525/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698013227951474/8641BEED6BF44F70975F6F27093477327361567C/"
+              }
+            ]
+          },
+          {
+            "name": "Rancor",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742458068/53A90269FBB599680D91DA51225BE59738A8C049/",
+            "size": "huge",
+            "type": "Creature Trooper",
+            "points": 155,
+            "speed": 1,
+            "upgrades": {
+              "Pilot": 1,
+              "Creature": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696827920773360/FA78C7E63C77DD4A9CDF435A2DCE83BEE4235B82/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696827920773489/CCC8F655681A6962AA133E4DB9D4EBD8B3D487AD/"
+              }
+            ]
+          },
+          {
+            "name": "WLO-5 Battle Tank",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743059742/E6358D1656688B41E351113B72177D770264FB6B/",
+            "size": "epic",
+            "type": "Repulsor Vehicle",
+            "points": 125,
+            "speed": 2,
+            "upgrades": {
+              "Pilot": 1,
+              "Hardpoint": 1,
+              "Illicit": 1,
+              "Comms": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436416564/7E56BA386FDC26CB14047F335B62C19995B4AA5E/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436416842/1C5A975045A289BF43FBDC29DC3F2BD0ED7E1E0C/"
+              }
+            ]
+          }
+        ]
+      },
+      "Separatist": {
+        "Commander": [
+          {
+            "name": "Darth Sidious",
+            "title": "Master of Manipulation",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743518519/E404C02C62D579D5E0385EEDCB318DC45FFF7D13/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 240,
+            "speed": 2,
+            "upgrades": {
+              "Force": 3,
+              "Command": 1,
+              "Training": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824153235918382/C6629B635DB0B3D04D345B83AE6A0DA0EF4CDDBC/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824153235918510/4CE73F1347AA53974D94CADE1B77D9875694299C/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Power! Unlimited Power!",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743519427/23500514817BCDB46436B493396E941FD5FFE6E7/",
+                "pip": 1
+              },
+              {
+                "name": "Execute Order 66",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743519790/0A304E9ECB85D8BCC65B1FA93658FC87D98DC96D/",
+                "pip": 2
+              },
+              {
+                "name": "A Surprise, To Be Sure",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743520163/A584E2B66E09368C6E89485F7C44DBA8CEA2A0D5/",
+                "pip": 3
+              }
+            ]
+          }
+        ],
+        "Operative": [
+          {
+            "name": "Sun Fac",
+            "title": "Archduke's Chief Lieutenant",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746952332/B95C799020F79D219FFDF62FF12C7EFB302E3920/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 105,
+            "speed": 3,
+            "upgrades": {
+              "Command": 1,
+              "Training": 2
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318234636/1ECC7AF43F26DDE2A82E90A54DCE2956F02A27F0/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893318234765/77E9C34FC82B00D2C3E96A60AF29948CBEC88784/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Enforcer of the Swarm",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746960145/1E5AA4E032A934D62D4DBA0FB0C892E07603F8D7/",
+                "pip": 1
+              }
+            ]
+          }
+        ],
+        "Corps": [
+          {
+            "name": "Geonosian Warriors",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746956460/10EC43D13EC18AB52E30175D8E015E2C233EC310/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 48,
+            "speed": 3,
+            "upgrades": {
+              "Heavy Weapon": 1,
+              "Personnel": 1,
+              "Training": 1,
+              "Armament": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318078184/8B5466E18846FE7CF66B17BC0A657A0208855F03/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893318078962/DEB31D473979E7DE679F9564781A76B0E8E522FD/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318071468/13869F37C5ED6881ED97E16D300ED50175E1C007/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893317930470/4A9F58F7B8BC80AF279695655E38DD81A9236057/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318070141/E59D21FBF0E1DCE0AA6CF1B9574AB6BDF26438FC/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893317930470/4A9F58F7B8BC80AF279695655E38DD81A9236057/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318076612/BCD33D7FAFC2C324271FB92894740CACEFF7ED9D/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893317930470/4A9F58F7B8BC80AF279695655E38DD81A9236057/"
+              }
+            ]
+          }
+        ],
+        "Support": [
+          {
+            "name": "LM-432 Crabdroid",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743527286/34BE0F9B234F769983BE410CB8D2D94B695D5840/",
+            "size": "medium",
+            "type": "Ground Vehicle",
+            "points": 90,
+            "speed": 2,
+            "upgrades": {
+              "Comms": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455020027815604/10F9822A314D818E81C27CE272E1F52E50B6EBF3/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455020027816841/367B15AD633665E238815516DF8E82AC4EFAA34B/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455020027819432/1A96D256F849409A6F2157F0A896967146B7A13C/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455020027816841/367B15AD633665E238815516DF8E82AC4EFAA34B/"
+              }
+            ]
+          },
+          {
+            "name": "LR1K Sonic Cannon",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746955793/8D7F4A2BA75689F096F5D44BC4AB28B6BBDBC062/",
+            "size": "large",
+            "type": "Emplacement Trooper",
+            "points": 75,
+            "speed": 0,
+            "upgrades": {
+              "Comms": 1,
+              "Generator": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318385775/0D78686C63C10B04D2BA172B26F125D007034C0C/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893318369456/484B53AD87428BCF7E190DB1A763640373914353/"
+              }
+            ]
+          },
+          {
+            "name": "Octuptarra Tri-Droid",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743539441/5709DCD601EB0694A3CA0DA71D1BCC1D3C2A0F87/",
+            "size": "large",
+            "type": "Ground Vehicle",
+            "points": 60,
+            "speed": 2,
+            "upgrades": {
+              "Hardpoint": 1,
+              "Comms": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455403164598593/5A7C010653DBCE628FE44C40B0915C460164945A/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455403164542430/B2F1D02EDF736CAE38008DD4CEF11F2394AB18B4/"
+              }
+            ]
+          },
+          {
+            "name": "SD-4K Assassin Droid",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412069008204/589A89C815CF960153728A928496992538741916/",
+            "size": "large",
+            "type": "Ground Vehicle",
+            "points": 70,
+            "speed": 2,
+            "upgrades": {
+              "Programming": 1,
+              "Comms": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1055478180707369319/5222F20E44E450F944F7C39E59C16359C9743A60/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1055478180707368539/DDBADF81B279336EBE157E67F2ECAB3B6C8A037A/"
+              }
+            ]
+          },
+          {
+            "name": "Sharpshooter Droideka",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743586301/1CCF100C94512AE1CB7D788234024FDC86B16A29/",
+            "size": "medium",
+            "type": "Ground Vehicle",
+            "points": 110,
+            "speed": 1,
+            "upgrades": {
+              "Comms": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455553732191897/63312F1C4D01590EDA8153640DDF31260E7A27E2/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455553732192021/2D0E1C0D65555EF7A52443E3000E0979A287E077/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455553732192630/7B686F1D43905244043848E1240DA5B112F92A09/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455553732192021/2D0E1C0D65555EF7A52443E3000E0979A287E077/"
+              }
+            ]
+          }
+        ],
+        "Heavy": [
+          {
+            "name": "Defoliator Deployment Tank",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743614358/8A82032A999FD9F81E83CA8925B0C8AC301D07FD/",
+            "size": "epic",
+            "type": "Repulsor Vehicle",
+            "points": 155,
+            "speed": 1,
+            "upgrades": {
+              "Pilot": 1,
+              "Hardpoint": 1,
+              "Ordnance": 1,
+              "Comms": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893327245472/0E4E57241F7F12B74598D3D83A5D501E5586315F/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893327220558/8D3108FC26DE5361995CDDB2CE24CE004F69F1C9/"
+              }
+            ]
+          },
+          {
+            "name": "HMP Droid Gunship",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743692190/E87C41BC6C6F5797FA124D17C0F5C0FCB15769B0/",
+            "size": "epic",
+            "type": "Repulsor Vehicle",
+            "points": 155,
+            "speed": 2,
+            "upgrades": {
+              "Hardpoint": 1,
+              "Ordnance": 2,
+              "Comms": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028454854943605642/C9B582DDD3BD0DD6A4C0C3AB35E91064DFF77C42/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028454854943586665/C0F6961CFFA9F8E15FB5F6B6538AE5C404DD40B4/"
+              }
+            ]
+          },
+          {
+            "name": "IG-227 Hailfire-Class Droid Tank",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743648691/D8401535639FA435BD7D89A4DC8A9CEF8E077529/",
+            "size": "huge",
+            "type": "Ground Vehicle",
+            "points": 110,
+            "speed": 3,
+            "upgrades": {
+              "Hardpoint": 1,
+              "Comms": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455516900984588/FD6A321B7F88D5680A3AF647417BA4BB5E74EAEF/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455516901771593/595DBAC62796FE3C66973A218C72DDCEC3B4B05B/"
+              }
+            ]
+          },
+          {
+            "name": "Octuptarra Magna Tri-Droid",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743670386/A2A33692DAFB2F4BE77EE01ABEAB89F7B7CA1228/",
+            "size": "epic",
+            "type": "Ground Vehicle",
+            "points": 180,
+            "speed": 2,
+            "upgrades": {
+              "Hardpoint": 1,
+              "Comms": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455403164753290/F8E53798804F16BA75E428DF4DE94D930DB0F20A/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455403164542430/B2F1D02EDF736CAE38008DD4CEF11F2394AB18B4/"
+              }
+            ]
+          },
+          {
+            "name": "OG-9 Homing Spider Droid",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743679867/D32CA64107D6C9D10B086FE2335D8CC6A545F90C/",
+            "size": "epic",
+            "type": "Ground Vehicle",
+            "points": 140,
+            "speed": 1,
+            "upgrades": {
+              "Comms": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455403167048357/2192FD561FA2D05EB86CC3AE445499640E570E21/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455403164322367/DB9DC63C0285A43C8547D724F882063227910D89/"
+              }
+            ]
+          }
+        ]
+      },
+      "Sith Empire": {
+        "Commander": [
+          {
+            "name": "Darth Malgus",
+            "title": "Prodigy of Battle",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277562476/E42383A66E46621D98A52DA5D0BD1C7FBAD02AB9/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 190,
+            "speed": 2,
+            "upgrades": {
+              "Force": 3,
+              "Training": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824296871909914/CC551973C1E900C1153BB015BED7EE408646DF78/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231133343207/A24CBD9CC466137A560F72A00359E34DF0083071/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Furious Charge",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277563415/5A0861160BA5F979A8F0C216F494C9925D5538BB/",
+                "pip": 1
+              },
+              {
+                "name": "Visions of Doubt",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277563761/ECD4F9155C9E74C1B70403FD0F547B55070F205C/",
+                "pip": 2
+              },
+              {
+                "name": "Force Maelstrom",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277564474/A1645474FAA791583F23BC7FFE299704AA112FCF/",
+                "pip": 3
+              }
+            ]
+          },
+          {
+            "name": "Lord Adraas",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277602848/B56DEFFD7CC8988D8568476DE4E0C7E59908A6E1/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 120,
+            "speed": 2,
+            "upgrades": {
+              "Force": 2
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885833891/AE635515661DD84861ADF0CF4FC48052FD3DEF87/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608885695776/F5A3AA78554B8F3CB86314E552D94D65C0080F0C/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Counting Corpses",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277603245/63BC127864462C645D997822348332C2053CD8C8/",
+                "pip": 1
+              },
+              {
+                "name": "Spearheading the Assault",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277603553/067F6633690E6A14497AA7AA0164F0B93F773C2D/",
+                "pip": 2
+              },
+              {
+                "name": "Claiming Victory",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277603895/1237D55EFD6265C9922C8B7DEC76F46AD20608C4/",
+                "pip": 3
+              }
+            ]
+          },
+          {
+            "name": "Shae Vizla",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277698530/3A31084E01120F5B0F53A17C0B6F3ECBD2FD6DA6/",
+            "size": "small",
+            "type": "Mandalorian Trooper",
+            "points": 135,
+            "speed": 3,
+            "upgrades": {
+              "Training": 2,
+              "Gear": 1,
+              "Armament": 2
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642366438145/53BAD2A0BECE84168DD54692576AFFD8D43A9962/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642366438391/C107A0534E3BC5211416290AD53F4EB4482E021B/"
+              }
+            ],
+            "commands": [
+              {
+                "name": "Flame Burst",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277699041/E5D63FF435C115846E9863192F7A61EBABCD0DE4/",
+                "pip": 1
+              },
+              {
+                "name": "Mandalore The Avenger",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277699427/213D174E2B02C59A9774F14990693D661012BA30/",
+                "pip": 2
+              },
+              {
+                "name": "Whatever...",
+                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277699707/C145698341E7B15563A59265F2D6D63A1F16E340/",
+                "pip": 3
+              }
+            ]
+          }
+        ],
+        "Corps": [
+          {
+            "name": "Sith Empire Troopers",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277742096/C1DC5A839A9F754B2EECA3F022F05A30C182F003/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 44,
+            "speed": 2,
+            "upgrades": {
+              "Heavy Weapon": 1,
+              "Personnel": 1,
+              "Training": 1,
+              "Grenades": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608878956135/77C5F51565475CEB63D9A0A0E97F3616EC17992E/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608878877171/C209E7E6493A8465F8FD60DE6566AA6BA2C745ED/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608878992636/D833E26E44A7763FAEFBE2430390376F9160E931/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608878877171/C209E7E6493A8465F8FD60DE6566AA6BA2C745ED/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608879652119/A6E9D1CC7FCF34BF844B1847503E21E60C007A21/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608878877171/C209E7E6493A8465F8FD60DE6566AA6BA2C745ED/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608878917211/A6984255B6241D8A292F4785C28A87E134354C9A/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608878877171/C209E7E6493A8465F8FD60DE6566AA6BA2C745ED/"
+              }
+            ]
+          },
+          {
+            "name": "Sith Empire Boarding Troopers",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277785197/971E0418CD2A7CE414F629E2AFEE3B684B99BA46/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 48,
+            "speed": 2,
+            "upgrades": {
+              "Personnel": 1,
+              "Heavy Weapon": 1,
+              "Training": 1,
+              "Comms": 1,
+              "Grenades": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885319465/2474308EBBDD92BDF8D331691E4F47EB4E1D9D7B/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885051525/BE73F7CADC7D35B297FE86A2C7C13532B33BED20/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885219099/28222F723E524C776ADFD8BF4072B274D5DD6513/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885271840/AEB99C8ABF425086732389D43FA67625C6E6C4CB/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
+              }
+            ]
+          },
+          {
+            "name": "Sith Empire Support Troopers",
+            "heavyWeaponTeam": true,
+            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277927003/D6339601058975760755CFB0F0FEE8ED3B6A4372/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 30,
+            "speed": 2,
+            "upgrades": {
+              "Heavy Weapon": 1,
+              "Training": 1,
+              "Comms": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824477681546677/855DD1F57D897B360CCA3F12DDB4449E0D116255/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824477681548557/DB63AB0044B89CB25D50A204A061D535CA20F495/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824477681548370/AFD42783EB041326C035DDB002BF34928A1AE002/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824477681548557/DB63AB0044B89CB25D50A204A061D535CA20F495/"
+              }
+            ]
+          }
+        ],
+        "Special Forces": [
+          {
+            "name": "Imperial Commandos",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277957842/94E04A758D860C9A7FCFE6D6356AA07DBFD811FD/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 72,
+            "speed": 2,
+            "upgrades": {
+              "Heavy Weapon": 1,
+              "Gear": 1,
+              "Training": 1,
+              "Comms": 1,
+              "Grenades": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024260308213/15A8FC12EB8192B2272D639557ED336BAF9718BE/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260606126/9430D9F19B59E68648F5261C8162A66C253EDDC0/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024261188154/B23F2669D0C619618D89D2BCF50E701363CDB26B/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260988667/8B8E27DFEDD6DEBA4EFABD6E738D3B6AC3E925AB/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024260446504/E46DFA85E16AF894A710D4F6714BA84BC9C6BBB3/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260606126/9430D9F19B59E68648F5261C8162A66C253EDDC0/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024260532062/6D98D9E28283E02F34B203849A11F420D1A1C99E/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260606126/9430D9F19B59E68648F5261C8162A66C253EDDC0/"
+              }
+            ]
+          },
+          {
+            "name": "Sith Acolytes",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278054907/1EA779D6C64F1883A9EF450C1424A0459EF087F9/",
+            "size": "small",
+            "type": "Trooper",
+            "points": 78,
+            "speed": 2,
+            "upgrades": {
+              "Personnel": 1,
+              "Training": 1,
+              "Force": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012691837448680455/252DCD7E06B5083BBE6CABCA4F8349D6DCE46498/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608885695776/F5A3AA78554B8F3CB86314E552D94D65C0080F0C/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885701810/42CE6863B9D31E7EDDA1C4DEEC0C52F6DFEBB0D1/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608885695776/F5A3AA78554B8F3CB86314E552D94D65C0080F0C/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885733918/43DD4CBAEAD756429F47BAF24133A3D97CEA9DA6/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608885695776/F5A3AA78554B8F3CB86314E552D94D65C0080F0C/"
+              }
+            ]
+          }
+        ],
+        "Support": [
+          {
+            "name": "War Droid MK I",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278072181/D3BB57A041FA5490F372A792EEF35A344BD68FCD/",
+            "size": "medium",
+            "type": "Ground Vehicle",
+            "points": 110,
+            "speed": 1,
+            "upgrades": {
+              "Comms": 1
+            },
+            "minis": [
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697620253289667/85745104AA0C94936FA804B87EA1A61938161B79/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697620253289816/7245F236A07C662A6AA471AA89E323417AB7D604/"
+              },
+              {
+                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697620253290925/09820A879BC9DB027D438A7F0051F90D558A3D97/",
+                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697620253289816/7245F236A07C662A6AA471AA89E323417AB7D604/"
+              }
+            ]
+          }
+        ]
+      }
     },
-    "First Order": {
-      "Commander": [
+    "upgrades": {
+      "Armament": [
         {
-          "name": "Captain Phasma",
-          "title": "Ruthless Leader",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1027324804930937035/30C22DF987890556EDA35958BBACA2AF066BBA4F/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 100,
-          "speed": 2,
-          "upgrades": {
-            "Command": 2,
-            "Training": 1,
-            "Armament": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804925773451/29E9C01AADB63D0F11307AC6DF9FE7F0C29178CD/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804925773688/AA999386C07D280297E4E55F78BE951C22CC4765/"
+          "name": "Amped up A-280's",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742002345/F99AB12D9FC7810EC0868DEA0DD3EEFBB15D686E/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "unit": ["Hired Guns"]
             }
-          ],
-          "commands": [
-            {
-              "name": "Traitor!",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1027324712401796009/E80F6D102F47A6DB9E6AFE5EB672F718A39F97BF/",
-              "pip": 1
-            },
-            {
-              "name": "So Good To Have You Back",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1027324712401797801/9068684896D2C73825A05F2CA954ACC3635913B8/",
-              "pip": 2
-            },
-            {
-              "name": "On My Command",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1027324712401799817/1A4627E71A0BA3C1F42A3624DC562C9E8CDB8A5F/",
-              "pip": 3
-            }
-          ]
+          }
         },
         {
-          "name": "First Order Officer",
-          "title": "Cruel Superior",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1022821664192142011/4877E14EACE788FC09498381DA595EDF3F61CC1C/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 50,
-          "speed": 2,
-          "upgrades": {
-            "Command": 1,
-            "Gear": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821664192111404/0E625C7A4614D3BE5DF4DF9D78BA558C2B78803C/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821664192111727/770A7C77419D31361A4E7DF14655D4339B5333BE/"
+          "name": "Anakin's Lightsaber",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1027324932753002794/C0A0C19E79DAF7B4B11E6DCEE218AB2F4C385966/",
+          "points": 25,
+          "restrictions": {
+            "include": {
+              "unit": ["Finn"]
             }
-          ]
+          }
         },
         {
-          "name": "General Hux",
-          "title": "First Order High Commander",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1027324712402790359/1C0058360D3E240DD96283474E52D2C3B7FE96E6/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 75,
-          "speed": 2,
-          "upgrades": {
-            "Command": 2
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324932753815007/08A3CB2CCDEDD302548596EF866CF64E5E0AFB75/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324932753720403/40A7224F1345DCD440F78BD1669290C07059002E/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "Orbital Strike!",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1027324712402791640/1C1BA7881D8BE1692ACEA33F4D6974AC9546F1F7/",
-              "pip": 1
-            },
-            {
-              "name": "A Cur's Weakness...",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1027324712402792910/3FDC85FB96B2814F38071A510F5138A2E26F76F2/",
-              "pip": 2
-            },
-            {
-              "name": "Acquiesces to Disorder!",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1027324712402795048/8FE78D03A5528F665440B415F9489E6F9CCCCBEB/",
-              "pip": 3
-            }
-          ]
-        }
-      ],
-      "Operative": [
-        {
-          "name": "Bazine Netal",
-          "title": "Skilled Mercenary and Spy",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1027324712402774123/CA1C28978DE1A7BD777A1505DE5ECA0689B1AA23/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 80,
-          "speed": 2,
-          "upgrades": {
-            "Training": 2,
-            "Gear": 1,
-            "Grenades": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027325137554369094/426567AD530CBB53A36B4DA286606A8028036940/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821664190500251/60F46C12E0D02DE01D36B03BDF1E8ECAFD604F87/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "The Perfect Weapon",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1027324712402775812/305D475803C323A0C1D1B4273C36CF5FFD9555E5/",
-              "pip": 1
-            },
-            {
-              "name": "They Die Or Disappear",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1021696515357822212/8534EA35A7B82B48A8DD08B64D023D1889F95702/",
-              "pip": 2
-            },
-            {
-              "name": "Inform The First Order",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1021696515357821665/686AD5E592C0FF9FC08F6C7B14DE6F63259732DA/",
-              "pip": 3
-            }
-          ]
-        },
-        {
-          "name": "Kylo Ren",
-          "title": "Fallen Apprentice",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1027324804930935641/32053EC6023686069120CF8DBBDF21C4625233B0/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 150,
-          "speed": 2,
-          "upgrades": {
-            "Force": 2,
-            "Training": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804925562786/E8A84B89A9397EDE6466F969084F683316C98D64/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804925562981/94795F169138667E0322FE1E28F68E2B8B7F4C37/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "I Will Finish What You Started",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1027324712401782746/D22391FEFBF043B2B445F41144FC2A492E4C28BD/",
-              "pip": 1
-            },
-            {
-              "name": "Raw Untamed Power",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1027324712401786509/F7F43ECE7A51D3E22F6588B8A6DD8493A22D16A6/",
-              "pip": 2
-            },
-            {
-              "name": "Mind Probe",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1027324712401788021/D2857A28E90794F48843CF6F281004E4A7B8AB18/",
-              "pip": 3
-            }
-          ]
-        }
-      ],
-      "Corps": [
-        {
-          "name": "First Order Stormtroopers",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1027324804931510298/AF04FDEDA7216024A534A74F972923DDBFF8A2A5/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 52,
-          "speed": 2,
-          "upgrades": {
-            "Heavy Weapon": 1,
-            "Personnel": 1,
-            "Training": 1,
-            "Gear": 1,
-            "Grenades": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804926496354/534247FC18865263C1D30BC8C906CB39C93B0394/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804926496614/9FECECAF48C7046C3714B33C4C16FFB773FCC94C/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804926504208/94BA6801EC3D5C7915A803C8DB037D55499DA148/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804926496614/9FECECAF48C7046C3714B33C4C16FFB773FCC94C/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804926505290/B0670893C896898E6BE4CAB01744CE00F1FFE52B/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804926496614/9FECECAF48C7046C3714B33C4C16FFB773FCC94C/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804926506313/1AF44B793BDE12347BA28238D08E48E507CFBD02/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804926496614/9FECECAF48C7046C3714B33C4C16FFB773FCC94C/"
-            }
-          ]
-        }
-      ],
-      "Special Forces": [
-        {
-          "name": "Jet Troopers",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1021698013227710802/31F1894E5D894CF8AA32648A9D2485ECA67CD778/",
-          "size": "small",
-          "type": "Trooper",
+          "name": "Anakin's Lightsaber Rey",
+          "displayName": "Anakin's Lightsaber",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1027324932753002794/C0A0C19E79DAF7B4B11E6DCEE218AB2F4C385966/",
           "points": 20,
-          "speed": 3,
-          "heavyWeaponTeam": true,
-          "upgrades": {
-            "Heavy Weapon": 1,
-            "Training": 1,
-            "Comms": 1,
-            "Gear": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698013227866981/5EA3E02AC241512021988DBE0EC44754960D7C1E/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698013227867246/FB14C11D0A31B44E68FDEF0CAF9D3CCE7D140EF7/"
+          "restrictions": {
+            "include": {
+              "unit": ["Rey"]
             }
-          ]
-        }
-      ],
-      "Support": [
-        {
-          "name": "125-Z Treadspeeder Bikes",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1021696515357808026/ABE976BE897F31B806CE32246741B2EB07D14FBA/",
-          "size": "medium",
-          "type": "Repulsor Vehicle",
-          "points": 75,
-          "speed": 3,
-          "upgrades": {
-            "Comms": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770981171565/A72EE65BB1B64233BC73B5A19F8BEEB49B6D25C2/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770981171714/24D19968CC914CDDF4318CD7F4D6A4A8C6453857/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1776099479274350301/4B9837939C2036E21527782F78E06152B3BFD831/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770981179713/F1CAD4EA45F501FA427BFC3194823758D23CAB4C/"
-            }
-          ]
-        }
-      ],
-      "Heavy": [
-        {
-          "name": "Light Infantry Utility Vehicle",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1027325137554521425/576094504D62AAD413446EBD13F1D013DA4B0C78/",
-          "size": "huge",
-          "type": "Repulsor Vehicle",
-          "points": 80,
-          "speed": 2,
-          "upgrades": {
-            "Crew": 1,
-            "Hardpoint": 1,
-            "Comms": 1,
-            "Generator": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027325137553435779/3A8FDD7CE7E77EA1D206645EEC453C509B3BD6F2/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027325137553435979/8778AF380A0A56B19CD1EA4BC88266803292180E/"
-            }
-          ]
-        }
-      ]
-    },
-    "Rebel": {
-      "Commander": [
-        {
-          "name": "General Rieekan",
-          "title": "Founding Member of the Alliance",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640752085723/9E5DE6BB4E45204DC3A997830A4DC8068C69CABD/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 80,
-          "speed": 2,
-          "upgrades": {
-            "Command": 2,
-            "Gear": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698230624925896/947BD1C75A604FAD92CB77ECAB27AC5109EB7F00/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698230624926095/54D107149A5C01B99334D873DC0D2B172AB71DA7/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "Rapid Response",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640752086080/BC550A52E3D05D8FFB63D4673FD71BCAD35FC13C/",
-              "pip": 1
-            },
-            {
-              "name": "Launch Patrols",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640752086446/2245AED04413455E4469534F5D70B03D02DD184C/",
-              "pip": 2
-            },
-            {
-              "name": "Armored Assault",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640752086781/B8BD73E178BA6F4492F8F9C5110E921BDB1ADA3A/",
-              "pip": 3
-            }
-          ]
-        }
-      ]
-    },
-    "Republic": {
-      "Commander": [
-        {
-          "name": "Mace Windu",
-          "title": "Master Jedi",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747447768/91A80BEC147782188809554C9E3E1C89E38D0A8C/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 200,
-          "speed": 2,
-          "upgrades": {
-            "Force": 3,
-            "Command": 1,
-            "Training": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455187825660/20318CF5820801C8D087056BFFF3B448DD1D24C0/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455187825926/3024C576BF271F52A8E09E226B9CE33A850279B5/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "This Party's Over",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747448183/4C67DCF52EA1A41CE347DFA72F1F249E6D2C990B/",
-              "pip": 1
-            },
-            {
-              "name": "High Jedi General",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747448594/5712552FEBB895EB97EFB122230A64DFC888F30D/",
-              "pip": 2
-            },
-            {
-              "name": "Shatterpoint",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747448920/DE303A6D36A7845AD8B10767827027D50EA8738E/",
-              "pip": 3
-            }
-          ]
+          }
         },
         {
-          "name": "Commander Cody",
-          "title": "Marshal Commander of the 212th",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747469835/A6730D0E28DBDA4AC78F4590BF0C5F1D46083322/",
-          "size": "small",
-          "type": "Clone Trooper",
-          "points": 110,
-          "speed": 2,
-          "upgrades": {
-            "Command": 1,
-            "Training": 1,
-            "Gear": 1,
-            "Armament": 1,
-            "Grenades": 1
+          "name": "BB-8 Grappling cord",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157660515/A2C7648C32E4AF4B631D2C498E6C76CC97B25925/",
+          "points": 0,
+          "restrictions": {
+            "include": {
+              "unit": ["BB-8"]
+            }
+          }
+        },
+        {
+          "name": "Cody's DC-15a",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747470278/1615C1C3D7C36AA201B25F52D99215DC4D12195C/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "unit": ["Commander Cody"]
+            }
+          }
+        },
+        {
+          "name": "Defilers Blaster",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735211533/50044D04BF35EAE0926C6A86936DC5A2DA95B0FD/",
+          "points": 15,
+          "restrictions": {
+            "include": {
+              "unit": ["Defiler"]
+            }
+          }
+        },
+        {
+          "name": "DC-17m Anti-Armor Config",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747570525/CACD6285B8098528A1E23C5AA68F3EB68076B4DF/",
+          "points": 18,
+          "restrictions": {
+            "include": {
+              "unit": ["Republic Commandos"]
+            }
+          }
+        },
+        {
+          "name": "DC-17m Sniper Rifle Config",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747571113/0AA95599A43D23EDBDA63F1835698A1CBAC6D746/",
+          "points": 20,
+          "restrictions": {
+            "include": {
+              "unit": ["Republic Commandos"]
+            }
+          }
+        },
+        {
+          "name": "Defilers Slug Thrower",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735211196/02C8A1B676C2CFC2A17BFB8819B8C6981DAD74D7/",
+          "points": 15,
+          "restrictions": {
+            "include": {
+              "unit": ["Defiler"]
+            }
+          }
+        },
+        {
+          "name": "DXR-6 Focused Fire Config",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735115917/9E0BA5F8013B1491D5EF74BED3C484BA0F3052AB/",
+          "flip": {
+            "name": "DXR-6 Power Shot Config",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735116297/419AF3D6925D7004CA92BE249969A1BFB42B9742/"
           },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893322692719/36CE1B78678368B94938143D4CEA2773F93F363A/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893322728253/2649AA8D8F66C02A791A73B8AFAD18C25B40A394/"
+          "points": 8,
+          "restrictions": {
+            "include": {
+              "unit": ["Mercenary Assault Squad"]
             }
-          ],
-          "commands": [
-            {
-              "name": "Blast Him",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747470658/793EFE2139085E54F9F85AAC92274E621C66DC6E/",
-              "pip": 1
-            },
-            {
-              "name": "Good Man That Cody",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747471029/C0DD76F36655C93C8C105652951B3B74FCDC202D/",
-              "pip": 2
-            },
-            {
-              "name": "You Must Realize That You Are Doomed",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747471461/265DF114E68306DF604691C110042DDB00C84DAC/",
-              "pip": 3
+          }
+        },
+        {
+          "name": "Elite Wrist Mounted Flamethrower",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640412575/1F3B56925DC71E5FAFDD405CF117B72CC0DB3B42/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "type": ["Mandalorian Trooper"],
+              "rank": ["Commander", "Operative"]
             }
-          ]
+          }
+        },
+        {
+          "name": "Gauntlet Blades",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640410174/FF136859D9C64EFC2B33CEDF111204596228A4B0/",
+          "points": 6,
+          "restrictions": {
+            "include": {
+              "unit": ["Bo-Katan Kryze"]
+            }
+          }
+        },
+        {
+          "name": "Hondo's Electrostaff",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738475192/6004D55A77E10329CE6EABD01DE46D1BB2DF1572/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "unit": ["Hondo Ohnaka"]
+            }
+          }
+        },
+        {
+          "name": "Illegally Modified E-11's",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742002948/59F017866F7B7293C00FED3BA937D371B7E71C0A/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "unit": ["Hired Guns"]
+            }
+          }
+        },
+        {
+          "name": "Quicksilver Baton",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081144482/1AA3BE94F83F1BE4DE2D135E655B5C1D811B327F/",
+          "flip": {
+            "name": "Chromium SE-44 Blaster",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081144665/EE6A1C8395737CB64EA6529ECFC1D00146A350FC/"
+          },
+          "points": 15,
+          "restrictions": {
+            "include": {
+              "unit": ["Captain Phasma"]
+            }
+          }
+        },
+        {
+          "name": "Static Pikes",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746953521/48A9A9BFC5662EA0496E1533D16AAE84DB4CCE48/",
+          "points": 6,
+          "restrictions": {
+            "include": {
+              "unit": ["Geonosian Warriors"]
+            }
+          }
+        },
+        {
+          "name": "Vibroblade",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412068779530/6BC0F180AB6278302B59DFDC3C381F048CFA28D7/",
+          "points": 12,
+          "restrictions": {
+            "include": {
+              "unit": ["Calo Nord"]
+            }
+          }
+        },
+        {
+          "name": "Wrist Rocket",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640428446/AE6DB75F1A3643AF7DCB7CA1BA8DAFF87E7A5C8A/",
+          "points": 6,
+          "restrictions": {
+            "include": {
+              "type": ["Mandalorian Trooper"]
+            }
+          }
+        },
+        {
+          "name": "Whistling Birds",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640411728/A3BCBA7C1B49EE5B996A55A8FC6CB581A9EAA96C/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "type": ["Mandalorian Trooper"],
+              "rank": ["Commander", "Operative"]
+            }
+          }
+        },
+        {
+          "name": "Wrist Mounted Blasters",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640413937/745B5BEAD23640A8222A54287029ACF70F9A81EE/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "type": ["Mandalorian Trooper"]
+            }
+          }
+        },
+        {
+          "name": "Wrist Mounted Flamethrower",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640416270/08971192288A83DD208F4D91D02703E094090133/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "type": ["Mandalorian Trooper"]
+            }
+          }
+        },
+        {
+          "name": "Z-6 Riot Control baton",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752981376/8F2F3430452BDBD8DD78E48243BCECEA994DF1AC/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "unit": ["Finn"]
+            }
+          }
         }
       ],
-      "Operative": [
+      "Command": [
         {
-          "name": "Ahsoka Tano",
-          "title": "Stubborn Padawan",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747500577/DCDE4281DCAD8EC68919759915AB4DF09EAB5546/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 110,
-          "speed": 2,
-          "upgrades": {
-            "Force": 2
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350883222773/A4B8C6678A7082E70BEC3204A279752479EA5EA2/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350882538520/1BB66CE6B8F58CFB17BE6A7850DC2F2A6F0A2CC3/"
+          "name": "Racketeering",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735072829/84C080C8B919D06884AF3BC12ADDB58B524C5271/",
+          "points": 5,
+          "restrictions": {
+            "include": {
+              "unit": ["Tyber Zann"]
             }
-          ],
-          "commands": [
-            {
-              "name": "Twin Lightsabers",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747502894/3AE99D7998FF7322CA29DCF7BAE0B72D459F9110/",
-              "pip": 1
-            },
-            {
-              "name": "Anakin's Apprentice",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747503725/0A7361854FBF8757DA002A670DBAA45BDDFD76D4/",
-              "pip": 2
-            },
-            {
-              "name": "Independant Adept",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747504272/935C0A5511D2455D302753EC8DEE0A9AF0326CB6/",
-              "pip": 3
-            }
-          ]
-        },
-        {
-          "name": "Commander Colt",
-          "title": "Rancor Batallion",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747527226/26A8CE439ADC2BDB1C9EE783B4013366CC9F97A8/",
-          "size": "small",
-          "type": "Clone Trooper",
-          "points": 90,
-          "speed": 2,
-          "upgrades": {
-            "Training": 1,
-            "Comms": 1,
-            "Gear": 2,
-            "Grenades": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693415431516051/4EAB6085C2D2D6C176B3C9847E2F1F228CEFE7BB/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693415431516248/89D5E03C721391A7CBC7930180396F3B14E5273F/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "Legacy Of A Legend",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747528124/18B118F66C532CAF69CC82877EC177C68A9A5278/",
-              "pip": 1
-            },
-            {
-              "name": "Shock Traps",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747528435/A7754C5F989DC2C48860EA1F8DDFC671FCD90338/",
-              "pip": 2
-            },
-            {
-              "name": "Shoulder to Shoulder",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747528812/CFDDAA0DDD1CB89C937F8B47D672B78CF44D19D5/",
-              "pip": 3
-            }
-          ]
+          }
         }
       ],
-      "Special Forces": [
+      "Comms": [
         {
-          "name": "Clone Paratroopers",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747550450/AB6335C9C96E10F6D70F161BCDFC89FDB2934C57/",
-          "size": "small",
-          "type": "Clone Trooper",
-          "points": 68,
-          "speed": 2,
-          "upgrades": {
-            "Heavy Weapon": 1,
-            "Personnel": 1,
-            "Training": 1,
-            "Comms": 1,
-            "Gear": 1,
-            "Grenades": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693290507071203/040CF6A943C83588994E5BD8C0DDB793F6DE9875/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693415425506623/121AA3B4552A900E92161C97E55443D4040D7886/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693290507016826/760576DD3D314CB88313B54E105FB561009F8502/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693290506836632/AE0366ABB62BED44CC56CB5F25D5C6478592EBBF/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
+          "name": "B1's Datapad",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1021698068155822603/B74DFBDE71FC462A482C92AF02C57AD2C6373E0F/",
+          "points": 6,
+          "restrictions": {
+            "include": {
+              "unit": ["Salvaged B2 Battle Droids"]
             }
-          ]
+          }
         },
         {
-          "name": "Republic Commandos",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747569673/F45852AF875FCB41E9BB5B23FFACC1029A8E548C/",
-          "size": "small",
-          "type": "Clone Trooper",
-          "points": 100,
-          "speed": 2,
-          "upgrades": {
-            "Training": 1,
-            "Comms": 1,
-            "Gear": 1,
-            "Armament": 2,
-            "Grenades": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455182355861/149A0196C96C1D78830C56F479A27BF825E9C6AB/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455182206940/096195C231ECC170C0963163315EFADABC01D5D7/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455182228456/B086CF963F81B78DCBE9E0893013169CF6454817/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455182206940/096195C231ECC170C0963163315EFADABC01D5D7/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455182280894/C546CADEC6AD3A41EFFC07CCD86AAE1EFB325BC7/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455182206940/096195C231ECC170C0963163315EFADABC01D5D7/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455182431253/81E98F267170F435E05AA7ED621A04F6476DC3B0/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455182206940/096195C231ECC170C0963163315EFADABC01D5D7/"
+          "name": "Proximity Signal",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743573243/8687C5FADEF63558D5088A664E51ACF3C9D3D172/",
+          "points": 6,
+          "restrictions": {
+            "include": {
+              "unit": ["SD-4K Assassin Droid"]
             }
-          ]
+          }
         }
       ],
-      "Heavy": [
-        {
-          "name": "AT-AP",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747585288/91E17B9FFBE325EE7E46C3F18DF4E613EF60E6A3/",
-          "size": "epic",
-          "type": "Ground Vehicle",
-          "points": 165,
-          "speed": 1,
-          "upgrades": {
-            "Pilot": 1,
-            "Hardpoint": 2,
-            "Comms": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756243525814/22DBD5FF8C4A887FF7DBFD977F190A7192C1D4B7/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756243525957/D334BA41B51D1DD235E2A5ED14F1EEACC9CD9EEF/"
-            }
-          ]
-        },
-        {
-          "name": "LA-AT/I Gunship",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747615420/DD22D969B4D59595325925BD059DBF83F295F406/",
-          "size": "epic",
-          "type": "Repulsor Vehicle",
-          "points": 190,
-          "speed": 2,
-          "upgrades": {
-            "Pilot": 1,
-            "Hardpoint": 2,
-            "Ordnance": 1,
-            "Comms": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028454854943442054/64C9040DF30E7980A9E9F22FD7A56D5C84052167/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028454854943501740/E509E21CEB3321071E6F56B006F24C1D919B6F3B/"
-            }
-          ]
-        }
-      ]
-    },
-    "Resistance": {
-      "Commander": [
-        {
-          "name": "Finn",
-          "title": "First Order Defector",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752987105/4E0911D06D60474448E5EF5CFB340A7CA015C62D/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 110,
-          "speed": 2,
-          "upgrades": {
-            "Command": 1,
-            "Comms": 1,
-            "Gear": 1,
-            "Armament": 1,
-            "Counterpart": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770985763040/56F6F436F140391F26FB16960E2D6CD57FB14B71/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770985763307/FB7EDB7C8D248BF873C1405012C99CC32C9FEBAA/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "Big Deal",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752986056/CDC39A7E6D1022EC938F8F8A599EE7513650A574/",
-              "pip": 1
-            },
-            {
-              "name": "Come Get It",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752985107/DEB9D333DCC6E48F6855736D9E28A806719CE0E0/",
-              "pip": 2
-            },
-            {
-              "name": "I am with the Resistance",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752983093/53828D3EB704897C38DD09ECE6E0083DEB51146F/",
-              "pip": 3
-            }
-          ]
-        },
-        {
-          "name": "Poe Dameron",
-          "title": "Reckless Flyboy",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1022821770975464596/6EDA2DD86069BD1A0B3B2690B5397BC3FC01C228/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 100,
-          "speed": 2,
-          "upgrades": {
-            "Command": 1,
-            "Training": 1,
-            "Comms": 1,
-            "Gear": 1,
-            "Counterpart": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770984969371/73F6B8B3D8D4C55321CBCE3D8B75E5A7E5B25A94/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770984969603/8925F3262BB3FE97EC31D45DAE964400AE8A528F/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "We are the Spark",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1022821770975465215/89BB4AAD301785869E3A3C44CFB2745F511C8FE8/",
-              "pip": 1
-            },
-            {
-              "name": "Dead Heros",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1022821770975470651/B99A6006460BC0A2B198BBE3CE6BA403E3B1AB7A/",
-              "pip": 2
-            },
-            {
-              "name": "I Need a Pilot",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1022821770975471416/4ED3DFBB9E55FC22BA5F9A7E2B1D5B5229CE9C79/",
-              "pip": 3
-            }
-          ]
-        }
-      ],
-      "Operative": [
-        {
-          "name": "Rey",
-          "title": "Force Prodigy",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1022821770981203693/E3069DE71ED495326B84393B00F82E021420E753/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 125,
-          "speed": 2,
-          "upgrades": {
-            "Force": 1,
-            "Training": 1,
-            "Gear": 1,
-            "Armament": 1,
-            "Counterpart": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804925013057/F62D7D1921B435B28DDB56BD129BB39D1FB2C2FD/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324712401180346/5DD131A4135CF4C90A2D42D264F3FAB332155AB3/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "The Force Awakens",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1027324582151432669/7A2F43C29C19033B13852F63165D64A18D766544/",
-              "pip": 1
-            },
-            {
-              "name": "You Came back For Me",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1027324582151438024/BC43E151F85D06C17D0602947648984AA604E08F/",
-              "pip": 2
-            },
-            {
-              "name": "I Think I Can Handle Myself",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752998047/158965EE8DD63D9BD1A1F43BC7E51993538FC7E3/",
-              "pip": 3
-            }
-          ]
-        },
+      "Counterpart": [
         {
           "name": "BB-8",
-          "title": "A Clever Little Droid",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1022824296871784130/E6058352DDF98D626EC56C53D97FBD31675E6898/",
-          "size": "small",
-          "type": "Droid Trooper",
-          "points": 45,
-          "speed": 2,
-          "upgrades": {
-            "Comms": 1
+          "image": "http://cloud-3.steamusercontent.com/ugc/1022824296871784739/BA69ED4E4B2926D1C9E5FB255791569EB5AA7A05/",
+          "points": 25,
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068157620585/9E7930221D8CD87F6338B9D4B58F4D3F824D08C0/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068157620780/493748852320ED988465533F8BC49FEA2672A9E8/"
           },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068157620585/9E7930221D8CD87F6338B9D4B58F4D3F824D08C0/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068157620780/493748852320ED988465533F8BC49FEA2672A9E8/"
+          "restrictions": {
+            "include": {
+              "faction": ["Resistance"],
+              "unit": ["Rose Tico", "Rey", "Poe Dameron", "Finn", "R2-D2"]
             }
-          ],
-          "commands": [
-            {
-              "name": "Happy Beeps",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157653789/55772CA9D24676C0367BBAC6F831F03E0340F4EB/",
-              "pip": 1
-            },
-            {
-              "name": "Keep an eye on this kid",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157657298/77DAA5AFFEDD096EC568637DC3777E4696DE7D9D/",
-              "pip": 1
-            },
-            {
-              "name": "Engineering Expertise",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157658855/8B72242F4B9650FC1DBE591F7FE32D574808DAA1/",
-              "pip": 2
-            },
-            {
-              "name": "Never Underestimate a Droid",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157658236/1E07FA41D1449A2991220D2733B1F51D2565C4F7/",
-              "pip": 2
-            },
-            {
-              "name": "A Mutual Understanding",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1022824296871786871/AF5D00FAB14B8C70B843DFB4BD18D6EFC9F8ADD1/",
-              "pip": 2
-            },
-            {
-              "name": "Impromptu Imposter",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157655413/18B1636E2055305E94F285684921B2FDAA773450/",
-              "pip": 2
-            },
-            {
-              "name": "Good Things Come Back",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1022824296871785786/4EA05DE445200A52D753CD1A023028FE0B5F0A0D/",
-              "pip": 3
-            },
-            {
-              "name": "Deus Ex Machina",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157655832/49730DEF4AAD9BF0481CA578387F21D074A104D8/",
-              "pip": 3
-            }
-          ]
+          }
         },
         {
-          "name": "R2-D2",
-          "title": "Hero Of A Thousand Devices",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1022821770981205050/4D72685715DF8671198FA4BC591397371BC96665/",
-          "size": "small",
-          "type": "Droid Trooper",
-          "points": 45,
-          "speed": 1,
-          "upgrades": {
-            "Counterpart": 1,
-            "Comms": 1
+          "name": "C-3PO",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1616219505080628828/F6A01DB4DFDB1A518FC4E373D72237AB1B31300B/",
+          "points": 15,
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/776232727456807069/DE7E32B39455DB5111769436FD0C5BFDA3841268/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/777357228032306506/D60CB8A1159723917EF1831D4042318A67458A7A/"
           },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/776232727456806966/EFBA4A71BFE748A2868C14B82DA3A7B0D559874A/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/777357228032306302/F5CA6FC54A8625E261F123D73792DE36D74E1686/"
+          "restrictions": {
+            "include": {
+              "unit": ["R2-D2"]
             }
-          ],
-          "commands": [
-            {
-              "name": "Blast Off!",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564037063/A7AE3401CB3A51A58A8682BBCD8D6F6C104804AF/",
-              "pip": 1
-            },
-            {
-              "name": "Impromptu Immolation",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564035209/4C4829AE9D1B01B14F2D4FDE2C6D3935D8055954/",
-              "pip": 2
-            },
-            {
-              "name": "Smoke Screen",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564033033/7FC32081CE8646476E7B0C475F452AA629BA7713/",
-              "pip": 3
+          }
+        },
+        {
+          "name": "Salacious B. Crumb",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741310541/C8ADFE085EC634C8766C303BD1F89D230BEADEBE/",
+          "points": 10,
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984838966754/DCEED639BB3AA1D36A2AF82B26708EF4007A3583/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984838966978/51C97B6161C17AE3229372F0C26331EAD0D44200/"
+          },
+          "restrictions": {
+            "include": {
+              "unit": ["Jabba The Hutt"]
             }
-          ]
+          }
+        },
+        {
+          "name": "Vornskr's",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741832560/CFA25E88275C65CC80ACE518A3DBDB2C4235E061/",
+          "points": 15,
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697620252875766/48FF7F717DEA00FCE1E830FD4FA888494433370A/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697620252875970/2006E4E0DA5EA0DEEEB1B3982D975944B8F9DC7B/"
+          },
+          "restrictions": {
+            "include": {
+              "unit": ["Beast Master"]
+            }
+          }
         }
       ],
-      "Corps": [
+      "Crew": [
         {
-          "name": "Resistance Troopers",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1027324582151747849/0DC6B237D0C8CC16BE47236FF1B5268D403945C1/",
-          "size": "small",
-          "type": "Trooper",
+          "name": "F-11D Blaster Rifle Gunner",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081208241/F230A7C4DE9FBF543B9DD9F4CB370A7D59B44BAA/",
+          "points": 7,
+          "restrictions": {
+            "include": {
+              "unit": ["Light Infantry Utility Vehicle"]
+            }
+          }
+        },
+        {
+          "name": "First Order Officer ",
+          "displayName": "First Order Officer",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081214064/11B6F493E9AFB18F34739932FD21874F50EA6E7E/",
+          "points": 8,
+          "restrictions": {
+            "include": {
+              "unit": ["Light Infantry Utility Vehicle"]
+            }
+          }
+        }
+      ],
+      "Flaw": [
+        {
+          "name": "I Don't Care if You Win",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081176926/A624D3D4A4BF45129F3D140BA5FFEFEF471065B9/",
+          "points": 0
+        },
+        {
+          "name": "I'll Bet You Have",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741747564/7E279CBA3100D1D5A3E4B5D9EBD362D57373ABE8/",
+          "points": 0
+        },
+        {
+          "name": "I'm Being Torn Apart",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081188353/E86EB5CB8B87C8CE341CD77CD32CD8A6A5FA3B67/",
+          "points": 0
+        }
+      ],
+      "Force": [
+        {
+          "name": "Acolyte Force Lightning",
+          "displayName": "Force Lightning",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278090576/86604BC87F9AB158776F63811C23AB3AE058722A/",
+          "points": 5,
+          "restrictions": {
+            "include": {
+              "faction": ["Sith Empire"]
+            }
+          }
+        },
+        {
+          "name": "Chain Lightning",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278091219/1C7C89C5537F9B248294B44DADC5F24D181892C2/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "faction": ["Sith Empire"]
+            }
+          }
+        },
+        {
+          "name": "Force Dash",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747371109/7290AD045A9201DA40F367CAD1FF04C1615B9851/",
+          "points": 9
+        },
+        {
+          "name": "Force Lightning",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747371606/231C69EF773D74B95CCC5EB34F1EB96C1119FA98/",
+          "points": 12,
+          "restrictions": {
+            "include": {
+              "alignment": ["Dark"]
+            }
+          }
+        },
+        {
+          "name": "Force Rend",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747370532/B97ADF8AC0302E13A315C68402376409B45A5FFE/",
+          "points": 17,
+          "restrictions": {
+            "include": {
+              "alignment": ["Dark"]
+            }
+          }
+        },
+        {
+          "name": "Force Statis",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747369898/5CC327BAEB59E3B817B71AFF6EC21D3E14ADB4A2/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "alignment": ["Dark"]
+            }
+          }
+        },
+        {
+          "name": "Maglus Force Lightning",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277562964/22A352A0E0EF8FE27B1DF1F19C08A80CE1564B3C/",
+          "points": 5,
+          "restrictions": {
+            "include": {
+              "unit": ["Darth Malgus"]
+            }
+          }
+        }
+      ],
+      "Gear": [
+        {
+          "name": "Bacta Auto-Dispenser",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747571812/21DA4C0C9811D5252F4FAB4E7F10B358FC74C2BA/",
+          "points": 20,
+          "restrictions": {
+            "include": {
+              "unit": ["Republic Commandos"]
+            }
+          }
+        },
+        {
+          "name": "Calo Nord's Battle Armor",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412068780383/4FE70939384B8CD88DC852C8CAED0D21BAF3C367/",
+          "points": 35,
+          "restrictions": {
+            "include": {
+              "unit": ["Calo Nord"]
+            }
+          }
+        },
+        {
+          "name": "Electro Grappling Line",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640414601/68D77CCDC40F2F1F103F1AF7568727FA6F9E8CE9/",
+          "points": 3,
+          "restrictions": {
+            "include": {
+              "type": ["Mandalorian Trooper"]
+            }
+          }
+        },
+        {
+          "name": "JT-12 Jetpack",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747527633/AF0E4FAA5C2D92BD45DC40252B9ADAB003A5FC5F/",
+          "points": 5,
+          "restrictions": {
+            "include": {
+              "unit": ["Commander Colt"]
+            }
+          }
+        },
+        {
+          "name": "Jump pack",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751974753/5AF713EB09F4AFDF88B76C8CB9F54CE4D0BEB7D8/",
+          "points": 0,
+          "restrictions": {
+            "include": {
+              "unit": ["Phase II Darktroopers"]
+            }
+          }
+        },
+        {
+          "name": "Personal Combat Shield",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640410953/DEF506B2DB3747BF1DD5ABBECEB36764450D0B7C/",
+          "points": 15,
+          "restrictions": {
+            "include": {
+              "type": ["Mandalorian Trooper"]
+            }
+          }
+        },
+        {
+          "name": "Target Designator",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638971560/0F6F9FB93CD712E0D2B5916DE3392EF98BDAB3DC/",
+          "points": 6,
+          "restrictions": {
+            "include": {
+              "faction": ["Scum"]
+            }
+          }
+        },
+        {
+          "name": "Vambrace Reloader",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640415774/E6C7E28AAA6C1EC3CB460AE5947F2AAE2960EF15/",
+          "points": 3,
+          "restrictions": {
+            "include": {
+              "type": ["Mandalorian Trooper"]
+            }
+          }
+        }
+      ],
+      "Generator": [
+        {
+          "name": "Class-5B1 Duplex Generator",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747375028/7DEFD098875FF94FD712C2FB42C37218AE5F95D9/",
+          "points": 10
+        },
+        {
+          "name": "GNK-series Power Droid",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747374218/EBE238DB2CCD3F06AC1CC96325D04FEE2B5ECD1C/",
+          "points": 5
+        },
+        {
+          "name": "Ion Generator",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747374603/462C32A767195B287E9FFCFC73BD0FA798F982DF/",
+          "points": 10
+        },
+        {
+          "name": "Scavenged Generator",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1022824296871788518/1BB5B0A6D3E8BDA3F3E66F6ED7B4E30BC24C4C3E/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "faction": ["Resistance", "Rebel"]
+            }
+          }
+        },
+        {
+          "name": "Targeted Generator",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742526797/6A85F0CB99FE4DB7DCFD7DA3EDF1E04B4D1A56DC/",
+          "points": 7,
+          "restrictions": {
+            "include": {
+              "unit": ["EWHB-12 Heavy Blaster team"]
+            }
+          }
+        }
+      ],
+      "Grenades": [
+        {
+          "name": "Cluster Grenades",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640427155/BAB17778B9558A117B7672B361169E1429B8FFBD/",
+          "points": 5,
+          "restrictions": {
+            "include": {
+              "type": ["Mandalorian Trooper"]
+            }
+          }
+        },
+        {
+          "name": "Cryoban Grenade",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747372562/020D8C7E51888C66929A5C68BC64CF2A0751AB96/",
+          "points": 10
+        },
+        {
+          "name": "Concussive Discs",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743157047/93145CADA2644E48715594A16814C0B588B09264/",
+          "points": 7,
+          "restrictions": {
+            "include": {
+              "unit": ["IG-88"]
+            }
+          }
+        }
+      ],
+      "Hardpoint": [
+        {
+          "name": "Auto Loader",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638973875/12A8A6DAC58F8AD954452CFC4B0DC38ED932407B/",
+          "points": 5,
+          "restrictions": {
+            "include": {
+              "unit": ["Missile Attack Launcher"]
+            }
+          }
+        },
+        {
+          "name": "Chain-Fed Missile Launcher",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743540463/2FDD9391217B4D3C83489ACFC70B5D4D70D828AF/",
+          "points": 8,
+          "restrictions": {
+            "include": {
+              "unit": ["Octuptarra Tri-Droid"]
+            }
+          }
+        },
+        {
+          "name": "D-93 Incinerator",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081207055/8CE886D73E5632DFB6B71F21AEE082B90DB862B2/",
+          "points": 24,
+          "restrictions": {
+            "include": {
+              "unit": ["Light Infantry Utility Vehicle"]
+            }
+          }
+        },
+        {
+          "name": "Ball Turrets",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747617309/E7A1C86302FE190A75A859B3405353D24B56AA93/",
+          "points": 20,
+          "restrictions": {
+            "include": {
+              "unit": ["LA-AT/I Gunship"]
+            }
+          }
+        },
+        {
+          "name": "Defoliator Missile Launcher",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743618077/FD3FF4AAAA791E2B578007273E93859B7FA12E6E/",
+          "points": 28,
+          "restrictions": {
+            "include": {
+              "unit": ["Defoliator Deployment Tank"]
+            }
+          }
+        },
+        {
+          "name": "Dorsal Laser Cannon",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747586054/E0CA1658DB7AB53E43598B3506A980E595D78AA8/",
+          "points": 16,
+          "restrictions": {
+            "include": {
+              "unit": ["AT-AP"]
+            }
+          }
+        },
+        {
+          "name": "Enhanced Stabilizers",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747587543/837CEB0047D91D5ADEB112F08F19C456609042D9/",
+          "points": 14,
+          "restrictions": {
+            "include": {
+              "unit": ["AT-AP"]
+            }
+          }
+        },
+        {
+          "name": "Enhanced Targeting Computer",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743649603/CC9BB61488A9EDD358521E3E62D73A316BC07F23/",
+          "points": 8,
+          "restrictions": {
+            "include": {
+              "unit": ["IG-227 Hailfire-Class Droid Tank"]
+            }
+          }
+        },
+        {
+          "name": "EWHB-12 Blaster Turret",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743064886/381FF3A3AED8050E5BDF1E3A4EC6B6DC2608B4EE/",
+          "points": 28,
+          "restrictions": {
+            "include": {
+              "unit": ["WLO-5 Battle Tank"]
+            }
+          }
+        },
+        {
+          "name": "Expanded Launch Tubes",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638975154/0F3C24800735B4BB8E0B156258FF032116C503F0/",
+          "points": 4,
+          "restrictions": {
+            "include": {
+              "unit": ["Missile Attack Launcher"]
+            }
+          }
+        },
+        {
+          "name": "Fire Direction Center",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638972654/A3E6D0BCB701B2DEFB788DA9CEB3F163F4025EEF/",
+          "points": 8,
+          "restrictions": {
+            "include": {
+              "unit": ["Missile Attack Launcher"]
+            }
+          }
+        },
+        {
+          "name": "FWMB-10 Megablaster",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081201870/567FD6D4762C52C8EA448858D8E030A5D9846683/",
+          "points": 35,
+          "restrictions": {
+            "include": {
+              "unit": ["Light Infantry Utility Vehicle"]
+            }
+          }
+        },
+        {
+          "name": "Ion Cannon",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638673967/DCE9270CEAD120F4DD068CDF23C326E2371DC75C/",
+          "points": 15,
+          "restrictions": {
+            "include": {
+              "unit": ["Droideka MKII"]
+            }
+          }
+        },
+        {
+          "name": "Magna Chain-Fed Missile Launcher",
+          "displayName": "Chain-Fed Missile Launcher",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743671604/F03AE6E7CE4E84CDA2D22BBD7B6A2BE97F45437B/",
+          "points": 20,
+          "restrictions": {
+            "include": {
+              "unit": ["Octuptarra Magna Tri-Droid"]
+            }
+          }
+        },
+        {
+          "name": "Magna Plague Carrier",
+          "displayName": "Plague Carrier",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743671273/2C55E19F1F47BABA103DCA4ECA92471CEA8D503A/",
+          "points": 5,
+          "restrictions": {
+            "include": {
+              "unit": ["Octuptarra Magna Tri-Droid"]
+            }
+          }
+        },
+        {
+          "name": "MS-1 Medium Laser Turret",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743066443/2CF2905266AA4BDE3F40F755F800CB0E0A3392A6/",
+          "points": 20,
+          "restrictions": {
+            "include": {
+              "unit": ["WLO-5 Battle Tank"]
+            }
+          }
+        },
+        {
+          "name": "Plague Carrier",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743540072/7D3F2EBDCE33584ED931379EFF49B8A3E26789C7/",
+          "points": 15,
+          "restrictions": {
+            "include": {
+              "unit": ["Octuptarra Tri-Droid"]
+            }
+          }
+        },
+        {
+          "name": "Proton Missile Launcher",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743617683/7B7D562698834D3ACEC51A5BC5BC6B148F4C55A4/",
+          "points": 20,
+          "restrictions": {
+            "include": {
+              "unit": ["Defoliator Deployment Tank"]
+            }
+          }
+        },
+        {
+          "name": "Raised Mono-Ski",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1021697620252782821/C642C07229E6BDCA7AA79F99D34328383622F962/",
+          "flip": {
+            "name": "Lowered Mono-Ski",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1021697620252782950/AE54FB7E97854E2621BC3F9EB314F432DBE1EC75/"
+          },
+          "points": 0,
+          "restrictions": {
+            "include": {
+              "unit": ["V-4X-D Ski Speeder"]
+            }
+          }
+        },
+        {
+          "name": "Rapid Fire Launchers",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743649159/0BAF4A7EC12DAC1AEB13A22120D2D3B1FA1BC0B6/",
+          "points": 14,
+          "restrictions": {
+            "include": {
+              "unit": ["IG-227 Hailfire-Class Droid Tank"]
+            }
+          }
+        },
+        {
+          "name": "Sealed Blast Shields",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747617819/F41341A8EA3FDEBA78238EC8298691A0E2C5248C/",
+          "points": 0,
+          "restrictions": {
+            "include": {
+              "unit": ["LA-AT/I Gunship"]
+            }
+          }
+        },
+        {
+          "name": "Transport Rack",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743692647/47DDE4B573774D76E0DD110994DEEF3C2F0406BB/",
+          "points": 20,
+          "restrictions": {
+            "include": {
+              "unit": ["HMP Droid Gunship"]
+            }
+          }
+        },
+        {
+          "name": "Tri Laser Cannons",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638674750/6057A2DACA2F104F889921E46FF3AC717DE4B962/",
+          "points": 25,
+          "restrictions": {
+            "include": {
+              "unit": ["Droideka MKII"]
+            }
+          }
+        },
+        {
+          "name": "Wing Ball Turrets",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747616297/2753260BCF4BD591144C4D74769F5E982D4E9D10/",
+          "points": 14,
+          "restrictions": {
+            "include": {
+              "unit": ["LA-AT/I Gunship"]
+            }
+          }
+        }
+      ],
+      "Heavy Weapon": [
+        {
+          "name": "ACP Trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735115264/1D92758AC20C28AA48019DCD564E31D271B20A2C/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068156270983/519A43ACE1F5461D51AA1BA81ADF4A5C37BEF9E4/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068156271135/318D90BCDE4E3E362797A38823A21FF17FAF651E/"
+          },
           "points": 30,
-          "speed": 2,
-          "upgrades": {
-            "Heavy Weapon": 1,
-            "Personnel": 1,
-            "Gear": 1,
-            "Grenades": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804924627970/AE0B4993C8FA598D93829CF55F0E0A6415ACBBFB/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324582151454188/1EC7453DFA3870ADCA468AD5A9257330B58CF8F4/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324582151456311/376D681EDE4D18D355A359F47C49551B6AC5EBAA/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324582151456617/9EBFAB9697DE7A1435FF501C6F39BBCC3B244BCB/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324582151464621/CEB3271C1C9E43C30C41206E919ACA9AFFB45247/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324582151464893/EF78574A7DFC9EBC7EC9FB76B27BA5F846B8F97D/"
+          "restrictions": {
+            "include": {
+              "unit": ["Mercenary Assault Squad"]
             }
-          ]
+          }
         },
         {
-          "name": "Resistance Trench Fighters",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1017194020628449858/1DC8646D5B2D0F5ABF7828732E6DE923F301DE46/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 39,
-          "speed": 2,
-          "upgrades": {
-            "Heavy Weapon": 1,
-            "Personnel": 1,
-            "Training": 1,
-            "Gear": 1,
-            "Grenades": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248440350/60BC7FB4B3F6B327003DAB9B924C5EC98FA67C4B/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248444916/D62AC2DD70775BA5025900AC76975C4AB45A54CC/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248441473/F330E21469E4FF560B9E8892E784C14373697F16/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248440578/125E76600442E01E3AD18725563EA1BE4D63BEFA/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248442051/472D72BABB02CCA9F99639F83E21A9D3AF83BB14/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248440578/125E76600442E01E3AD18725563EA1BE4D63BEFA/"
+          "name": "B1",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1021698068155818428/717521A597961079FBE4E4121DECAF4F0ED00471/",
+          "points": 16,
+          "restrictions": {
+            "include": {
+              "unit": ["Salvaged B2 Battle droids"]
             }
-          ]
-        }
-      ],
-      "Special Forces": [
-        {
-          "name": "Salvaged B2 Battle droids",
-          "title": "Defenders of the Colossus",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1021698068155819425/F5A156E66B986DA76D65B649D689496C6A4BB79A/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 64,
-          "speed": 2,
-          "upgrades": {
-            "Heavy Weapon": 1,
-            "Comms": 1
           },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/775105953849586118/94F967F21EA7E390A200C4BDA5581D07DBB37AC2/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/775105953849585789/91A639AB9F57BE393683DA53212E395886307C52/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/775105953849586430/E5941CF7A3631E6D4A28832AE489A4340C96B0B9/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/775105953849585789/91A639AB9F57BE393683DA53212E395886307C52/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/775105953849586226/9326AD8D3EC80CC53F4BF2D156014978DCD715D9/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/775105953849585789/91A639AB9F57BE393683DA53212E395886307C52/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/775105953849586324/B5D59E535AFA2BF99FCA3C584E28FA500ADB89BD/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/775105953849585789/91A639AB9F57BE393683DA53212E395886307C52/"
-            }
-          ]
-        }
-      ],
-      "Support": [
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/785234780869166347/AA861F86A0B74CF335533E425A6CBACB99395A09/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/785234780869166529/263C2AB95B1743539EC2CBDE40B0A14B1F5E5693/"
+          }
+        },
         {
-          "name": "Orbak Riders",
-          "heavyWeaponTeam": true,
-          "image": "http://cloud-3.steamusercontent.com/ugc/1022821770986742661/33B78DBDC2B4A466B810D5299DB14745FAFB1E68/",
-          "size": "medium",
-          "type": "Creature Trooper",
+          "name": "BD-1 Vibroaxe Guard",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741407943/466AB5745404A77F5156D5AF55160CCB52545A50/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407431287477/62E1591E99BD747C7C130C3D4B5F70CA6FFA34B2/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407431272263/BBD5D7D12BC2B61E0C88AA50721BDD40AF766FF7/"
+          },
+          "points": 25,
+          "restrictions": {
+            "include": {
+              "unit": ["Gamorrean Gaurds"]
+            }
+          }
+        },
+        {
+          "name": "Beam Blaster Elite",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746958937/58D737AAB1676A6450C545CEE6299DBC19AF6E59/",
+          "points": 38,
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318091926/A474DAED7A90C67374FC60462D9A34FA7A29261F/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893318085783/83580E45A97E753127E6E4D5E221E5227B35E6A4/"
+          },
+          "restrictions": {
+            "include": {
+              "unit": ["Geonosian Warriors"]
+            }
+          }
+        },
+        {
+          "name": "Blaster Lance Droid",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742382205/FD43E6FF2AEF649B5A4A59B02630F602BEAE2C42/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407432789217/7FA6CC4082ED2BA4F96DB4A6A32DC268B55A924A/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432781824/644CE23A0B74C79BF20698A408FCF00D319EA7BE/"
+          },
+          "points": 30,
+          "restrictions": {
+            "include": {
+              "unit": ["IG-86 Sentinel Droids"]
+            }
+          }
+        },
+        {
+          "name": "Boarding Shotgun Trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277786673/D0232B6BBE5FA4816C85DF20383B0892B8151979/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692419888092880/788628E64550196C6371C2B129FEB590CC2691DE/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
+          },
+          "points": 24,
+          "restrictions": {
+            "include": {
+              "unit": ["Sith Empire Boarding Troopers"]
+            }
+          }
+        },
+        {
+          "name": "Commander Pyre",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081379697/2F3B002E5BB2D13118DF5330C9BE7BA27B84D749/",
+          "points": 30,
+          "leader": true,
+          "restrictions": {
+            "include": {
+              "faction": ["First Order"],
+              "rank": ["Corps"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027325137553590946/9E9D1E1798483BDDE43862B03D2424FB7B68EBB0/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027325137553591247/46CE15787E0615D89B2D6931B1BCDE53F1D2B954/"
+          }
+        },
+        {
+          "name": "Concussion Rifle Trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735114688/7F06A4AA27BBEFE8D08FF392CB8E7E8FC4083F6B/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068156271785/233649FA9B56D451B97E71E706C777AD529B0810/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068156271944/671F0E7483F7DA3D92D551E5042698EE06E510EB/"
+          },
+          "points": 30,
+          "restrictions": {
+            "include": {
+              "unit": ["Mercenary Assault Squad"]
+            }
+          }
+        },
+        {
+          "name": "Cycler Rifle Sniper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638840781/F5E96AC72E6D27DDA4AAC1467261D01B33AAD476/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068156464799/C000C8B3CF81A11687F6B39574ACE73A8FEF1A28/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068156464974/774C639F2300D7816E654D8276585556DEAD6432/"
+          },
+          "points": 30,
+          "restrictions": {
+            "include": {
+              "unit": ["Infiltrators"]
+            }
+          }
+        },
+        {
+          "name": "CY-M Carbine Geonosian",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746958335/3F471B7803B243D2ED9C1A3E69C86655874E3AAE/",
+          "points": 25,
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318084126/7B0D406E30E73FC005FA1AB1258738A91908E9D0/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893318095905/A0476F5F976ACE1C0BCE6F1D5C12085DBF6628B7/"
+          },
+          "restrictions": {
+            "include": {
+              "unit": ["Geonosian Warriors"]
+            }
+          }
+        },
+        {
+          "name": "DC-15 Paratrooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747551847/74C7612A3CD055BEF6F7ED101DCC13AC2EF96D2F/",
+          "points": 34,
+          "restrictions": {
+            "include": {
+              "unit": ["Clone Paratroopers"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693290506984196/E1DADD867AD088A500B4D44B6966A1BDA6F1A62A/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
+          }
+        },
+        {
+          "name": "Death Watch Duelist",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736282375/F5A9EF30A976727C91F3C880E7B603D827086B6F/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357841451/50164A1C84E6D119BC45BDD31C8209ED7D9A0F29/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515357841757/1DC29C81D9DFCB2FB7D8A3B2EA2F2ABD3F416396/"
+          },
+          "points": 25,
+          "restrictions": {
+            "include": {
+              "unit": ["Death Watch Fireteam"]
+            }
+          }
+        },
+        {
+          "name": "Death Watch Fireteam Trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736282915/B810832E8ACDF94B56D90DE60C159FE0A5FF77D2/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357844380/B08FE1606E634293EBE16FFD9541B5F7C801E2CF/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886427771/60D6CA1D97D822A2222E4FAF614931265B7B0AF2/"
+          },
+          "points": 18,
+          "restrictions": {
+            "include": {
+              "unit": ["Death Watch Fireteam"]
+            }
+          }
+        },
+        {
+          "name": "Death Watch Marksman",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736284088/EF0FB8D721EE6297963990219E9FC01B1A0AB940/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886436522/D0CBBE1EB66E7A3FEECA1A6DF0FEF6F352287404/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886436834/E27641C0A96264724D710A4B3F912F543CF9413E/"
+          },
+          "points": 34,
+          "restrictions": {
+            "include": {
+              "unit": ["Death Watch Fireteam"]
+            }
+          }
+        },
+        {
+          "name": "Detonite Charge Saboteur",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638839094/D0D81BD4107CD9647D5C041676865BAA1CFF027D/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068156470652/C2D7BF3AADDECA01B8C5442DF6419D2F1FF2389B/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068156470835/5E87EEBFF97975FF1A8985808C26B645EC53CAAC/"
+          },
+          "points": 28,
+          "restrictions": {
+            "include": {
+              "unit": ["Infiltrators"]
+            }
+          },
+          "additionalObjects": ["Proton Charge Token"]
+        },
+        {
+          "name": "Disruptor Rifle Trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277743519/060D5A5B2B512DF5E41BD6923EF07C064EEC1E7C/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608881149656/B3DDF1010726FDC59F24ACC4375251D7919F6135/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608881150442/1B5AD6129AC8D180D97CFE93ACE1DC7E49119F04/"
+          },
+          "points": 22,
+          "restrictions": {
+            "include": {
+              "unit": ["Sith Empire Troopers"]
+            }
+          }
+        },
+        {
+          "name": "DLA-13 Trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277745430/15ED754DCBAE03022CE8D08671C057280FE90B7F/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608879755028/53718ACF3D389983D1CF2630D761DF90121CDA5A/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608879744395/158047D5CFC30AFE6A2A50F64A2DA8F7BD4073B4/"
+          },
+          "points": 20,
+          "restrictions": {
+            "include": {
+              "unit": ["Sith Empire Troopers"]
+            }
+          }
+        },
+        {
+          "name": "EL-16HFE Fighter",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1021697756245234129/D1D2CFCCD4C29B15FEBC3BB12EE0E66292729C1F/",
+          "points": 25,
+          "restrictions": {
+            "include": {
+              "unit": ["Resistance Trench Fighters"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248448323/8992031636B30867375FF6724079096F6F95F5B0/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248448499/974E02AC778A5EFD4EF7F33F393B06B71ADF20A6/"
+          }
+        },
+        {
+          "name": "Electro-chain Whip Guard",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081435049/EE1C47B91E05240A23E58D4E5A905843DC1AECD6/",
+          "points": 30,
+          "restrictions": {
+            "include": {
+              "unit": ["Elite Praetorian Guards"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817957003764515/0FDC98B926F47CE64FE6407AACBCD29E5F1A8C78/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817957003763776/D3F6005987B0D827683E0B7EB3E482E8D5213424/"
+          }
+        },
+        {
+          "name": "F-11ABA Sith Trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081229621/9B54F3E6AD5E11523D82D0152FE273FA459E7FDD/",
+          "points": 28,
+          "restrictions": {
+            "include": {
+              "unit": ["Jet Troopers"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698013227868656/38A393B4932FF16ABF01AAB99C280BA4C224FE25/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698013227868793/0A4C85E66B3E68C4DDCF3D191D1E9E8B809C0727/"
+          }
+        },
+        {
+          "name": "F-11D Assault Cannon Trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277928461/7263E2C1EF01981353B16786CB01441C92A7D941/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824477681555675/1E4C571546078FEFFD4E753CBBC08EF18CBD0342/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824477681548557/DB63AB0044B89CB25D50A204A061D535CA20F495/"
+          },
+          "points": 30,
+          "restrictions": {
+            "include": {
+              "unit": ["Sith Empire Support Troopers"]
+            }
+          }
+        },
+        {
+          "name": "FN-2199",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081374822/8CF5DD30B49BCDA674B5A2E7343C421C7D367A1E/",
+          "points": 28,
+          "restrictions": {
+            "include": {
+              "unit": ["First Order Stormtroopers"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821972716827731/5B0D97A839084D07EA0B8A1F6C925732D300D681/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821972716828171/0331B4B577F867C2D647DDC63E4F201D400D679E/"
+          }
+        },
+        {
+          "name": "FWMB-10K Heavy Trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081336883/0386F13822F48C2CE6086861FAF8FA18C862645C/",
+          "points": 24,
+          "restrictions": {
+            "include": {
+              "unit": ["First Order Stormtroopers"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804930752354/251CAAD6FBAED5982A2DE07F97E73DAC15AA9B0F/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804930752683/A8A5605318AA4D5D0E86706390784598DFE8E1D9/"
+          }
+        },
+        {
+          "name": "First Order Executioner",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081370859/0CC06F999D1152E6D2591DC70C58F75D70310DAC/",
+          "points": 24,
+          "restrictions": {
+            "include": {
+              "unit": ["First Order Stormtroopers"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804931312746/A2A7E0ED462A3CC61067CD54DD75FE3EDB6FBB96/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804931312990/768DB3CC7A9A7C481E90874F6D0EBA7B76830145/"
+          }
+        },
+        {
+          "name": "First Order Flametrooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081363087/EACBFEE7B2FAB08DAA79F044AA8933BB6B2C7000/",
+          "points": 22,
+          "restrictions": {
+            "include": {
+              "unit": ["First Order Stormtroopers"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804930743225/47AC918E4F8214D21DFA7F41A1BFDC7DDC03AEC0/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804930743458/9AE62864563BECCC50045802E4B9F010B9C34098/"
+          }
+        },
+        {
+          "name": "G125 Projectile Trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081230342/5DB2636553D599B55D5642F3235445BC77C6BFEA/",
+          "points": 34,
+          "restrictions": {
+            "include": {
+              "unit": ["Jet Troopers"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698013227867905/C5D8EACB94ED7499B8B9396A430BE3E3B0074D3D/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698013227868129/0C5AB5D1F2332F71B7DFCD4F74272056F8D4A82A/"
+          }
+        },
+        {
+          "name": "Gi/9 Cannon Hired Gun",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742003564/A822E18141D6C082B017F73378B458F77F1685EF/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138166568/ED8EA2877D68277418CD413C22E7298490A0E88A/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138166740/961EBEFD298B956494AD8C52FAE4089A66129240/"
+          },
+          "points": 22,
+          "restrictions": {
+            "include": {
+              "unit": ["Hired Guns"]
+            }
+          }
+        },
+        {
+          "name": "Heavy Blaster Cannon Gunner",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736281792/283829A6193016BD5AF9264D1E90D59D07D7125A/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357847983/815BAE46D59A5AE4EE98449FF47A9F4E1F5FF4F7/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515357848221/4A5E3289B5C619501C33A169426DCEEE5F31C670/"
+          },
+          "points": 34,
+          "restrictions": {
+            "include": {
+              "unit": ["Death Watch Fireteam"]
+            }
+          }
+        },
+        {
+          "name": "Hutt Cartel lieutenant",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741194306/575F31C4867CAD2378D7FC8C57B97BE1BC7168C2/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132349796/F0D00662C6C5F6DC99EA86808B428D1A13E5F062/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132349987/DE29CB1DE563DCFE69E72C45F89F7BA994DA9599/"
+          },
+          "leader": true,
+          "points": 26,
+          "restrictions": {
+            "include": {
+              "unit": ["Hutt Cartel Troopers"]
+            }
+          }
+        },
+        {
+          "name": "Hyperstorm Heavy Cannon Gunner",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277928814/8CB3DD46BE7B2AFC9558DF5180F6FD6DAB46EFAE/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824477681557142/6A6BB38909200F986FCC00C6ED6D09B055D780BE/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824477681557325/B9CACA9DF2EB9B7AAC473686F3E8597B000E1387/"
+          },
+          "points": 32,
+          "restrictions": {
+            "include": {
+              "unit": ["Sith Empire Support Troopers"]
+            }
+          }
+        },
+        {
+          "name": "IQA-11 Sniper Droid",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742382638/9E6E5FD638CB2D2304CD6621F66CA7E1529785FC/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407432785196/AFC423350DB19E06E25D2B7B67DF95CA3323FBEF/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432781824/644CE23A0B74C79BF20698A408FCF00D319EA7BE/"
+          },
+          "points": 32,
+          "restrictions": {
+            "include": {
+              "unit": ["IG-86 Sentinel Droids"]
+            }
+          }
+        },
+        {
+          "name": "Jannah",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1022821770986743715/2D901A3B93E61AA15B16922B7C314BFE18FE079B/",
+          "points": 65,
+          "restrictions": {
+            "include": {
+              "unit": ["Orbak Riders"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770976479474/71199B4B530A5D511E21B37E7AAE4D28AEF8F799/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770976479691/41E9EEF26B5B57FE44F5ED0C4B2912F09827F465/"
+          }
+        },
+        {
+          "name": "Kronos-327",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742383051/E35635E0213C5BF6D3DECFF3DEBAEB53385737AE/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407432807943/6854E55A0F61C5DE97189B6CAC90202E6BC1F622/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432805568/E1F93A35700D25A3C33BA87AD4D64514795D6FDE/"
+          },
+          "leader": true,
+          "points": 34,
+          "restrictions": {
+            "include": {
+              "unit": ["IG-86 Sentinel Droids"]
+            }
+          }
+        },
+        {
+          "name": "M-45 Ion Fighter",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1017194020628455620/5C9E4D9872161408669629A2BD9455804F3BFBB7/",
+          "points": 27,
+          "restrictions": {
+            "include": {
+              "unit": ["Resistance Trench Fighters"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248443153/7D7FF98B537193A399A5974FF7CA73941E6D80AD/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248443360/6BD1A35DC4787C5086210BA1A0436B983B39B4CE/"
+          }
+        },
+        {
+          "name": "Mantellan Frontline Cannon Trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277928133/6CF94D4B6DA81B997D2E3BC9438CB8254F39BC0D/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824477681558249/5B7DA9706523B65997C0F39E0E3BCF6FA82F7628/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824477681547387/758CB297CD1211353CBBC992035532A98F53893E/"
+          },
+          "points": 30,
+          "restrictions": {
+            "include": {
+              "unit": ["Sith Empire Support Troopers"]
+            }
+          }
+        },
+        {
+          "name": "Mercenary Assault Trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735114176/44B42375B5C11B5BADA3029FC1BF45BBCE56575C/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365878231/A04BECDA5804E0A38FF974528C70AB5AAAE4B715/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365878394/8AD2A611C51D78184D8E4204A720C59EEC2C7755/"
+          },
+          "points": 18,
+          "restrictions": {
+            "include": {
+              "unit": ["Mercenary Assault Squad"]
+            }
+          }
+        },
+        {
+          "name": "Modified E-5C Trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741194755/20A0EFE3551FB3F616037ECA2A6B085B32437E09/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132330046/E57A960285EF5FF9C8519B41BAF73C3AFE2E9910/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132330505/2C66A444F87C08CCD808F9EC32307C893552204A/"
+          },
+          "points": 24,
+          "restrictions": {
+            "include": {
+              "unit": ["Hutt Cartel Troopers"]
+            }
+          }
+        },
+        {
+          "name": "MPL-57 Ion Stormtrooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081352987/219CD748E9D94C081BC63179004FEAF74A821088/",
+          "points": 24,
+          "restrictions": {
+            "include": {
+              "unit": ["First Order Stormtroopers"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804930745597/D46A49EBCC75A7E442CE5B9B393880CAA55411EC/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804930745893/C3D0240348A1F44EB8D086D4AC626DCCFA1DB209/"
+          }
+        },
+        {
+          "name": "Orback Rider",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1022821770986745583/D188E40D6063DA1246C0DD94216E458C45B6FDE6/",
           "points": 45,
-          "speed": 2,
-          "upgrades": {
-            "Heavy Weapon": 1,
-            "Comms": 1,
-            "Gear": 2
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770976478153/4E00BD588837F87DDA2828DC092CEEE3BEDCC7A3/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770976472996/354C4EE85A60585BD0FB817AFEE21D00E93799BA/"
+          "restrictions": {
+            "include": {
+              "unit": ["Orbak Riders"]
             }
-          ]
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770976472837/B6A4F9FAEAF8F6DC50A4EB8CE30D1D9D62CE1477/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770976472996/354C4EE85A60585BD0FB817AFEE21D00E93799BA/"
+          }
+        },
+        {
+          "name": "Ordnance launcher trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742001131/D2429556F4177E933131B739E7E038AA5546B250/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138167432/E485629FA5F7F44891F3DE6ECF6C0F8726AD1AE3/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138184470/30F29A14D05E0FF6A5153C51E7DFC770706D0119/"
+          },
+          "points": 27,
+          "restrictions": {
+            "include": {
+              "unit": ["Hired Guns"]
+            }
+          }
+        },
+        {
+          "name": "Proton Charge Commando",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277967164/198C348A7F75677615C77AC57C0229F6B0934D03/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024261154211/0A0578275AD73052B08D31C272B3AD066484EFEB/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260988667/8B8E27DFEDD6DEBA4EFABD6E738D3B6AC3E925AB/"
+          },
+          "points": 30,
+          "restrictions": {
+            "include": {
+              "unit": ["Sith Empire Boarding Troopers", "Imperial Commandos"]
+            }
+          },
+          "additionalObjects": ["Proton Charge Token"]
         },
         {
           "name": "Rose Tico",
-          "title": "Skilled Technician",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1021697620253184171/055BD7F8C30E5D043104316A572B1846227F6DC5/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 50,
-          "speed": 2,
-          "upgrades": {
-            "Comms": 1,
-            "Gear": 2,
-            "Counterpart": 1
+          "image": "http://cloud-3.steamusercontent.com/ugc/1021697620252778506/96583F29F6DDE41276C77D92C892C2DE8965A086/",
+          "leader": true,
+          "points": 28,
+          "restrictions": {
+            "include": {
+              "faction": ["Resistance"],
+              "rank": ["Corps"]
+            }
           },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697601906861807/C7CB31D9AFAFF6C7B2633663A2A33D939F4E8205/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697601906862116/99E8BDA93C81AD3875DFC214AA5E39DC4F5477A5/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "Saving What We Love",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1021697620253191671/458068FD2D398FA6C7540EEFF383BD8E39509350/",
-              "pip": 3
-            }
-          ]
-        }
-      ],
-      "Heavy": [
-        {
-          "name": "V-4X-D Ski Speeder",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1021697620252781965/A29532E1391479BD4424DEE3CD7130CC5927AB08/",
-          "size": "epic",
-          "type": "Repulsor Vehicle",
-          "points": 140,
-          "speed": 3,
-          "upgrades": {
-            "Pilot": 1,
-            "Hardpoint": 1,
-            "Comms": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804931072163/80F5B756EF0C02455B5C31CD1A608DD51B9108BD/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804925084213/855D3C37D204F44B1840665B50CCCB73A7CD62D2/"
-            }
-          ]
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697601906861807/C7CB31D9AFAFF6C7B2633663A2A33D939F4E8205/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697601906862116/99E8BDA93C81AD3875DFC214AA5E39DC4F5477A5/"
+          }
         },
         {
-          "name": "V-232 Turret",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157670378/DB2D6E46CD982AE3C38EA63F93939CDC2EECA984/",
-          "size": "huge",
-          "type": "Ground Vehicle",
-          "points": 100,
-          "speed": 0,
-          "upgrades": {
-            "Comms": 1,
-            "Generator": 1
+          "name": "RSP-6 Paratrooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747551248/7EB35E562D1685283C46BCC74678C8B0573F68FE/",
+          "points": 29,
+          "restrictions": {
+            "include": {
+              "unit": ["Clone Paratroopers"]
+            }
           },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068157631207/B54652720E993614D7AD481BD4A1B8236561DCAA/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756247150301/5C9F0E6F01394012B925C60CC4D8548E66B05427/"
-            }
-          ]
-        }
-      ]
-    },
-    "Revans Sith Empire": {
-      "Commander": [
-        {
-          "name": "Darth Revan",
-          "title": "Fallen Lord",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281811934/A5A06CC61DE1B518F307931E848ED0F2F84DBE3C/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 220,
-          "speed": 2,
-          "upgrades": {
-            "Force": 3
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933832570/34E443C62233F9BFAB5A1A56848C92AF12D16DB0/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933823285/EE9DA185779FAC54191A9DC0353E57D542CF6EE9/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "Slayer of Mandalore",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281812320/441136636E20A3C920D22041163506AC74BD9E34/",
-              "pip": 1
-            },
-            {
-              "name": "I am the Dark Lord of the Sith",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281812673/A864BC3FB16C88EF914102FA82EBE360D05B7016/",
-              "pip": 2
-            },
-            {
-              "name": "The Fallen Lords",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281813019/D00A57B0F11280E97F8A27269F9F39A031001D38/",
-              "pip": 3
-            }
-          ]
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693415425547360/64A0DE5FC04770CADAEFA3F202A83EF0ACA1AABB/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
+          }
         },
         {
-          "name": "Darth Malak",
-          "title": "Treacherous Apprentice",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281873194/CE73E7B8BE4C4C155231F3BBEE4F857395F1C174/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 195,
-          "speed": 2,
-          "upgrades": {
-            "Force": 2
+          "name": "Salvaged T-21 Rider",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1022821770986744919/D39D941758BD3209F2D9F72B075DE5752FC2AD80/",
+          "points": 55,
+          "restrictions": {
+            "include": {
+              "unit": ["Orbak Riders"]
+            }
           },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933880695/1D163F620C1BF4639F889CE39C1DCB6E8ED159E9/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933876696/ED5A556257FEA5E3EA9AD18215604CB599E132C2/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "This is but a Taste of the Dark Side",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281873643/108B3E63FB5AAE3E70915C74CB0CEADB660F1899/",
-              "pip": 1
-            },
-            {
-              "name": "You Will Forever Stand Alone",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281874073/CC8FEB5E5D0934D8C0FA1A3E8752A656D6EE849E/",
-              "pip": 2
-            },
-            {
-              "name": "Wipe this planet from the face of the galaxy",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281874384/99D8B33D2B2422AFD4D24953C07B352DD585F493/",
-              "pip": 3
-            }
-          ]
-        }
-      ],
-      "Corps": [
-        {
-          "name": "Sith Troopers",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281907874/694CCAFD2FB6C6ADA01DAB52DCEFB6CE4DBAB1D0/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 44,
-          "speed": 2,
-          "upgrades": {
-            "Heavy Weapon": 1,
-            "Personnel": 1,
-            "Gear": 1,
-            "Grenades": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933591216/236BEBCCFA8E4701879F66DE28E7E61EB71696DA/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933675175/1561AB6D3E5FCD7952FC0B2A76BEF1B14D75D00D/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933538068/07579EBF0F9C9A7BD0DBC30EFE30BEEF1FB31D33/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933630508/AF5621F9AAF5556EADD9373D4C8F7DE5C3A6D95D/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
-            }
-          ]
-        }
-      ]
-    },
-    "Scum": {
-      "Commander": [
-        {
-          "name": "Tyber Zann",
-          "title": "Cold, Methodical, and Ruthless",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735070640/74612E44D0AF4F505937EE2E0DAF21C08EB4E15B/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 140,
-          "speed": 2,
-          "upgrades": {
-            "Command": 1,
-            "Training": 1,
-            "Illicit": 1,
-            "Gear": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365775807/337D2A5009DD4A91F0A469B418D4C77867FDF52D/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365776115/8606DE28865E723D2343D17F890A99959E25AC8F/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "Orbital Bombardment",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735071380/B7CEA3F14638418D63BEFF3F7A611F5078D31667/",
-              "pip": 1
-            },
-            {
-              "name": "Corruption is My Weapon",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735071871/7524B10AD4DB25DAA1E5F5F0275A58DE9C3EC666/",
-              "pip": 2
-            },
-            {
-              "name": "Everyone Has a Price",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735072378/3A407CC85B615E03763D5F22E7116CA3FB217F0B/",
-              "pip": 3
-            }
-          ]
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770976478775/74F36986A6C7597A92FB07CBD80D29430F2ADC0C/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770976478988/8EA7C3063101B4163C223C1AA9D3FFD5196EED24/"
+          }
         },
         {
-          "name": "Urai Fen",
-          "title": "Loyal Lieutenant",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735039360/1B0C02842ADDAA687687E529BE8B33983CAD933F/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 90,
-          "speed": 2,
-          "upgrades": {
-            "Training": 2,
-            "Illicit": 1,
-            "Gear": 1
+          "name": "Sith Rifleman",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281908934/40B735C56C1C6EFF536F72A96FCB2E86EBA4D7B5/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933721582/A454C20F4D869C5BDCBB07E7DF297D3A97C518F1/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
           },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984835649865/8FC3F2E4E22555D72BDF283AD0E686537F33A043/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984835650100/057E08B03AAE7CA89B585D8916BB25023B63341A/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "Strike and Fade",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735040340/32D15FA78098AB05AD6D98B51631935EC6DEC3C3/",
-              "pip": 1
-            },
-            {
-              "name": "The Consortium Commands It",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735041426/F309B5F10C9F44B3E9FE50A42FAD541185DEE9A5/",
-              "pip": 2
-            },
-            {
-              "name": "No Mission is too Dangerous",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735047596/1516182BE8ED3D0635F56F830C4FB85F869C477C/",
-              "pip": 3
-            }
-          ]
-        },
-        {
-          "name": "Defiler",
-          "title": "Under Cover Agent",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735208736/794BBDD282201AA4D82C0B728D90073E6CAF423C/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 90,
-          "speed": 2,
-          "upgrades": {
-            "Training": 1,
-            "Gear": 1,
-            "Armament": 1,
-            "Illicit": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515362210843/CDD5E72C8CE5B42739060E6ADC81DC64751294F0/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515362211007/246011C13B53F2A881968B8996802F50B33D075F/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "I Like Explosions",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735209433/1B7DC25C849E9B7D2657E40E71FF198B8588381F/",
-              "pip": 1
-            },
-            {
-              "name": "Nothing Stops Me",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735210006/8EAEC185C0C43B5D6099ED763E9B3D4FC5C493A5/",
-              "pip": 2
-            },
-            {
-              "name": "I Stand In the Shadows",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735210753/1BF727CB55BFAB8151A9F9A368C91C6B76248636/",
-              "pip": 3
-            }
-          ]
-        },
-        {
-          "name": "Pre Vizsla",
-          "title": "Defender of Tradition",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640671157/50ED9FE9885FBF3530E3BF5D7E2ECA85E331972F/",
-          "size": "small",
-          "type": "Mandalorian Trooper",
-          "points": 165,
-          "speed": 3,
-          "upgrades": {
-            "Command": 1,
-            "Training": 2,
-            "Illicit": 1,
-            "Gear": 1,
-            "Armament": 2
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886396178/07FB37CA0A11552BEF96C3DCA10AF232C65AF7B6/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886396372/35E5047903DC30F882B40719809ECF90DBC65A5A/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "Blade Launcher",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640671650/36CC81AF419D113B28FC5AB7CF6B3210085DFB45/",
-              "pip": 1
-            },
-            {
-              "name": "Warlord of Mandalore",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640672041/2F91858F91AB3648DDEF429A5C1C584D129634C1/",
-              "pip": 2
-            },
-            {
-              "name": "Rise of the Death Watch",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640672498/BED2FE1183721CCB1A1B623A6C4DED69383DA739/",
-              "pip": 3
-            }
-          ]
-        },
-        {
-          "name": "Jabba The Hutt",
-          "title": "Vile Gangster",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741311873/1C5E99B44B0F2BAB89FF0F00315D88DCAC991BBE/",
-          "size": "large",
-          "type": "Trooper",
-          "points": 180,
-          "speed": 1,
-          "upgrades": {
-            "Command": 2,
-            "Counterpart": 1,
-            "Illicit": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984838965716/328A3D3A0AFDA83FC55E8DDCAF62845FFF80CF64/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984838965864/2C27448D99B31E0730B60E10427A6009A6AEF1C7/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "Appetite for Violence",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741312832/9DD7CEC7F0A4BBEC81E368726BA5A07E4F81AD9D/",
-              "pip": 1
-            },
-            {
-              "name": "Sinister Belly Laugh",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741313391/27122DF6EB3315976464D7B481537EE5E1E58D94/",
-              "pip": 2
-            },
-            {
-              "name": "Big Shot Gangster",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741313883/86E8818123FD0C01DA7890E271BE897212D4733D/",
-              "pip": 3
-            }
-          ]
-        },
-        {
-          "name": "Hondo Ohnaka",
-          "title": "Self-Serving Pirate",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738473397/8A62072BB1AFA3D4BF14CC3BA56EB1C2F1614F46/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 90,
-          "speed": 2,
-          "upgrades": {
-            "Command": 1,
-            "Illicit": 3,
-            "Armament": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697601906780896/650CF3405CD4106C46B9CB7F0B8C3884B62CD278/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697601906781011/E61558EE4DCDF12D33E98940751D940381181C93/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "No Longer Profitable!",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738477182/571BC50F3C1ABB05DAF75F3BE004DCEBD4C27DD7/",
-              "pip": 1
-            },
-            {
-              "name": "Drive a Big Tank",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738476702/E723D8E97412E2B9E422741F4E2225D5B8A146C8/",
-              "pip": 2
-            },
-            {
-              "name": "Insolence! We are Pirates!",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738475852/69D3EE2DF1CDA15E4BDC49F143CE2DD621B8553F/",
-              "pip": 3
-            }
-          ]
-        }
-      ],
-      "Operative": [
-        {
-          "name": "Silri",
-          "title": "Dark Witch",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735151492/82278C71E894B0710E02376909241ECAAD41F8C7/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 150,
-          "speed": 2,
-          "upgrades": {
-            "Force": 1,
-            "Training": 2,
-            "Illicit": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984835654759/B33E7C3B1D34E7DDAC7B617DC466F12FF66774E1/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984835654931/3ACEDEC6F99A311A245C7492883DAB9720D05348/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "I Shall Rip Out Their Souls",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735165967/E52C14F2A96A0DDA785B12C9400F47E9E5E2F4A7/",
-              "pip": 1
-            },
-            {
-              "name": "Come Closer",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735165400/6E97DF5AC3BF3172E316DD409240AA04BD4C6DE4/",
-              "pip": 2
-            },
-            {
-              "name": "They Will Know Fear",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735164916/B6CDD990B416AE4B7897AB3A27E35ACD4A46DE07/",
-              "pip": 3
-            }
-          ]
-        },
-        {
-          "name": "Bo-Katan Kryze",
-          "title": "Death Watch Lieutenant",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640560685/8771A2D7895F003917A4CD9D170E7D5FBAA81D65/",
-          "size": "small",
-          "type": "Mandalorian Trooper",
-          "points": 120,
-          "speed": 3,
-          "upgrades": {
-            "Training": 2,
-            "Gear": 1,
-            "Armament": 2
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886421665/441B37D17213CA1B82174A8988ED23AA2D59336E/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886421832/BBE3592A7496E444E116271913178A8ED41F5323/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "Poison Dart",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640561281/E6C9BE0EB9F4357B31FB1459E8615D85BBE6F660/",
-              "pip": 1
-            },
-            {
-              "name": "Fierce and Deadly",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640561707/6E91E487B7F9AD4225A336081B4AB58F4AAB3CD2/",
-              "pip": 2
-            },
-            {
-              "name": "Memorable and Funny Quote",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640562097/E3FFDCB0E1AC2EB8E690C90C0599AA093788759C/",
-              "pip": 3
-            }
-          ]
-        },
-        {
-          "name": "Dengar",
-          "title": "Payback",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743206950/10A169A5029EDFC4ACA82E73B8BA7D4777BB499D/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 105,
-          "speed": 2,
-          "upgrades": {
-            "Training": 1,
-            "Illicit": 1,
-            "Gear": 2
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982050300/7F58F09A4EBE2B1D4036CA35ECD771FAC087027F/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982050497/14DBD099731E973681F538C811E89F52971C6258/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "Ello Darlin",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743207736/AC879456E5C89349EDE04DC810B7437A49F9017B/",
-              "pip": 1
-            },
-            {
-              "name": "Thats Not a Knife",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743208077/F604A72BAD8ADED41170B6134687C8792E272C0B/",
-              "pip": 2
-            },
-            {
-              "name": "Credits are Calling my Name",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743208459/015271D4636D4659598040A7A33AABA2A7373863/",
-              "pip": 3
-            }
-          ]
-        },
-        {
-          "name": "Greedo",
-          "title": "Mercenary of Misfortune",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741745161/DE21A067535ADD00F083F96CE00AEF706CDBC1B3/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 60,
-          "speed": 2,
-          "upgrades": {
-            "Training": 2,
-            "Gear": 1,
-            "Grenades": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697128192156760/0799D47F8ABA442104B92441C2EE558246DD447B/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697128192156907/44D809B717035663BCC53BBF8B6C34E47F27D953/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "Maclunky!",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741745870/4D9A87A50635EFDD25A2E01B381D20FC3B23D0E7/",
-              "pip": 1
-            },
-            {
-              "name": "Oonta Goota?",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741746363/52B7999E4C27DFA029632DF034C633BD94B6ECE3/",
-              "pip": 2
-            },
-            {
-              "name": "E Chu Ta",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741747117/E0DD4D0E9489424A42EF020B57AFCB2E34CC3935/",
-              "pip": 3
-            }
-          ],
-          "required": ["I'll Bet You Have"]
-        },
-        {
-          "name": "IG-88",
-          "title": "Calculating Assassin",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743156483/4AB94765581EEA7C01F1C931649279C0820A18D6/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 130,
-          "speed": 1,
-          "upgrades": {
-            "Training": 1,
-            "Illicit": 1,
-            "Gear": 2,
-            "Grenades": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982048942/6855349E653C6F4E0433AF56E1554F75F307CBF3/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982049139/F1EB5D96934D784828CAD32E88CFD581446B6041/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "Toxic Dioxis Despenser",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743157480/AC5FF98814A9D017737A5C5FEDE3FD7E401A7D4D/",
-              "pip": 1
-            },
-            {
-              "name": "Defensive Programming",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743157867/DBE4FB014B259FD7B2E4C6774D766C557735F320/",
-              "pip": 2
-            },
-            {
-              "name": "I Destroy, Therefore I Endure",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743158259/1693B7E0EECA04393914E8566B892A1E0052039F/",
-              "pip": 3
-            }
-          ]
-        }
-      ],
-      "Corps": [
-        {
-          "name": "Grenadier Squad",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735128053/8071373F43B26B004A85BB1423AE10D8BA9FA2D9/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 33,
-          "speed": 2,
-          "upgrades": {
-            "Personnel": 1,
-            "Illicit": 1,
-            "Comms": 1,
-            "Gear": 1,
-            "Grenades": 2
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365822891/9245AC0020E31C369AE4129B35D0BA467A01F2B4/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365823446/E94BC334A0B2F95CFB75FEDC3A0FEDF2FFD5A970/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365824294/5F43B720E0198A078E25BA472E7DDBCA8F51CBEC/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365824481/27693FC709ADF50440623C6347A11151608D5E2F/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365824294/5F43B720E0198A078E25BA472E7DDBCA8F51CBEC/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365824481/27693FC709ADF50440623C6347A11151608D5E2F/"
-            }
-          ]
-        },
-        {
-          "name": "Hutt Cartel Troopers",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741193364/B2A9024FE737F3E6CAC757C062FAE63B180020F4/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 40,
-          "speed": 2,
-          "upgrades": {
-            "Heavy Weapon": 1,
-            "Personnel": 1,
-            "Illicit": 1,
-            "Grenades": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132327065/C97ECB0137975A84387D1450B76E656DD3A34CC6/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132327244/97AF50B5FA4E76262E8F7A6BBCBF465FD8D13210/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132328895/00FFC141D583FDE6EB27DCEF374C6EA79E4BC8DC/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132233662/46758BE4190670991AEEB84884D2C0926704577E/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132328408/9323E551FA703709CF34056F60EB7B9808DBBC6F/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132233662/46758BE4190670991AEEB84884D2C0926704577E/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132327863/05220805319D5F586AF2C45288D1880BBCF5B1D4/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132233662/46758BE4190670991AEEB84884D2C0926704577E/"
-            }
-          ]
-        },
-        {
-          "name": "Weequay Pirates",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738627390/5CC1A1E67FA0FB421324802CFFF43AEBF54CC512/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 44,
-          "speed": 2,
-          "upgrades": {
-            "Heavy Weapon": 1,
-            "Personnel": 1,
-            "Illicit": 2,
-            "Grenades": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436112170/7B9627FA526DBD9262F7B82066DF7F5BDF1E5B76/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112951/28554A829163EDA67DDE90D1CF137C093FF8A9AC/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436113638/F31ACA002873CE6039E4A0438F29423E59383C71/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112951/28554A829163EDA67DDE90D1CF137C093FF8A9AC/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436114564/440659EBF9A36F6A6E2C7E4C7AE6B2C6A6DBFABD/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112951/28554A829163EDA67DDE90D1CF137C093FF8A9AC/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436115021/ECE24BA2DD41BC0C0EA4638CF553ABDE1969DC4C/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112951/28554A829163EDA67DDE90D1CF137C093FF8A9AC/"
-            }
-          ]
-        },
-        {
-          "name": "Hired Guns",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741999970/AEA964040C9423D7CB3BBFE8E6127BFF6D9B4B16/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 36,
-          "speed": 2,
-          "upgrades": {
-            "Heavy Weapon": 1,
-            "Personnel": 1,
-            "Illicit": 1,
-            "Armament": 1,
-            "Grenades": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138162716/6618383926180465FB60EC9786E27A680C85BFC9/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138162922/C28DD0F623633DABFC9748FFE85A4AFA8D6010DE/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138162195/FB52D7D4C013778E22F5FB391B8506E10F7C8126/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138163807/FF1D50425F0F472D96EA277636EC08E98F969A4F/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138164240/210C9B6E98EBF1F2648A855CDFFEA405E75AFB82/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138164385/1460EF2F670C31A209FB8FD428800D727F310A9F/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138164936/04CD0F0BF910DC7E078F67D680411F0B948714C2/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138165334/AEF9F43EDE77B3E981B4EE3CFA26869D27B45CE0/"
-            }
-          ]
-        }
-      ],
-      "Special Forces": [
-        {
-          "name": "Mercenary Assault Squad",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735112958/CA567516B908134719A9891C1855E81C88E39E7E/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 72,
-          "speed": 1,
-          "upgrades": {
-            "Heavy Weapon": 1,
-            "Training": 1,
-            "Illicit": 1,
-            "Gear": 1,
-            "Armament": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365876771/3C9BD90A0E8E6BA277A1133D1AF61B2D44C2DEB0/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365877132/5DEAE7FFFF586E0ACBFD5BB29AF4869E6D675044/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365880281/45B6B327A692DBFDE6D5E5F642EB7FEBBC2A0A4F/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365878394/8AD2A611C51D78184D8E4204A720C59EEC2C7755/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365879761/026D7FD22C9074A12068AE05CE293EBB833FC70E/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365878394/8AD2A611C51D78184D8E4204A720C59EEC2C7755/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365879295/EC66EBB1550D6D61DAC1AC96CAE92A0273B06A45/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365878394/8AD2A611C51D78184D8E4204A720C59EEC2C7755/"
-            }
-          ]
-        },
-        {
-          "name": "Infiltrators",
-          "title": "Strike Team",
-          "heavyWeaponTeam": true,
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638837280/E9F99045D6B7FA98055D860B700FB5402373070B/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 22,
-          "speed": 2,
-          "upgrades": {
-            "Heavy Weapon": 1,
-            "Training": 1,
-            "Illicit": 1,
-            "Comms": 1,
-            "Gear": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068156464007/651A73813208989A1D36777648388ABBF2F11376/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068156464181/1FABB24F11BA883FEB5A7CB16CB7EAE86CB50402/"
-            }
-          ]
-        },
-        {
-          "name": "Death Watch Fireteam",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736281138/4153C964147552CEAC2E3E23A51ED5358BC5C424/",
-          "size": "small",
-          "type": "Mandalorian Trooper",
-          "points": 54,
-          "speed": 3,
-          "upgrades": {
-            "Heavy Weapon": 1,
-            "Training": 1,
-            "Illicit": 1,
-            "Comms": 1,
-            "Gear": 1,
-            "Armament": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886427483/34A3605CA2B2D8280D40991583D41D7D1B3F0E31/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886427771/60D6CA1D97D822A2222E4FAF614931265B7B0AF2/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886435784/9A83A99579A78DF53A23E3FFB79C07798E4F3C5C/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886427771/60D6CA1D97D822A2222E4FAF614931265B7B0AF2/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886429750/5D62ADB1200B1AD16A0349AF87E757F40E720115/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886427771/60D6CA1D97D822A2222E4FAF614931265B7B0AF2/"
-            }
-          ]
-        },
-        {
-          "name": "Nite Owls",
-          "title": "Bo-Katan's Elite",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736216918/59B584E476FCEAE304E4E3152B4BF12843AE9214/",
-          "size": "small",
-          "type": "Mandalorian Trooper",
-          "points": 60,
-          "speed": 3,
-          "upgrades": {
-            "Training": 1,
-            "Illicit": 1,
-            "Comms": 1,
-            "Gear": 1,
-            "Armament": 1,
-            "Grenades": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357880094/FFFBDA79DE3B6192926EFCDFC257708C2A360562/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515357880292/78883B5B08CCDC0B7BC4EF36D45DAB06E9057FEB/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357881561/B365369415AE0FB6A96E69817D76D9BAD1366038/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515357880292/78883B5B08CCDC0B7BC4EF36D45DAB06E9057FEB/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357880886/06542D3BD6F03DC43D9E675680F86F2964B210F9/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515357880292/78883B5B08CCDC0B7BC4EF36D45DAB06E9057FEB/"
-            }
-          ]
-        },
-        {
-          "name": "Gamorrean Gaurds",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741407333/B5A53DE0F8D6ECC08CCD913669E3AB7D846F9320/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 75,
-          "speed": 2,
-          "upgrades": {
-            "Heavy Weapon": 1,
-            "Training": 1,
-            "Illicit": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407431269414/974FE237CC3CE17AEC2C321DBB69DE340A0D962F/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407431269590/C7A08ECB6A962EC390A208C771B6A8AF513AE685/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407431271048/84FBE9C70610660263F4FE0424E1C02C401A945B/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407431270422/909F25E16D76BF99AE8122963CEE8BAD7ECFD15A/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407431270243/80653030A9E58BF9637ED105E4F63598082B2D9E/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407431270422/909F25E16D76BF99AE8122963CEE8BAD7ECFD15A/"
-            }
-          ]
-        },
-        {
-          "name": "Beast Master",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741833198/7B472992DE2786ABF9B11852AC28F1BBE3EFF7BF/",
-          "size": "small",
-          "type": "Trooper",
           "points": 20,
-          "speed": 1,
-          "upgrades": {
-            "Training": 1,
-            "Comms": 1,
-            "Illicit": 1,
-            "Gear": 1,
-            "Counterpart": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696827920718216/511748ACB39B86DB07F412D61B8BC0706C09A5C5/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696827920718383/E67A519C2234A19CB159E833352376586A237A07/"
+          "restrictions": {
+            "include": {
+              "unit": ["Sith Troopers"]
             }
-          ]
+          }
         },
         {
-          "name": "IG-86 Sentinel Droids",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742381727/F1DAD4DF93EE4BE12C4E2E2BC1D7BADF29BAD32A/",
-          "size": "small",
-          "type": "Droid Trooper",
-          "points": 80,
-          "speed": 2,
-          "upgrades": {
-            "Heavy Weapon": 1,
-            "Training": 1,
-            "Illicit": 1,
-            "Gear": 1,
-            "Grenades": 1
+          "name": "Smart Rocket Trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081347253/3C29E016BF3A1401C14EE4B73127663E916A14F2/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817412080915363/ECDC62217B6E15167C6E1CCFD38F0FDA4E424C7A/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817412080915548/72D86514E3B30EBE60DFEF4D7E5EBE63FCFCD01B/"
           },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407432785617/C21E190F258AC17A01C5D096C890DFA3B988759D/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432785832/186A72B65075EEA56ED2C3D1DC80718E987884B5/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407433051929/749E23C3D0FD9CE738CEA98802F52CA8B64ADABE/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432785832/186A72B65075EEA56ED2C3D1DC80718E987884B5/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407433051436/F1EA8C6D3CCB8278F7775C7AB78AD996DFC24291/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432785832/186A72B65075EEA56ED2C3D1DC80718E987884B5/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407433050963/ED218EC8188C166AFEE1E1DE86351BE786E764D7/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432785832/186A72B65075EEA56ED2C3D1DC80718E987884B5/"
+          "points": 28,
+          "restrictions": {
+            "include": {
+              "unit": ["First Order Stormtroopers"]
             }
-          ]
+          }
         },
         {
-          "name": "IG-86 Sentinel Droids",
-          "title": "Strike Team",
-          "displayName": "Sentinel Droids (Strike Team)",
-          "heavyWeaponTeam": true,
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742381186/83833409E9638CCAE4D3E135DD7DE7C3F50BF6B2/",
-          "size": "small",
-          "type": "Droid Trooper",
+          "name": "Stolen RPS-6 Trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738627942/4B5C5C7EE5C0A917920BC1ACD6D9BDC884C3F66F/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436116594/297A8181876F9899A0116189C171CB6DCF8F7E91/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436116780/2EDB6D1F02708B64292E99D8A6C1C2BA9772D6CD/"
+          },
           "points": 25,
-          "speed": 2,
-          "upgrades": {
-            "Heavy Weapon": 1,
-            "Training": 1,
-            "Illicit": 1,
-            "Comms": 1,
-            "Gear": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407432785617/C21E190F258AC17A01C5D096C890DFA3B988759D/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432785832/186A72B65075EEA56ED2C3D1DC80718E987884B5/"
+          "restrictions": {
+            "include": {
+              "unit": ["Weequay Pirates"]
             }
-          ]
-        }
-      ],
-      "Support": [
-        {
-          "name": "Droideka MKII",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638672297/9A21A780F96BA78A849FD5FFF320FF4D0581259A/",
-          "size": "medium",
-          "type": "Ground Vehicle",
-          "points": 110,
-          "speed": 1,
-          "upgrades": {
-            "Comms": 1,
-            "Hardpoint": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365798378/BE8A6530AC8273FFE4549147A2F83C7A77BA5597/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365798566/72991BC6227C745C3157A2328EEFDF4F1671924D/"
-            }
-          ]
+          }
         },
         {
-          "name": "EWHB-12 Heavy Blaster team",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742525705/7188974BC1594CD7D0B2D6775629F3933FE40E62/",
-          "displayName": "EWHB-12 Team",
-          "size": "medium",
-          "type": "Emplacement Trooper",
-          "points": 60,
-          "speed": 1,
-          "upgrades": {
-            "Comms": 1,
-            "Illicit": 1,
-            "Generator": 1
+          "name": "Tactial Shotgun Commando",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277958661/B7303152FFBCFF29BFD241865245D297469E6F17/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024261155036/D5997D5F703F00DB00BB6C2CB1C92B0BB3E4B972/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260988667/8B8E27DFEDD6DEBA4EFABD6E738D3B6AC3E925AB/"
           },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756243818494/7211F52034FC36725841F968E5F2B991F8C10274/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756243792095/065CF347E346B773F8F93F81B0048E6A6A67A2C1/"
-            }
-          ]
-        }
-      ],
-      "Heavy": [
-        {
-          "name": "Cuddles",
-          "title": "Ferocious One",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735162413/20647BC13446FAA4A0951E6E9D5003D9904557E9/",
-          "size": "huge",
-          "type": "Creature Trooper",
-          "points": 135,
-          "speed": 1,
-          "upgrades": {
-            "Creature": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984835661685/1668BEEE179A260B9988D3C60872160FF93CEE51/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984835661821/7B52CEEC4169ACB4A32C0489D4A878BC72030DE2/"
-            }
-          ]
-        },
-        {
-          "name": "Canderous Class Assault Tank",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556639132725/E48531757B6B7D582D3D3AD313D790E21FAD2655/",
-          "size": "epic",
-          "type": "Repulsor Vehicle",
-          "points": 180,
-          "speed": 1,
-          "upgrades": {
-            "Pilot": 1,
-            "Comms": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231133144508/4BB9CD650D4795CEB6C81CBB95AB31DA7365F7EF/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231133144655/86527E20BE4B11B688A7F14894775EBE347C475B/"
-            }
-          ]
-        },
-        {
-          "name": "Missile Attack Launcher",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556639035496/5F41C143C5ADE4631FFDC497CD8053BF7F0F9E43/",
-          "size": "epic",
-          "type": "Repulsor Vehicle",
-          "points": 140,
-          "speed": 1,
-          "upgrades": {
-            "Pilot": 1,
-            "Ordnance": 2,
-            "Comms": 1,
-            "Hardpoint": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698013227951332/BDA59EEE85EBD5AE628E38AC9B0C539D59DC9525/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698013227951474/8641BEED6BF44F70975F6F27093477327361567C/"
-            }
-          ]
-        },
-        {
-          "name": "Rancor",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742458068/53A90269FBB599680D91DA51225BE59738A8C049/",
-          "size": "huge",
-          "type": "Creature Trooper",
-          "points": 155,
-          "speed": 1,
-          "upgrades": {
-            "Pilot": 1,
-            "Creature": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696827920773360/FA78C7E63C77DD4A9CDF435A2DCE83BEE4235B82/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696827920773489/CCC8F655681A6962AA133E4DB9D4EBD8B3D487AD/"
-            }
-          ]
-        },
-        {
-          "name": "WLO-5 Battle Tank",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743059742/E6358D1656688B41E351113B72177D770264FB6B/",
-          "size": "epic",
-          "type": "Repulsor Vehicle",
-          "points": 125,
-          "speed": 2,
-          "upgrades": {
-            "Pilot": 1,
-            "Hardpoint": 1,
-            "Illicit": 1,
-            "Comms": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436416564/7E56BA386FDC26CB14047F335B62C19995B4AA5E/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436416842/1C5A975045A289BF43FBDC29DC3F2BD0ED7E1E0C/"
-            }
-          ]
-        }
-      ]
-    },
-    "Separatist": {
-      "Commander": [
-        {
-          "name": "Darth Sidious",
-          "title": "Master of Manipulation",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743518519/E404C02C62D579D5E0385EEDCB318DC45FFF7D13/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 240,
-          "speed": 2,
-          "upgrades": {
-            "Force": 3,
-            "Command": 1,
-            "Training": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824153235918382/C6629B635DB0B3D04D345B83AE6A0DA0EF4CDDBC/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824153235918510/4CE73F1347AA53974D94CADE1B77D9875694299C/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "Power! Unlimited Power!",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743519427/23500514817BCDB46436B493396E941FD5FFE6E7/",
-              "pip": 1
-            },
-            {
-              "name": "Execute Order 66",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743519790/0A304E9ECB85D8BCC65B1FA93658FC87D98DC96D/",
-              "pip": 2
-            },
-            {
-              "name": "A Surprise, To Be Sure",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743520163/A584E2B66E09368C6E89485F7C44DBA8CEA2A0D5/",
-              "pip": 3
-            }
-          ]
-        }
-      ],
-      "Operative": [
-        {
-          "name": "Sun Fac",
-          "title": "Archduke's Chief Lieutenant",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746952332/B95C799020F79D219FFDF62FF12C7EFB302E3920/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 105,
-          "speed": 3,
-          "upgrades": {
-            "Command": 1,
-            "Training": 2
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318234636/1ECC7AF43F26DDE2A82E90A54DCE2956F02A27F0/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893318234765/77E9C34FC82B00D2C3E96A60AF29948CBEC88784/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "Enforcer of the Swarm",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746960145/1E5AA4E032A934D62D4DBA0FB0C892E07603F8D7/",
-              "pip": 1
-            }
-          ]
-        }
-      ],
-      "Corps": [
-        {
-          "name": "Geonosian Warriors",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746956460/10EC43D13EC18AB52E30175D8E015E2C233EC310/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 48,
-          "speed": 3,
-          "upgrades": {
-            "Heavy Weapon": 1,
-            "Personnel": 1,
-            "Training": 1,
-            "Armament": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318078184/8B5466E18846FE7CF66B17BC0A657A0208855F03/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893318078962/DEB31D473979E7DE679F9564781A76B0E8E522FD/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318071468/13869F37C5ED6881ED97E16D300ED50175E1C007/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893317930470/4A9F58F7B8BC80AF279695655E38DD81A9236057/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318070141/E59D21FBF0E1DCE0AA6CF1B9574AB6BDF26438FC/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893317930470/4A9F58F7B8BC80AF279695655E38DD81A9236057/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318076612/BCD33D7FAFC2C324271FB92894740CACEFF7ED9D/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893317930470/4A9F58F7B8BC80AF279695655E38DD81A9236057/"
-            }
-          ]
-        }
-      ],
-      "Support": [
-        {
-          "name": "LM-432 Crabdroid",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743527286/34BE0F9B234F769983BE410CB8D2D94B695D5840/",
-          "size": "medium",
-          "type": "Ground Vehicle",
-          "points": 90,
-          "speed": 2,
-          "upgrades": {
-            "Comms": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455020027815604/10F9822A314D818E81C27CE272E1F52E50B6EBF3/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455020027816841/367B15AD633665E238815516DF8E82AC4EFAA34B/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455020027819432/1A96D256F849409A6F2157F0A896967146B7A13C/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455020027816841/367B15AD633665E238815516DF8E82AC4EFAA34B/"
-            }
-          ]
-        },
-        {
-          "name": "LR1K Sonic Cannon",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746955793/8D7F4A2BA75689F096F5D44BC4AB28B6BBDBC062/",
-          "size": "large",
-          "type": "Emplacement Trooper",
-          "points": 75,
-          "speed": 0,
-          "upgrades": {
-            "Comms": 1,
-            "Generator": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318385775/0D78686C63C10B04D2BA172B26F125D007034C0C/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893318369456/484B53AD87428BCF7E190DB1A763640373914353/"
-            }
-          ]
-        },
-        {
-          "name": "Octuptarra Tri-Droid",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743539441/5709DCD601EB0694A3CA0DA71D1BCC1D3C2A0F87/",
-          "size": "large",
-          "type": "Ground Vehicle",
-          "points": 60,
-          "speed": 2,
-          "upgrades": {
-            "Hardpoint": 1,
-            "Comms": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455403164598593/5A7C010653DBCE628FE44C40B0915C460164945A/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455403164542430/B2F1D02EDF736CAE38008DD4CEF11F2394AB18B4/"
-            }
-          ]
-        },
-        {
-          "name": "SD-4K Assassin Droid",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743571510/E772880DCEEA1B27CB80B2DCEF91D89F356D4C11/",
-          "size": "large",
-          "type": "Ground Vehicle",
-          "points": 70,
-          "speed": 2,
-          "upgrades": {
-            "Pilot": 1,
-            "Hardpoint": 1,
-            "Comms": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1055478180707369319/5222F20E44E450F944F7C39E59C16359C9743A60/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1055478180707368539/DDBADF81B279336EBE157E67F2ECAB3B6C8A037A/"
-            }
-          ]
-        },
-        {
-          "name": "Sharpshooter Droideka",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743586301/1CCF100C94512AE1CB7D788234024FDC86B16A29/",
-          "size": "medium",
-          "type": "Ground Vehicle",
-          "points": 110,
-          "speed": 1,
-          "upgrades": {
-            "Comms": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455553732191897/63312F1C4D01590EDA8153640DDF31260E7A27E2/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455553732192021/2D0E1C0D65555EF7A52443E3000E0979A287E077/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455553732192630/7B686F1D43905244043848E1240DA5B112F92A09/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455553732192021/2D0E1C0D65555EF7A52443E3000E0979A287E077/"
-            }
-          ]
-        }
-      ],
-      "Heavy": [
-        {
-          "name": "Defoliator Deployment Tank",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743614358/8A82032A999FD9F81E83CA8925B0C8AC301D07FD/",
-          "size": "epic",
-          "type": "Repulsor Vehicle",
-          "points": 155,
-          "speed": 1,
-          "upgrades": {
-            "Pilot": 1,
-            "Hardpoint": 1,
-            "Ordnance": 1,
-            "Comms": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893327245472/0E4E57241F7F12B74598D3D83A5D501E5586315F/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893327220558/8D3108FC26DE5361995CDDB2CE24CE004F69F1C9/"
-            }
-          ]
-        },
-        {
-          "name": "HMP Droid Gunship",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743692190/E87C41BC6C6F5797FA124D17C0F5C0FCB15769B0/",
-          "size": "epic",
-          "type": "Repulsor Vehicle",
-          "points": 155,
-          "speed": 2,
-          "upgrades": {
-            "Hardpoint": 1,
-            "Ordnance": 2,
-            "Comms": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028454854943605642/C9B582DDD3BD0DD6A4C0C3AB35E91064DFF77C42/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028454854943586665/C0F6961CFFA9F8E15FB5F6B6538AE5C404DD40B4/"
-            }
-          ]
-        },
-        {
-          "name": "IG-227 Hailfire-Class Droid Tank",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743648691/D8401535639FA435BD7D89A4DC8A9CEF8E077529/",
-          "size": "huge",
-          "type": "Ground Vehicle",
-          "points": 110,
-          "speed": 3,
-          "upgrades": {
-            "Hardpoint": 1,
-            "Comms": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455516900984588/FD6A321B7F88D5680A3AF647417BA4BB5E74EAEF/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455516901771593/595DBAC62796FE3C66973A218C72DDCEC3B4B05B/"
-            }
-          ]
-        },
-        {
-          "name": "Octuptarra Magna Tri-Droid",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743670386/A2A33692DAFB2F4BE77EE01ABEAB89F7B7CA1228/",
-          "size": "epic",
-          "type": "Ground Vehicle",
-          "points": 180,
-          "speed": 2,
-          "upgrades": {
-            "Hardpoint": 1,
-            "Comms": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455403164753290/F8E53798804F16BA75E428DF4DE94D930DB0F20A/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455403164542430/B2F1D02EDF736CAE38008DD4CEF11F2394AB18B4/"
-            }
-          ]
-        },
-        {
-          "name": "OG-9 Homing Spider Droid",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743679867/D32CA64107D6C9D10B086FE2335D8CC6A545F90C/",
-          "size": "epic",
-          "type": "Ground Vehicle",
-          "points": 140,
-          "speed": 1,
-          "upgrades": {
-            "Comms": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455403167048357/2192FD561FA2D05EB86CC3AE445499640E570E21/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455403164322367/DB9DC63C0285A43C8547D724F882063227910D89/"
-            }
-          ]
-        }
-      ]
-    },
-    "Sith Empire": {
-      "Commander": [
-        {
-          "name": "Darth Malgus",
-          "title": "Prodigy of Battle",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277562476/E42383A66E46621D98A52DA5D0BD1C7FBAD02AB9/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 190,
-          "speed": 2,
-          "upgrades": {
-            "Force": 3,
-            "Training": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824296871909914/CC551973C1E900C1153BB015BED7EE408646DF78/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231133343207/A24CBD9CC466137A560F72A00359E34DF0083071/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "Furious Charge",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277563415/5A0861160BA5F979A8F0C216F494C9925D5538BB/",
-              "pip": 1
-            },
-            {
-              "name": "Visions of Doubt",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277563761/ECD4F9155C9E74C1B70403FD0F547B55070F205C/",
-              "pip": 2
-            },
-            {
-              "name": "Force Maelstrom",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277564474/A1645474FAA791583F23BC7FFE299704AA112FCF/",
-              "pip": 3
-            }
-          ]
-        },
-        {
-          "name": "Lord Adraas",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277602848/B56DEFFD7CC8988D8568476DE4E0C7E59908A6E1/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 120,
-          "speed": 2,
-          "upgrades": {
-            "Force": 2
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885833891/AE635515661DD84861ADF0CF4FC48052FD3DEF87/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608885695776/F5A3AA78554B8F3CB86314E552D94D65C0080F0C/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "Counting Corpses",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277603245/63BC127864462C645D997822348332C2053CD8C8/",
-              "pip": 1
-            },
-            {
-              "name": "Spearheading the Assault",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277603553/067F6633690E6A14497AA7AA0164F0B93F773C2D/",
-              "pip": 2
-            },
-            {
-              "name": "Claiming Victory",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277603895/1237D55EFD6265C9922C8B7DEC76F46AD20608C4/",
-              "pip": 3
-            }
-          ]
-        },
-        {
-          "name": "Shae Vizla",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277698530/3A31084E01120F5B0F53A17C0B6F3ECBD2FD6DA6/",
-          "size": "small",
-          "type": "Mandalorian Trooper",
-          "points": 135,
-          "speed": 3,
-          "upgrades": {
-            "Training": 2,
-            "Gear": 1,
-            "Armament": 2
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642366438145/53BAD2A0BECE84168DD54692576AFFD8D43A9962/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642366438391/C107A0534E3BC5211416290AD53F4EB4482E021B/"
-            }
-          ],
-          "commands": [
-            {
-              "name": "Flame Burst",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277699041/E5D63FF435C115846E9863192F7A61EBABCD0DE4/",
-              "pip": 1
-            },
-            {
-              "name": "Mandalore The Avenger",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277699427/213D174E2B02C59A9774F14990693D661012BA30/",
-              "pip": 2
-            },
-            {
-              "name": "Whatever...",
-              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277699707/C145698341E7B15563A59265F2D6D63A1F16E340/",
-              "pip": 3
-            }
-          ]
-        }
-      ],
-      "Corps": [
-        {
-          "name": "Sith Empire Troopers",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277742096/C1DC5A839A9F754B2EECA3F022F05A30C182F003/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 44,
-          "speed": 2,
-          "upgrades": {
-            "Heavy Weapon": 1,
-            "Personnel": 1,
-            "Training": 1,
-            "Grenades": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608878956135/77C5F51565475CEB63D9A0A0E97F3616EC17992E/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608878877171/C209E7E6493A8465F8FD60DE6566AA6BA2C745ED/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608878992636/D833E26E44A7763FAEFBE2430390376F9160E931/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608878877171/C209E7E6493A8465F8FD60DE6566AA6BA2C745ED/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608879652119/A6E9D1CC7FCF34BF844B1847503E21E60C007A21/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608878877171/C209E7E6493A8465F8FD60DE6566AA6BA2C745ED/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608878917211/A6984255B6241D8A292F4785C28A87E134354C9A/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608878877171/C209E7E6493A8465F8FD60DE6566AA6BA2C745ED/"
-            }
-          ]
-        },
-        {
-          "name": "Sith Empire Boarding Troopers",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277785197/971E0418CD2A7CE414F629E2AFEE3B684B99BA46/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 48,
-          "speed": 2,
-          "upgrades": {
-            "Personnel": 1,
-            "Heavy Weapon": 1,
-            "Training": 1,
-            "Comms": 1,
-            "Grenades": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885319465/2474308EBBDD92BDF8D331691E4F47EB4E1D9D7B/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885051525/BE73F7CADC7D35B297FE86A2C7C13532B33BED20/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885219099/28222F723E524C776ADFD8BF4072B274D5DD6513/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885271840/AEB99C8ABF425086732389D43FA67625C6E6C4CB/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
-            }
-          ]
-        },
-        {
-          "name": "Sith Empire Support Troopers",
-          "heavyWeaponTeam": true,
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277927003/D6339601058975760755CFB0F0FEE8ED3B6A4372/",
-          "size": "small",
-          "type": "Trooper",
           "points": 30,
-          "speed": 2,
-          "upgrades": {
-            "Heavy Weapon": 1,
-            "Training": 1,
-            "Comms": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824477681546677/855DD1F57D897B360CCA3F12DDB4449E0D116255/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824477681548557/DB63AB0044B89CB25D50A204A061D535CA20F495/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824477681548370/AFD42783EB041326C035DDB002BF34928A1AE002/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824477681548557/DB63AB0044B89CB25D50A204A061D535CA20F495/"
+          "restrictions": {
+            "include": {
+              "unit": ["Imperial Commandos"]
             }
-          ]
-        }
-      ],
-      "Special Forces": [
-        {
-          "name": "Imperial Commandos",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277957842/94E04A758D860C9A7FCFE6D6356AA07DBFD811FD/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 72,
-          "speed": 2,
-          "upgrades": {
-            "Heavy Weapon": 1,
-            "Gear": 1,
-            "Training": 1,
-            "Comms": 1,
-            "Grenades": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024260308213/15A8FC12EB8192B2272D639557ED336BAF9718BE/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260606126/9430D9F19B59E68648F5261C8162A66C253EDDC0/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024261188154/B23F2669D0C619618D89D2BCF50E701363CDB26B/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260988667/8B8E27DFEDD6DEBA4EFABD6E738D3B6AC3E925AB/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024260446504/E46DFA85E16AF894A710D4F6714BA84BC9C6BBB3/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260606126/9430D9F19B59E68648F5261C8162A66C253EDDC0/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024260532062/6D98D9E28283E02F34B203849A11F420D1A1C99E/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260606126/9430D9F19B59E68648F5261C8162A66C253EDDC0/"
-            }
-          ]
+          }
         },
         {
-          "name": "Sith Acolytes",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278054907/1EA779D6C64F1883A9EF450C1424A0459EF087F9/",
-          "size": "small",
-          "type": "Trooper",
-          "points": 78,
-          "speed": 2,
-          "upgrades": {
-            "Personnel": 1,
-            "Training": 1,
-            "Force": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012691837448680455/252DCD7E06B5083BBE6CABCA4F8349D6DCE46498/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608885695776/F5A3AA78554B8F3CB86314E552D94D65C0080F0C/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885701810/42CE6863B9D31E7EDDA1C4DEEC0C52F6DFEBB0D1/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608885695776/F5A3AA78554B8F3CB86314E552D94D65C0080F0C/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885733918/43DD4CBAEAD756429F47BAF24133A3D97CEA9DA6/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608885695776/F5A3AA78554B8F3CB86314E552D94D65C0080F0C/"
+          "name": "TL-50 Resistance Trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752980632/3AC1DF926A9DF195B85993DE03C1BA837FF12038/",
+          "points": 26,
+          "restrictions": {
+            "include": {
+              "unit": ["Resistance Troopers"]
             }
-          ]
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324582151739582/7B71E9B3E009D0CE72542DCE4EE88F80A15975F1/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324582151739873/59E17839EF9DE940D822E980A6B8D17EAF323009/"
+          }
+        },
+        {
+          "name": "TL-50 Stormtrooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751871157/BC6D8D82C13ED515680AE0748BCBF8BBA1967D52/",
+          "points": 28,
+          "restrictions": {
+            "include": {
+              "unit": ["Stormtroopers"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324932748013140/6A82D4809AA884C3F5786210898CE813BC9789F9/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324932748013349/A449441B895CE926D13CE9D1501BFC9B12A08A9D/"
+          }
+        },
+        {
+          "name": "Trandoshan Blaster Trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738629805/EEDC0DDF8D9737D6CFFDBAAEDDF73C2BC39DC9AF/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436115961/DBF66375F8D2143292D9BBDC3F6FF6AB46D7AB16/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112372/F530C8FD39C7DAC7766DF00F0087A82E8044DE0D/"
+          },
+          "points": 27,
+          "restrictions": {
+            "include": {
+              "unit": ["Weequay Pirates"]
+            }
+          }
+        },
+        {
+          "name": "Vibro-arbir Blade Guard",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081435867/C1A0F6BB89AB4B4C2C2857491FFD840AA82AFFA6/",
+          "points": 25,
+          "restrictions": {
+            "include": {
+              "unit": ["Elite Praetorian Guards"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817957003763616/5D2007C0F4115E9406A2A83D98E4D4D3275E168F/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817957003763776/D3F6005987B0D827683E0B7EB3E482E8D5213424/"
+          }
+        },
+        {
+          "name": "Riot Control Trooper (Offensive)",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081343404/198C195A7C6538264754E6ED65810E699941909B/",
+          "flip": {
+            "name": "Riot Control Trooper (Defensive)",
+            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081343586/AFEAA0E712AC4720D360E2A44E8DD5DCC5AD2F3E/"
+          },
+          "points": 22,
+          "restrictions": {
+            "include": {
+              "unit": ["First Order Stormtroopers"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324932747749076/BC0B7C898A646CCDFC518280A48B7C82EECB54B1/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324932747749244/7BD30A42AAF722FC4D005E08EC5EB2BCBD938E22/"
+          }
+        },
+        {
+          "name": "Z-6B Resistance Trooper ",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752971387/1606CD1A3BD10A2FAF39558C7B36597840920010/",
+          "points": 22,
+          "restrictions": {
+            "include": {
+              "unit": ["Resistance Troopers"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324932752944952/1207D0D12B5971CC86CDAC845AB9487AFB0913E2/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324932752945165/7BFD62143549CA0DC0C9FDF7A251A8546AFB50DD/"
+          }
+        },
+        {
+          "name": "Z-6 StormTrooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751870825/96353DB410957633EF3D108F2BC58D4F84EBEC7E/",
+          "points": 25,
+          "restrictions": {
+            "include": {
+              "unit": ["Stormtroopers"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324932748082014/050A615D4A688CAF04806338E172186E1BEE93F5/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324932748082306/B60EBE5BB730F9B03EC541DDF15993BADBE2820F/"
+          }
         }
       ],
-      "Support": [
+      "Illicit": [
         {
-          "name": "War Droid MK I",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278072181/D3BB57A041FA5490F372A792EEF35A344BD68FCD/",
-          "size": "medium",
-          "type": "Ground Vehicle",
-          "points": 110,
-          "speed": 1,
-          "upgrades": {
-            "Comms": 1
-          },
-          "minis": [
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697620253289667/85745104AA0C94936FA804B87EA1A61938161B79/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697620253289816/7245F236A07C662A6AA471AA89E323417AB7D604/"
-            },
-            {
-              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697620253290925/09820A879BC9DB027D438A7F0051F90D558A3D97/",
-              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697620253289816/7245F236A07C662A6AA471AA89E323417AB7D604/"
+          "name": "Black Market Weapon Modifications",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735317485/24DDC0FD309F0F75C04559832E888C0ED6E52CB1/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "type": ["Trooper"]
             }
-          ]
+          }
+        },
+        {
+          "name": "Black sun Assault mod",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742527952/354B544F4AB6ED4EA8FE90895DA7E62CC6D9DED9/",
+          "points": 5,
+          "restrictions": {
+            "include": {
+              "unit": ["EWHB-12 Heavy Blaster team"]
+            }
+          }
+        },
+        {
+          "name": "Ewok Bomb",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741833695/4345404F4A2F9E97DC140024285F113A8DDEAAE9/",
+          "points": 22,
+          "restrictions": {
+            "include": {
+              "unit": ["Beast Master"]
+            }
+          },
+          "additionalObjects": ["Proton Charge Token"]
+        },
+        {
+          "name": "Glitterstim",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735317047/31F1D322D5E1C986DFB20E582590653A0B0CAF7F/",
+          "points": 5,
+          "restrictions": {
+            "include": {
+              "type": ["Trooper"]
+            }
+          }
+        },
+        {
+          "name": "Inspiring Monologue",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738474691/8D852B6879C8FF5C5F0A2883FC9A204FB8937979/",
+          "points": 5,
+          "restrictions": {
+            "include": {
+              "unit": ["Hondo Ohnaka"]
+            }
+          }
+        },
+        {
+          "name": "Lord of Pirates",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738474167/126CF97710D8C7F9BDFBB16BF051B1F8660C7263/",
+          "points": 15,
+          "restrictions": {
+            "include": {
+              "unit": ["Hondo Ohnaka"]
+            }
+          }
+        },
+        {
+          "name": "Outer Rim Modifications",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735317893/3A2F6E60B2980B2608C4DA9B029E1C4B2F257560/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "type": ["Droid Trooper", "Ground Vehicle", "Repulsor Vehicle"]
+            }
+          }
+        },
+        {
+          "name": "Personal Shield",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735181899/208D960208099BDF4461E2E09204169FF959FC52/",
+          "points": 8,
+          "restrictions": {
+            "include": {
+              "type": ["Trooper"]
+            }
+          }
+        },
+        {
+          "name": "Piercing Dart",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640417521/8FE5D7BA77D3E25ED3FB812B261AD3E3DD88EF10/",
+          "points": 6,
+          "restrictions": {
+            "include": {
+              "type": ["Mandalorian Trooper"]
+            }
+          }
+        },
+        {
+          "name": "Pirate Retrofit",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742527540/AA9771542B3B0F58F1D813AE833F6E230163C361/",
+          "points": 5,
+          "restrictions": {
+            "include": {
+              "unit": ["EWHB-12 Heavy Blaster team"]
+            }
+          }
+        },
+        {
+          "name": "Poison Dart",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640416768/843BE27BBC497AC58846ED0295BFC661E391BEDF/",
+          "points": 6,
+          "restrictions": {
+            "include": {
+              "type": ["Mandalorian Trooper"]
+            }
+          }
+        },
+        {
+          "name": "Rancor Tamer",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741834052/EE3F163A5E5986958BCE4A45AD91F861EB85459F/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "unit": ["Beast Master"]
+            }
+          }
+        },
+        {
+          "name": "Reputation of the Hutts",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741312392/906B601379C476DB20B6997F64A1B29916A421DB/",
+          "points": 7,
+          "restrictions": {
+            "include": {
+              "unit": ["Jabba The Hutt"]
+            }
+          }
+        },
+        {
+          "name": "Self-Destruct Sequencing",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735318468/FF453A532280D1626623E10338ED5D288FA47B6E/",
+          "points": 5,
+          "restrictions": {
+            "include": {
+              "type": ["Droid Trooper", "Ground Vehicle", "Repulsor Vehicle"]
+            }
+          }
+        },
+        {
+          "name": "Stimpack",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735182732/C3B2C7FA3F05FC71D5C3ED089A8037A92171A103/",
+          "points": 5,
+          "restrictions": {
+            "include": {
+              "type": ["Trooper"]
+            }
+          }
+        },
+        {
+          "name": "Wrist Mounted Disintegrator",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640426484/CAA3EE923F691577E92958B5BAA38AB8221EDF61/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "type": ["Mandalorian Trooper"]
+            }
+          }
+        },
+        {
+          "name": "Wrist Mounted Disruptor",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640427887/A13950D10FE563732533E3C91584E465D47F05F5/",
+          "points": 3,
+          "restrictions": {
+            "include": {
+              "type": ["Mandalorian Trooper"]
+            }
+          }
+        },
+        {
+          "name": "Wrist Mounted Slugthrower",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640413367/65913371690794787832DA2D5D970C42E484A5E0/",
+          "points": 6,
+          "restrictions": {
+            "include": {
+              "type": ["Mandalorian Trooper"]
+            }
+          }
+        },
+        {
+          "name": "Ysalamiri cage",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741834581/FDBF31BD0BD3997D1415E1409F8C4A82744019D9/",
+          "points": 8,
+          "restrictions": {
+            "include": {
+              "unit": ["Beast Master"]
+            }
+          }
+        }
+      ],
+      "Ordnance": [
+        {
+          "name": "Bunker Buster Missiles",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751975579/6613DFBE1168370B4DB2AA3BAC7CCDC8F2B1EEDD/",
+          "points": 5,
+          "restrictions": {
+            "include": {
+              "unit": ["Phase II Darktroopers"]
+            }
+          }
+        },
+        {
+          "name": "Carbonite Missiles",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638969743/EEA573B6F2E054B13E3A220888FFDC03906CA74C/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "unit": ["Missile Attack Launcher"]
+            }
+          }
+        },
+        {
+          "name": "Sabot Missiles",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751975146/7766942C8563D444E253FC2262E6E7DDE1A95F00/",
+          "points": 5,
+          "restrictions": {
+            "include": {
+              "unit": ["Phase II Darktroopers"]
+            }
+          }
+        },
+        {
+          "name": "Shrapnel Missiles",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751975982/EBFAC7D348F41D8A319B15EAF27ADF6F443DD56C/",
+          "points": 5,
+          "restrictions": {
+            "include": {
+              "unit": ["Phase II Darktroopers"]
+            }
+          }
+        }
+      ],
+      "Personnel": [
+        {
+          "name": "Clone Paratrooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747552501/731105BAC6B5011092706B93C5853B6B51317D55/",
+          "points": 16,
+          "restrictions": {
+            "include": {
+              "unit": ["Clone Paratroopers"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693290507042014/A16ED28591E7E27887C7BC119152B6AD889BFF9E/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
+          }
+        },
+        {
+          "name": "Extra Grenadier",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735129141/9805A2223DB725582E8105414121E4505895193F/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365824294/5F43B720E0198A078E25BA472E7DDBCA8F51CBEC/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365824481/27693FC709ADF50440623C6347A11151608D5E2F/"
+          },
+          "points": 11,
+  
+          "restrictions": {
+            "include": {
+              "unit": ["Grenadier Squad"]
+            }
+          }
+        },
+        {
+          "name": "First Order Officer",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081395449/B2459EAD6D5B9FCF46951EF77CC2BCBF23370C10/",
+          "points": 22,
+          "leader": true,
+          "restrictions": {
+            "include": {
+              "faction": ["First Order"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821664192111404/0E625C7A4614D3BE5DF4DF9D78BA558C2B78803C/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821664192111727/770A7C77419D31361A4E7DF14655D4339B5333BE/"
+          }
+        },
+        {
+          "name": "First Order Stormtrooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081340137/E2C8E810E5F4D2F842F4B633A9EF4E633317B5AC/",
+          "points": 12,
+          "restrictions": {
+            "include": {
+              "unit": ["First Order Stormtroopers"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804926507457/5178F7589B3E8647E3FBFDE3C3C0829F284FA23D/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804926496614/9FECECAF48C7046C3714B33C4C16FFB773FCC94C/"
+          }
+        },
+        {
+          "name": "First Order Stormtrooper Officer",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081357391/65AB363DC36732A59EF1CF526B1C236F54F63C87/",
+          "points": 15,
+          "leader": true,
+          "restrictions": {
+            "include": {
+              "unit": ["First Order Stormtroopers"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804930715422/16120934F642C553591C4773C4F9E4B21F167A52/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804930715848/CC1157E547C67A4FD8CF56868BFCD9EF3A04075D/"
+          }
+        },
+        {
+          "name": "Forward Observer",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735128538/8947A618AAA4A4A0D92B3C7C12E651A494FDEDA7/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984835690936/3C42012D036A5F420DD9ADD158E66901AB4A5671/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984835691208/1C0C86466F3298E9663CEE3961B7F3F6DBED4DD9/"
+          },
+          "points": 17,
+          "restrictions": {
+            "include": {
+              "unit": ["Grenadier Squad"]
+            }
+          }
+        },
+        {
+          "name": "General Caluan Emmat",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1021697756245233178/36866FDE340064CDE02A6C0BB423EA8CAD2B1ABC/",
+          "points": 20,
+          "leader": true,
+          "restrictions": {
+            "include": {
+              "faction": ["Resistance"],
+              "rank": ["Corps"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248463256/9A71FCC63F00BFF1B30323727AE4ECE40A797845/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248457898/6A102129E4F692F04E02D1269F913A4D22B22FBC/"
+          }
+        },
+        {
+          "name": "Geonosian Warrior",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746955018/3E851672C18FC4978BF8E7D82D3BB6E0D4433A9D/",
+          "points": 12,
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893317940526/D1A4E66DAA988ABE66C6D0014DD6D49047AA6697/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893317930470/4A9F58F7B8BC80AF279695655E38DD81A9236057/"
+          },
+          "restrictions": {
+            "include": {
+              "unit": ["Geonosian Warriors"]
+            }
+          }
+        },
+        {
+          "name": "Hired Gun",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742004196/087F0B1F89E7E79E87461EE5D2661B2585C52D4A/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138165871/C51E95633C934897949CFF29D8F9BCE471BF8FFA/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138166035/1BA43B16941621DB32750B2B3CDD35053996ABA9/"
+          },
+          "points": 9,
+          "restrictions": {
+            "include": {
+              "unit": ["Hired Guns"]
+            }
+          }
+        },
+        {
+          "name": "Hutt Cartel Sentry",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738629292/FE183D473B13C247AC36F6DD253B934B09655B34/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436124726/C43B4DBB33AABF8482E19400E53948B5ED032CCB/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436124875/9CB0C0F06DD8F10B227161EE26DD1B55F8F5BDD4/"
+          },
+          "leader": true,
+          "points": 23,
+          "restrictions": {
+            "include": {
+              "unit": ["Weequay Pirates"]
+            }
+          }
+        },
+        {
+          "name": "Hutt Cartel Trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741193921/7F0C6BE42AE860AB77EB6C2BC779788371FE78B7/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132329491/14A83C22F3313876B13BB0A0016C687ED2E77D44/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132233662/46758BE4190670991AEEB84884D2C0926704577E/"
+          },
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "unit": ["Hutt Cartel Troopers"]
+            }
+          }
+        },
+        {
+          "name": "Imperial Supercommando",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751939006/CBC6F2FE8C1DF0F75561DAE45F1F721222BF52FB/",
+          "points": 23,
+          "restrictions": {
+            "include": {
+              "unit": ["Imperial Supercommandos"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982276859/C65AD83F5B3BE7D8787B3F0DC71C3637F257CF58/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982273931/809947D430BEB447CD2FA3E99DD31AF57C3E8F84/"
+          }
+        },
+        {
+          "name": "Paratrooper Medic",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747553122/09BE4CDAF6D1A40AED895C9DAC9B03EECA17E46A/",
+          "points": 29,
+          "restrictions": {
+            "include": {
+              "unit": ["Clone Paratroopers"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693415425401629/49D60D4EE5794A206AF8F604A68F58979CFEBC42/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693415425408778/BD84B4C5CAA84DDA6302739AD749CD29B1C39669/"
+          }
+        },
+        {
+          "name": "Resistance Trench Fighter",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1017194020628451982/E73E545FCA80240A75FBE0988782C8014F891577/",
+          "points": 13,
+          "restrictions": {
+            "include": {
+              "faction": ["Resistance Trench Fighters"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248442551/9D7BC64B0ECFEA79E16E695F4823085745EA8C51/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248440578/125E76600442E01E3AD18725563EA1BE4D63BEFA/"
+          }
+        },
+        {
+          "name": "Resistance Trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752970508/02879490220A6F3BD0B3B501770CE6567C152BD1/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "unit": ["Resistance Troopers"]
+            }
+          },
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324582151467148/595A4E7837AB3D12604D3A2858D08496E4FCBEA5/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324582151467561/892B00728A9164598F3FBE91C0D7C0F8619FCB20/"
+          }
+        },
+        {
+          "name": "Sith Empire Boarding Trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277786308/E222A61B5021B9FC2E56A8A957633B8BD2384CDB/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608884994661/01F7CD51333718A8A814885CF5A93B2A84651652/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
+          },
+          "points": 12,
+          "restrictions": {
+            "include": {
+              "unit": ["Sith Empire Boarding Troopers"]
+            }
+          }
+        },
+        {
+          "name": "Sith Empire Trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277742848/35DD1780CE5A8F446954CC178C0C05089A10B21B/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608878992636/D833E26E44A7763FAEFBE2430390376F9160E931/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608878877171/C209E7E6493A8465F8FD60DE6566AA6BA2C745ED/"
+          },
+          "points": 11,
+          "restrictions": {
+            "include": {
+              "unit": ["Sith Empire Troopers"]
+            }
+          }
+        },
+        {
+          "name": "Sith Sorcerer",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278055781/ED051F07880B0030B6DE21C04E01E640FEAD93C2/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061823163250038/32C72D2D0F766BFD34626E6A8944954C50CC0D77/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061823163250299/7A3E3550E4630C1BF03CF91847C63638AB684434/"
+          },
+          "points": 35,
+          "restrictions": {
+            "include": {
+              "unit": ["Sith Acolytes"]
+            }
+          }
+        },
+        {
+          "name": "Sith Trooper",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281908575/338762E958A0C98B0AB49C47AA6A715893E4548B/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933703057/89125C10F7477148926E221D7D01FC48B49D2502/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
+          },
+          "points": 11,
+          "restrictions": {
+            "include": {
+              "unit": ["Sith Troopers"]
+            }
+          }
+        },
+        {
+          "name": "Sith Warrior",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278056315/1665856EDAB96AF7A8C172511E6599CD901D4E71/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885796271/427E4FBA584A22712C84414761D3EEBB1AE714E7/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608885695776/F5A3AA78554B8F3CB86314E552D94D65C0080F0C/"
+          },
+          "points": 35,
+          "restrictions": {
+            "include": {
+              "unit": ["Sith Acolytes"]
+            }
+          }
+        },
+        {
+          "name": "Veteran Sergeant",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277744958/3610B8D3EB6E459B5BF3C7F97B0E7B2B9AA4CBE1/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608881242939/0D60224C8880F4609ADFC4B901EC92EEA545B235/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608881243790/F0D722D6703135FDF3BB2B7F3105FCAA49DB5284/"
+          },
+          "leader": true,
+          "points": 25,
+          "restrictions": {
+            "include": {
+              "unit": ["Sith Empire Troopers"]
+            }
+          }
+        },
+        {
+          "name": "Weequay Pirate",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738628849/92249CF6F8DC12990B7073346AEF4DE3F3C5BB43/",
+          "mini": {
+            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436114050/3985CF5B2D5C91AEF263706C20E4C84D7401F1BE/",
+            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112951/28554A829163EDA67DDE90D1CF137C093FF8A9AC/"
+          },
+          "points": 11,
+          "restrictions": {
+            "include": {
+              "unit": ["Weequay Pirates"]
+            }
+          }
+        }
+      ],
+      "Pilot": [
+        {
+          "name": "Agent Terex",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081428303/9A5F8BEFCF2B962CAD2849472B5123723578E868/",
+          "points": 15,
+          "restrictions": {
+            "include": {
+              "faction": ["First Order"],
+              "type": ["Repulsor Vehicle"]
+            }
+          }
+        },
+        {
+          "name": "Defoliator Lok Durd",
+          "displayName": "Lok Durd",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743617101/58D618F0C66FFCDC5FEBF39BC32D54D6BA55EB30/",
+          "points": 9,
+          "restrictions": {
+            "include": {
+              "unit": ["Defoliator Deployment Tank"]
+            }
+          }
+        },
+        {
+          "name": "Defoliator T-Series Tactical Droid Pilot",
+          "displayName": "T-Series Tactical Droid Pilot",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743616760/DF7B027C96C111F6170C6DD30E32DC1FBBE08AEE/",
+          "points": 5,
+          "restrictions": {
+            "include": {
+              "unit": ["Defoliator Deployment Tank"]
+            }
+          }
+        },
+        {
+          "name": "Excitable Pirate",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743063563/DECCDDEB113FF6F7E278657E96EB142AEE9690B7/",
+          "points": 15,
+          "restrictions": {
+            "include": {
+              "unit": ["WLO-5 Battle Tank"]
+            }
+          }
+        },
+        {
+          "name": "Hawkeye",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747619367/B0EFDF7F817DC850C3A28D1CD885213958C2248E/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "unit": ["LA-AT/I Gunship"]
+            }
+          }
+        },
+        {
+          "name": "Hutt Cartel Pilot",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743063098/6FA89F40EA19F2FA891BD06D60B6DC06539C1212/",
+          "points": 15,
+          "restrictions": {
+            "include": {
+              "unit": ["WLO-5 Battle Tank"]
+            }
+          }
+        },
+        {
+          "name": "Commander Malarus",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081428804/85C88660A6344BDA309990BD1BCA5254EB26D6FE/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "faction": ["First Order"],
+              "rank": ["Heavy"]
+            }
+          }
+        },
+        {
+          "name": "Nightsister Rider",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742458550/DA4B94232A6C585F9052738F990C70095E579256/",
+          "points": 30,
+          "restrictions": {
+            "include": {
+              "unit": ["Rancor"]
+            }
+          }
+        },
+        {
+          "name": "Oddball",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747618963/6FE86EFBC23C8FDFDB87FBE066C60CBD32FF1DFE/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "unit": ["LA-AT/I Gunship"]
+            }
+          }
+        },
+        {
+          "name": "Pirate Hotshot",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556639096066/A06D6ABDA4E9B1B1F2A63187D6B24F13D5D283A5/",
+          "points": 15,
+          "restrictions": {
+            "include": {
+              "unit": ["Canderous Class Assault Tank"]
+            }
+          }
+        },
+        {
+          "name": "Pirate Speed Freak",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556639095451/373D5F83FB4E8F4D3223A3CAD3E6A8E661FAAC2F/",
+          "points": 8,
+          "restrictions": {
+            "include": {
+              "unit": ["Canderous Class Assault Tank"]
+            }
+          }
+        },
+        {
+          "name": "Rose Tico",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1021697620252778721/621B535E20B29F253B38AD3548C986EE0DB42CCF/",
+          "points": 8,
+          "restrictions": {
+            "include": {
+              "faction": ["Resistance"]
+            }
+          }
+        },
+        {
+          "name": "Veteran Gunner",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747586823/256792792FFE8D876759E9A894F76F489BFDE968/",
+          "points": 6,
+          "restrictions": {
+            "include": {
+              "unit": ["AT-AP"]
+            }
+          }
+        },
+        {
+          "name": "Veteran Mechanic",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638970650/AE724920A75FF2F1D840AC3DE707166D67EA0323/",
+          "points": 8,
+          "restrictions": {
+            "include": {
+              "unit": ["Missile Attack Launcher"]
+            }
+          }
+        },
+        {
+          "name": "Veteran Tank Pilot",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556639094597/6678DD776757AAFAFA216FB7538DA7BC35147757/",
+          "points": 5,
+          "restrictions": {
+            "include": {
+              "unit": ["Canderous Class Assault Tank"]
+            }
+          }
+        },
+        {
+          "name": "Warthog",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747618630/E00C8B7A4F81CCD6F2A12747031B7D62D05857E3/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "unit": ["LA-AT/I Gunship"]
+            }
+          }
+        }
+      ],
+      "Relic": [
+        {
+          "name": "Sith Holocron",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747372001/0447B19DFCA692F5AC2D176A7C6C7A1CB53A156B/",
+          "points": 15
+        }
+      ],
+      "Programming": [
+        {
+          "name": "Blitz Programming",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412069009833/BCC52828E3F19620E57D60244623D8A3E5C94135/",
+          "points": 12,
+          "restrictions": {
+            "include": {
+              "unit": ["SD-4K Assassin Droid"]
+            }
+          }
+        },
+        {
+          "name": "Stealth Programming",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412069009272/8CD2CDD81193F051285BF5B44FD7B45AE80FC4B6/",
+          "points": 18,
+          "restrictions": {
+            "include": {
+              "unit": ["SD-4K Assassin Droid"]
+            }
+          }
+        }
+      ],
+      "Training": [
+        {
+          "name": "Advanced Assault Training",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640415256/3E0DA25CB2B44F7093E46DADA1965C0DBD3C703A/",
+          "points": 5,
+          "restrictions": {
+            "include": {
+              "type": ["Mandalorian Trooper"]
+            }
+          }
+        },
+        {
+          "name": "Blend In",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735182379/DD072454059CA2BB5CB206848D0BCBF656F494F9/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "faction": ["Scum"],
+              "rank": ["Commander", "Operative", "Special Forces"]
+            }
+          }
+        },
+        {
+          "name": "Brutality",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741408425/6FED2B70FD2FCEFC6A1A8249888003F3C9798118/",
+          "points": 10
+        },
+        {
+          "name": "Conditioning",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081410188/2D437F005CAE9C5E11B19E2A59D5CB24D58CDB28/",
+          "points": 5,
+          "restrictions": {
+            "include": {
+              "faction": ["First Order"],
+              "rank": ["Corps", "Special Forces"]
+            }
+          }
+        },
+        {
+          "name": "Conditioning ",
+          "displayName": "Conditioning",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081410188/2D437F005CAE9C5E11B19E2A59D5CB24D58CDB28/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "faction": ["First Order"],
+              "rank": ["Commander", "Operative", "Support", "Heavy"]
+            }
+          }
+        },
+        {
+          "name": "Disarming Slash",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747373016/011CE3497BCC2229C114CDBF69464D3FB6E16B26/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "slot": ["Force"]
+            }
+          }
+        },
+        {
+          "name": "Hasty Exit",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747373759/AF9520B70176F54DCB2B098735D1D3F468E9F442/",
+          "points": 3
+        },
+        {
+          "name": "Faithful Companion",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735164302/4C5E96A3397E6BD2F8C07A61AA9B25FDC0D8C031/",
+          "points": 8,
+          "restrictions": {
+            "include": {
+              "unit": ["Beast Master", "Silri"]
+            }
+          }
+        },
+        {
+          "name": "Geonosian Brain Worms",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746957609/4564866DD4465ADC1224AC20C8A82A2895D19FE9/",
+          "points": 0,
+          "restrictions": {
+            "include": {
+              "unit": ["Geonosian Warriors"]
+            }
+          }
+        },
+        {
+          "name": "Rising Phoenix Training",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640409422/F8AF40A8E8F4C87CA364A0ADADA7281F20F8F0D7/",
+          "points": 10,
+          "restrictions": {
+            "include": {
+              "type": ["Mandalorian Trooper"]
+            }
+          }
         }
       ]
-    }
-  },
-  "upgrades": {
-    "Armament": [
-      {
-        "name": "Amped up A-280's",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742002345/F99AB12D9FC7810EC0868DEA0DD3EEFBB15D686E/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "unit": ["Hired Guns"]
-          }
-        }
-      },
-      {
-        "name": "Anakin's Lightsaber",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1027324932753002794/C0A0C19E79DAF7B4B11E6DCEE218AB2F4C385966/",
-        "points": 25,
-        "restrictions": {
-          "include": {
-            "unit": ["Finn"]
-          }
-        }
-      },
-      {
-        "name": "Anakin's Lightsaber Rey",
-        "displayName": "Anakin's Lightsaber",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1027324932753002794/C0A0C19E79DAF7B4B11E6DCEE218AB2F4C385966/",
-        "points": 20,
-        "restrictions": {
-          "include": {
-            "unit": ["Rey"]
-          }
-        }
-      },
-      {
-        "name": "BB-8 Grappling cord",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157660515/A2C7648C32E4AF4B631D2C498E6C76CC97B25925/",
-        "points": 0,
-        "restrictions": {
-          "include": {
-            "unit": ["BB-8"]
-          }
-        }
-      },
-      {
-        "name": "Cody's DC-15a",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747470278/1615C1C3D7C36AA201B25F52D99215DC4D12195C/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "unit": ["Commander Cody"]
-          }
-        }
-      },
-      {
-        "name": "Defilers Blaster",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735211533/50044D04BF35EAE0926C6A86936DC5A2DA95B0FD/",
-        "points": 15,
-        "restrictions": {
-          "include": {
-            "unit": ["Defiler"]
-          }
-        }
-      },
-      {
-        "name": "DC-17m Anti-Armor Config",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747570525/CACD6285B8098528A1E23C5AA68F3EB68076B4DF/",
-        "points": 18,
-        "restrictions": {
-          "include": {
-            "unit": ["Republic Commandos"]
-          }
-        }
-      },
-      {
-        "name": "DC-17m Sniper Rifle Config",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747571113/0AA95599A43D23EDBDA63F1835698A1CBAC6D746/",
-        "points": 20,
-        "restrictions": {
-          "include": {
-            "unit": ["Republic Commandos"]
-          }
-        }
-      },
-      {
-        "name": "Defilers Slug Thrower",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735211196/02C8A1B676C2CFC2A17BFB8819B8C6981DAD74D7/",
-        "points": 15,
-        "restrictions": {
-          "include": {
-            "unit": ["Defiler"]
-          }
-        }
-      },
-      {
-        "name": "DXR-6 Focused Fire Config",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735115917/9E0BA5F8013B1491D5EF74BED3C484BA0F3052AB/",
-        "flip": {
-          "name": "DXR-6 Power Shot Config",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735116297/419AF3D6925D7004CA92BE249969A1BFB42B9742/"
-        },
-        "points": 8,
-        "restrictions": {
-          "include": {
-            "unit": ["Mercenary Assault Squad"]
-          }
-        }
-      },
-      {
-        "name": "Elite Wrist Mounted Flamethrower",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640412575/1F3B56925DC71E5FAFDD405CF117B72CC0DB3B42/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "type": ["Mandalorian Trooper"],
-            "rank": ["Commander", "Operative"]
-          }
-        }
-      },
-      {
-        "name": "Gauntlet Blades",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640410174/FF136859D9C64EFC2B33CEDF111204596228A4B0/",
-        "points": 6,
-        "restrictions": {
-          "include": {
-            "unit": ["Bo-Katan Kryze"]
-          }
-        }
-      },
-      {
-        "name": "Hondo's Electrostaff",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738475192/6004D55A77E10329CE6EABD01DE46D1BB2DF1572/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "unit": ["Hondo Ohnaka"]
-          }
-        }
-      },
-      {
-        "name": "Illegally Modified E-11's",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742002948/59F017866F7B7293C00FED3BA937D371B7E71C0A/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "unit": ["Hired Guns"]
-          }
-        }
-      },
-      {
-        "name": "Quicksilver Baton",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1021696515357818157/FAAC5F19359BE39BD499A8BA18F7D790FD5A7562/",
-        "flip": {
-          "name": "Phasma's SE-44 Blaster",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1021696515357818372/8C90C1594751F45D7F199F0FE3D264E79C43E27D/"
-        },
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "unit": ["Captain Phasma"]
-          }
-        }
-      },
-      {
-        "name": "Static Pikes",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746953521/48A9A9BFC5662EA0496E1533D16AAE84DB4CCE48/",
-        "points": 6,
-        "restrictions": {
-          "include": {
-            "unit": ["Geonosian Warriors"]
-          }
-        }
-      },
-      {
-        "name": "Wrist Rocket",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640428446/AE6DB75F1A3643AF7DCB7CA1BA8DAFF87E7A5C8A/",
-        "points": 6,
-        "restrictions": {
-          "include": {
-            "type": ["Mandalorian Trooper"]
-          }
-        }
-      },
-      {
-        "name": "Whistling Birds",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640411728/A3BCBA7C1B49EE5B996A55A8FC6CB581A9EAA96C/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "type": ["Mandalorian Trooper"],
-            "rank": ["Commander", "Operative"]
-          }
-        }
-      },
-      {
-        "name": "Wrist Mounted Blasters",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640413937/745B5BEAD23640A8222A54287029ACF70F9A81EE/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "type": ["Mandalorian Trooper"]
-          }
-        }
-      },
-      {
-        "name": "Wrist Mounted Flamethrower",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640416270/08971192288A83DD208F4D91D02703E094090133/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "type": ["Mandalorian Trooper"]
-          }
-        }
-      },
-      {
-        "name": "Z-6 Riot Control baton",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752981376/8F2F3430452BDBD8DD78E48243BCECEA994DF1AC/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "unit": ["Finn"]
-          }
-        }
-      }
-    ],
-    "Command": [
-      {
-        "name": "Racketeering",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735072829/84C080C8B919D06884AF3BC12ADDB58B524C5271/",
-        "points": 5,
-        "restrictions": {
-          "include": {
-            "unit": ["Tyber Zann"]
-          }
-        }
-      }
-    ],
-    "Comms": [
-      {
-        "name": "B1's Datapad",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1021698068155822603/B74DFBDE71FC462A482C92AF02C57AD2C6373E0F/",
-        "points": 6,
-        "restrictions": {
-          "include": {
-            "unit": ["Salvaged B2 Battle Droids"]
-          }
-        }
-      },
-      {
-        "name": "Proximity Signal",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743573243/8687C5FADEF63558D5088A664E51ACF3C9D3D172/",
-        "points": 6,
-        "restrictions": {
-          "include": {
-            "unit": ["SD-4K Assassin Droid"]
-          }
-        }
-      }
-    ],
-    "Counterpart": [
-      {
-        "name": "BB-8",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1022824296871784739/BA69ED4E4B2926D1C9E5FB255791569EB5AA7A05/",
-        "points": 25,
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068157620585/9E7930221D8CD87F6338B9D4B58F4D3F824D08C0/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068157620780/493748852320ED988465533F8BC49FEA2672A9E8/"
-        },
-        "restrictions": {
-          "include": {
-            "faction": ["Resistance"],
-            "unit": ["Rose Tico", "Rey", "Poe Dameron", "Finn", "R2-D2"]
-          }
-        }
-      },
-      {
-        "name": "C-3PO",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1616219505080628828/F6A01DB4DFDB1A518FC4E373D72237AB1B31300B/",
-        "points": 15,
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/776232727456807069/DE7E32B39455DB5111769436FD0C5BFDA3841268/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/777357228032306506/D60CB8A1159723917EF1831D4042318A67458A7A/"
-        },
-        "restrictions": {
-          "include": {
-            "unit": ["R2-D2"]
-          }
-        }
-      },
-      {
-        "name": "Salacious B. Crumb",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741310541/C8ADFE085EC634C8766C303BD1F89D230BEADEBE/",
-        "points": 10,
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984838966754/DCEED639BB3AA1D36A2AF82B26708EF4007A3583/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984838966978/51C97B6161C17AE3229372F0C26331EAD0D44200/"
-        },
-        "restrictions": {
-          "include": {
-            "unit": ["Jabba The Hutt"]
-          }
-        }
-      },
-      {
-        "name": "Vornskr's",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741832560/CFA25E88275C65CC80ACE518A3DBDB2C4235E061/",
-        "points": 15,
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697620252875766/48FF7F717DEA00FCE1E830FD4FA888494433370A/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697620252875970/2006E4E0DA5EA0DEEEB1B3982D975944B8F9DC7B/"
-        },
-        "restrictions": {
-          "include": {
-            "unit": ["Beast Master"]
-          }
-        }
-      }
-    ],
-    "Crew": [
-      {
-        "name": "D-93 Incinerator",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1022821664192160937/FE5410F1E6458AA427B97E1D9A909FCD8EE099A1/",
-        "points": 24,
-        "restrictions": {
-          "include": {
-            "unit": ["Light Infantry Utility Vehicle"]
-          }
-        }
-      },
-      {
-        "name": "F-11D Blaster Rifle Gunner",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1021696515357811074/8EA7C690EEF82E31B1B5300C604076EAEA6B8007/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "unit": ["Light Infantry Utility Vehicle"]
-          }
-        }
-      },
-      {
-        "name": "First Order Officer",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1027325137554520003/07103992D66251E0D15B74EDCFD29ED861FA1055/",
-        "points": 8,
-        "restrictions": {
-          "include": {
-            "unit": ["Light Infantry Utility Vehicle"]
-          }
-        }
-      },
-      {
-        "name": "FWMB-10 Megablaster ",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1027325137553485519/1CDC601DC66624341BF4A98928094D5DB4AEAF0E/",
-        "points": 30,
-        "restrictions": {
-          "include": {
-            "unit": ["Light Infantry Utility Vehicle"]
-          }
-        }
-      }
-    ],
-    "Flaw": [
-      {
-        "name": "I'll Bet You Have",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741747564/7E279CBA3100D1D5A3E4B5D9EBD362D57373ABE8/",
-        "points": 0
-      }
-    ],
-    "Force": [
-      {
-        "name": "Acolyte Force Lightning",
-        "displayName": "Force Lightning",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278090576/86604BC87F9AB158776F63811C23AB3AE058722A/",
-        "points": 5,
-        "restrictions": {
-          "include": {
-            "faction": ["Sith Empire"]
-          }
-        }
-      },
-      {
-        "name": "Chain Lightning",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278091219/1C7C89C5537F9B248294B44DADC5F24D181892C2/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "faction": ["Sith Empire"]
-          }
-        }
-      },
-      {
-        "name": "Force Dash",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747371109/7290AD045A9201DA40F367CAD1FF04C1615B9851/",
-        "points": 9
-      },
-      {
-        "name": "Force Lightning",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747371606/231C69EF773D74B95CCC5EB34F1EB96C1119FA98/",
-        "points": 12,
-        "restrictions": {
-          "include": {
-            "alignment": ["Dark"]
-          }
-        }
-      },
-      {
-        "name": "Force Rend",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747370532/B97ADF8AC0302E13A315C68402376409B45A5FFE/",
-        "points": 17,
-        "restrictions": {
-          "include": {
-            "alignment": ["Dark"]
-          }
-        }
-      },
-      {
-        "name": "Force Statis",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747369898/5CC327BAEB59E3B817B71AFF6EC21D3E14ADB4A2/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "alignment": ["Dark"]
-          }
-        }
-      },
-      {
-        "name": "Maglus Force Lightning",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277562964/22A352A0E0EF8FE27B1DF1F19C08A80CE1564B3C/",
-        "points": 5,
-        "restrictions": {
-          "include": {
-            "unit": ["Darth Malgus"]
-          }
-        }
-      }
-    ],
-    "Gear": [
-      {
-        "name": "Bacta Auto-Dispenser",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747571812/21DA4C0C9811D5252F4FAB4E7F10B358FC74C2BA/",
-        "points": 20,
-        "restrictions": {
-          "include": {
-            "unit": ["Republic Commandos"]
-          }
-        }
-      },
-      {
-        "name": "Electro Grappling Line",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640414601/68D77CCDC40F2F1F103F1AF7568727FA6F9E8CE9/",
-        "points": 3,
-        "restrictions": {
-          "include": {
-            "type": ["Mandalorian Trooper"]
-          }
-        }
-      },
-      {
-        "name": "JT-12 Jetpack",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747527633/AF0E4FAA5C2D92BD45DC40252B9ADAB003A5FC5F/",
-        "points": 5,
-        "restrictions": {
-          "include": {
-            "unit": ["Commander Colt"]
-          }
-        }
-      },
-      {
-        "name": "Jump pack",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751974753/5AF713EB09F4AFDF88B76C8CB9F54CE4D0BEB7D8/",
-        "points": 0,
-        "restrictions": {
-          "include": {
-            "unit": ["Phase II Darktroopers"]
-          }
-        }
-      },
-      {
-        "name": "Personal Combat Shield",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640410953/DEF506B2DB3747BF1DD5ABBECEB36764450D0B7C/",
-        "points": 15,
-        "restrictions": {
-          "include": {
-            "type": ["Mandalorian Trooper"]
-          }
-        }
-      },
-      {
-        "name": "Target Designator",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638971560/0F6F9FB93CD712E0D2B5916DE3392EF98BDAB3DC/",
-        "points": 6,
-        "restrictions": {
-          "include": {
-            "faction": ["Scum"]
-          }
-        }
-      },
-      {
-        "name": "Vambrace Reloader",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640415774/E6C7E28AAA6C1EC3CB460AE5947F2AAE2960EF15/",
-        "points": 3,
-        "restrictions": {
-          "include": {
-            "type": ["Mandalorian Trooper"]
-          }
-        }
-      }
-    ],
-    "Generator": [
-      {
-        "name": "Class-5B1 Duplex Generator",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747375028/7DEFD098875FF94FD712C2FB42C37218AE5F95D9/",
-        "points": 10
-      },
-      {
-        "name": "GNK-series Power Droid",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747374218/EBE238DB2CCD3F06AC1CC96325D04FEE2B5ECD1C/",
-        "points": 5
-      },
-      {
-        "name": "Ion Generator",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747374603/462C32A767195B287E9FFCFC73BD0FA798F982DF/",
-        "points": 10
-      },
-      {
-        "name": "Scavenged Generator",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1022824296871788518/1BB5B0A6D3E8BDA3F3E66F6ED7B4E30BC24C4C3E/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "faction": ["Resistance", "Rebel"]
-          }
-        }
-      },
-      {
-        "name": "Targeted Generator",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742526797/6A85F0CB99FE4DB7DCFD7DA3EDF1E04B4D1A56DC/",
-        "points": 7,
-        "restrictions": {
-          "include": {
-            "unit": ["EWHB-12 Heavy Blaster team"]
-          }
-        }
-      }
-    ],
-    "Grenades": [
-      {
-        "name": "Cluster Grenades",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640427155/BAB17778B9558A117B7672B361169E1429B8FFBD/",
-        "points": 5,
-        "restrictions": {
-          "include": {
-            "type": ["Mandalorian Trooper"]
-          }
-        }
-      },
-      {
-        "name": "Cryoban Grenade",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747372562/020D8C7E51888C66929A5C68BC64CF2A0751AB96/",
-        "points": 10
-      },
-      {
-        "name": "Concussive Discs",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743157047/93145CADA2644E48715594A16814C0B588B09264/",
-        "points": 7,
-        "restrictions": {
-          "include": {
-            "unit": ["IG-88"]
-          }
-        }
-      }
-    ],
-    "Hardpoint": [
-      {
-        "name": "Auto Loader",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638973875/12A8A6DAC58F8AD954452CFC4B0DC38ED932407B/",
-        "points": 5,
-        "restrictions": {
-          "include": {
-            "unit": ["Missile Attack Launcher"]
-          }
-        }
-      },
-
-      {
-        "name": "Chain-Fed Missile Launcher",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743540463/2FDD9391217B4D3C83489ACFC70B5D4D70D828AF/",
-        "points": 8,
-        "restrictions": {
-          "include": {
-            "unit": ["Octuptarra Tri-Droid"]
-          }
-        }
-      },
-      {
-        "name": "D-98 Incinerator",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1022821664192160937/FE5410F1E6458AA427B97E1D9A909FCD8EE099A1/",
-        "points": 24,
-        "restrictions": {
-          "include": {
-            "unit": ["Light Infantry Utility Vehicle"]
-          }
-        }
-      },
-      {
-        "name": "Ball Turrets",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747617309/E7A1C86302FE190A75A859B3405353D24B56AA93/",
-        "points": 20,
-        "restrictions": {
-          "include": {
-            "unit": ["LA-AT/I Gunship"]
-          }
-        }
-      },
-      {
-        "name": "Defoliator Missile Launcher",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743618077/FD3FF4AAAA791E2B578007273E93859B7FA12E6E/",
-        "points": 28,
-        "restrictions": {
-          "include": {
-            "unit": ["Defoliator Deployment Tank"]
-          }
-        }
-      },
-      {
-        "name": "Dorsal Laser Cannon",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747586054/E0CA1658DB7AB53E43598B3506A980E595D78AA8/",
-        "points": 16,
-        "restrictions": {
-          "include": {
-            "unit": ["AT-AP"]
-          }
-        }
-      },
-      {
-        "name": "Enhanced Stabilizers",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747587543/837CEB0047D91D5ADEB112F08F19C456609042D9/",
-        "points": 14,
-        "restrictions": {
-          "include": {
-            "unit": ["AT-AP"]
-          }
-        }
-      },
-      {
-        "name": "Enhanced Targeting Computer",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743649603/CC9BB61488A9EDD358521E3E62D73A316BC07F23/",
-        "points": 8,
-        "restrictions": {
-          "include": {
-            "unit": ["IG-227 Hailfire-Class Droid Tank"]
-          }
-        }
-      },
-      {
-        "name": "EWHB-12 Blaster Turret",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743064886/381FF3A3AED8050E5BDF1E3A4EC6B6DC2608B4EE/",
-        "points": 28,
-        "restrictions": {
-          "include": {
-            "unit": ["WLO-5 Battle Tank"]
-          }
-        }
-      },
-      {
-        "name": "Expanded Launch Tubes",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638975154/0F3C24800735B4BB8E0B156258FF032116C503F0/",
-        "points": 4,
-        "restrictions": {
-          "include": {
-            "unit": ["Missile Attack Launcher"]
-          }
-        }
-      },
-      {
-        "name": "Fire Direction Center",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638972654/A3E6D0BCB701B2DEFB788DA9CEB3F163F4025EEF/",
-        "points": 8,
-        "restrictions": {
-          "include": {
-            "unit": ["Missile Attack Launcher"]
-          }
-        }
-      },
-      {
-        "name": "FWMB-10 Megablaster",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1027325137553485519/1CDC601DC66624341BF4A98928094D5DB4AEAF0E/",
-        "points": 30,
-        "restrictions": {
-          "include": {
-            "unit": ["Light Infantry Utility Vehicle"]
-          }
-        }
-      },
-      {
-        "name": "Ion Cannon",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638673967/DCE9270CEAD120F4DD068CDF23C326E2371DC75C/",
-        "points": 15,
-        "restrictions": {
-          "include": {
-            "unit": ["Droideka MKII"]
-          }
-        }
-      },
-      {
-        "name": "Magna Chain-Fed Missile Launcher",
-        "displayName": "Chain-Fed Missile Launcher",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743671604/F03AE6E7CE4E84CDA2D22BBD7B6A2BE97F45437B/",
-        "points": 20,
-        "restrictions": {
-          "include": {
-            "unit": ["Octuptarra Magna Tri-Droid"]
-          }
-        }
-      },
-      {
-        "name": "Magna Plague Carrier",
-        "displayName": "Plague Carrier",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743671273/2C55E19F1F47BABA103DCA4ECA92471CEA8D503A/",
-        "points": 5,
-        "restrictions": {
-          "include": {
-            "unit": ["Octuptarra Magna Tri-Droid"]
-          }
-        }
-      },
-      {
-        "name": "MS-1 Medium Laser Turret",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743066443/2CF2905266AA4BDE3F40F755F800CB0E0A3392A6/",
-        "points": 20,
-        "restrictions": {
-          "include": {
-            "unit": ["WLO-5 Battle Tank"]
-          }
-        }
-      },
-      {
-        "name": "Plague Carrier",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743540072/7D3F2EBDCE33584ED931379EFF49B8A3E26789C7/",
-        "points": 15,
-        "restrictions": {
-          "include": {
-            "unit": ["Octuptarra Tri-Droid"]
-          }
-        }
-      },
-      {
-        "name": "Probe Killer Swarm",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743572146/A9C25E9C8099DED5F453F3B84B2FAC0D72FAF367/",
-        "points": 0,
-        "restrictions": {
-          "include": {
-            "unit": ["SD-4K Assassin Droid"]
-          }
-        }
-      },
-      {
-        "name": "Proton Missile Launcher",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743617683/7B7D562698834D3ACEC51A5BC5BC6B148F4C55A4/",
-        "points": 20,
-        "restrictions": {
-          "include": {
-            "unit": ["Defoliator Deployment Tank"]
-          }
-        }
-      },
-      {
-        "name": "Raised Mono-Ski",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1021697620252782821/C642C07229E6BDCA7AA79F99D34328383622F962/",
-        "flip": {
-          "name": "Lowered Mono-Ski",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1021697620252782950/AE54FB7E97854E2621BC3F9EB314F432DBE1EC75/"
-        },
-        "points": 0,
-        "restrictions": {
-          "include": {
-            "unit": ["V-4X-D Ski Speeder"]
-          }
-        }
-      },
-      {
-        "name": "Rapid Fire Launchers",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743649159/0BAF4A7EC12DAC1AEB13A22120D2D3B1FA1BC0B6/",
-        "points": 14,
-        "restrictions": {
-          "include": {
-            "unit": ["IG-227 Hailfire-Class Droid Tank"]
-          }
-        }
-      },
-      {
-        "name": "Sealed Blast Shields",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747617819/F41341A8EA3FDEBA78238EC8298691A0E2C5248C/",
-        "points": 0,
-        "restrictions": {
-          "include": {
-            "unit": ["LA-AT/I Gunship"]
-          }
-        }
-      },
-      {
-        "name": "Transport Rack",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743692647/47DDE4B573774D76E0DD110994DEEF3C2F0406BB/",
-        "points": 20,
-        "restrictions": {
-          "include": {
-            "unit": ["HMP Droid Gunship"]
-          }
-        }
-      },
-      {
-        "name": "Tri Laser Cannons",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638674750/6057A2DACA2F104F889921E46FF3AC717DE4B962/",
-        "points": 25,
-        "restrictions": {
-          "include": {
-            "unit": ["Droideka MKII"]
-          }
-        }
-      },
-      {
-        "name": "Wing Ball Turrets",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747616297/2753260BCF4BD591144C4D74769F5E982D4E9D10/",
-        "points": 14,
-        "restrictions": {
-          "include": {
-            "unit": ["LA-AT/I Gunship"]
-          }
-        }
-      }
-    ],
-    "Heavy Weapon": [
-      {
-        "name": "ACP Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735115264/1D92758AC20C28AA48019DCD564E31D271B20A2C/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068156270983/519A43ACE1F5461D51AA1BA81ADF4A5C37BEF9E4/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068156271135/318D90BCDE4E3E362797A38823A21FF17FAF651E/"
-        },
-        "points": 30,
-        "restrictions": {
-          "include": {
-            "unit": ["Mercenary Assault Squad"]
-          }
-        }
-      },
-      {
-        "name": "B1",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1021698068155818428/717521A597961079FBE4E4121DECAF4F0ED00471/",
-        "points": 16,
-        "restrictions": {
-          "include": {
-            "unit": ["Salvaged B2 Battle droids"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/785234780869166347/AA861F86A0B74CF335533E425A6CBACB99395A09/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/785234780869166529/263C2AB95B1743539EC2CBDE40B0A14B1F5E5693/"
-        }
-      },
-      {
-        "name": "BD-1 Vibroaxe Guard",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741407943/466AB5745404A77F5156D5AF55160CCB52545A50/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407431287477/62E1591E99BD747C7C130C3D4B5F70CA6FFA34B2/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407431272263/BBD5D7D12BC2B61E0C88AA50721BDD40AF766FF7/"
-        },
-        "points": 25,
-        "restrictions": {
-          "include": {
-            "unit": ["Gamorrean Gaurds"]
-          }
-        }
-      },
-      {
-        "name": "Beam Blaster Elite",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746958937/58D737AAB1676A6450C545CEE6299DBC19AF6E59/",
-        "points": 38,
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318091926/A474DAED7A90C67374FC60462D9A34FA7A29261F/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893318085783/83580E45A97E753127E6E4D5E221E5227B35E6A4/"
-        },
-        "restrictions": {
-          "include": {
-            "unit": ["Geonosian Warriors"]
-          }
-        }
-      },
-      {
-        "name": "Blaster Lance Droid",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742382205/FD43E6FF2AEF649B5A4A59B02630F602BEAE2C42/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407432789217/7FA6CC4082ED2BA4F96DB4A6A32DC268B55A924A/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432781824/644CE23A0B74C79BF20698A408FCF00D319EA7BE/"
-        },
-        "points": 30,
-        "restrictions": {
-          "include": {
-            "unit": ["IG-86 Sentinel Droids"]
-          }
-        }
-      },
-      {
-        "name": "Boarding Shotgun Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277786673/D0232B6BBE5FA4816C85DF20383B0892B8151979/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692419888092880/788628E64550196C6371C2B129FEB590CC2691DE/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
-        },
-        "points": 24,
-        "restrictions": {
-          "include": {
-            "unit": ["Sith Empire Boarding Troopers"]
-          }
-        }
-      },
-      {
-        "name": "Commander Pyre",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1022824296877112254/0BFC3B6F4510CEA964BB8F2B8B45A56FF6CE6E34/",
-        "points": 30,
-        "leader": true,
-        "restrictions": {
-          "include": {
-            "faction": ["First Order"],
-            "rank": ["Corps"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027325137553590946/9E9D1E1798483BDDE43862B03D2424FB7B68EBB0/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027325137553591247/46CE15787E0615D89B2D6931B1BCDE53F1D2B954/"
-        }
-      },
-      {
-        "name": "Concussion Rifle Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735114688/7F06A4AA27BBEFE8D08FF392CB8E7E8FC4083F6B/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068156271785/233649FA9B56D451B97E71E706C777AD529B0810/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068156271944/671F0E7483F7DA3D92D551E5042698EE06E510EB/"
-        },
-        "points": 30,
-        "restrictions": {
-          "include": {
-            "unit": ["Mercenary Assault Squad"]
-          }
-        }
-      },
-      {
-        "name": "Cycler Rifle Sniper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638840781/F5E96AC72E6D27DDA4AAC1467261D01B33AAD476/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068156464799/C000C8B3CF81A11687F6B39574ACE73A8FEF1A28/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068156464974/774C639F2300D7816E654D8276585556DEAD6432/"
-        },
-        "points": 30,
-        "restrictions": {
-          "include": {
-            "unit": ["Infiltrators"]
-          }
-        }
-      },
-      {
-        "name": "CY-M Carbine Geonosian",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746958335/3F471B7803B243D2ED9C1A3E69C86655874E3AAE/",
-        "points": 25,
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318084126/7B0D406E30E73FC005FA1AB1258738A91908E9D0/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893318095905/A0476F5F976ACE1C0BCE6F1D5C12085DBF6628B7/"
-        },
-        "restrictions": {
-          "include": {
-            "unit": ["Geonosian Warriors"]
-          }
-        }
-      },
-      {
-        "name": "DC-15 Paratrooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747551847/74C7612A3CD055BEF6F7ED101DCC13AC2EF96D2F/",
-        "points": 34,
-        "restrictions": {
-          "include": {
-            "unit": ["Clone Paratroopers"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693290506984196/E1DADD867AD088A500B4D44B6966A1BDA6F1A62A/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
-        }
-      },
-      {
-        "name": "Death Watch Duelist",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736282375/F5A9EF30A976727C91F3C880E7B603D827086B6F/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357841451/50164A1C84E6D119BC45BDD31C8209ED7D9A0F29/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515357841757/1DC29C81D9DFCB2FB7D8A3B2EA2F2ABD3F416396/"
-        },
-        "points": 25,
-        "restrictions": {
-          "include": {
-            "unit": ["Death Watch Fireteam"]
-          }
-        }
-      },
-      {
-        "name": "Death Watch Fireteam Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736282915/B810832E8ACDF94B56D90DE60C159FE0A5FF77D2/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357844380/B08FE1606E634293EBE16FFD9541B5F7C801E2CF/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886427771/60D6CA1D97D822A2222E4FAF614931265B7B0AF2/"
-        },
-        "points": 18,
-        "restrictions": {
-          "include": {
-            "unit": ["Death Watch Fireteam"]
-          }
-        }
-      },
-      {
-        "name": "Death Watch Marksman",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736284088/EF0FB8D721EE6297963990219E9FC01B1A0AB940/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886436522/D0CBBE1EB66E7A3FEECA1A6DF0FEF6F352287404/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886436834/E27641C0A96264724D710A4B3F912F543CF9413E/"
-        },
-        "points": 34,
-        "restrictions": {
-          "include": {
-            "unit": ["Death Watch Fireteam"]
-          }
-        }
-      },
-      {
-        "name": "Detonite Charge Saboteur",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638839094/D0D81BD4107CD9647D5C041676865BAA1CFF027D/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068156470652/C2D7BF3AADDECA01B8C5442DF6419D2F1FF2389B/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068156470835/5E87EEBFF97975FF1A8985808C26B645EC53CAAC/"
-        },
-        "points": 28,
-        "restrictions": {
-          "include": {
-            "unit": ["Infiltrators"]
-          }
-        }
-      },
-      {
-        "name": "Disruptor Rifle Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277743519/060D5A5B2B512DF5E41BD6923EF07C064EEC1E7C/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608881149656/B3DDF1010726FDC59F24ACC4375251D7919F6135/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608881150442/1B5AD6129AC8D180D97CFE93ACE1DC7E49119F04/"
-        },
-        "points": 22,
-        "restrictions": {
-          "include": {
-            "unit": ["Sith Empire Troopers"]
-          }
-        }
-      },
-      {
-        "name": "DLA-13 Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277745430/15ED754DCBAE03022CE8D08671C057280FE90B7F/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608879755028/53718ACF3D389983D1CF2630D761DF90121CDA5A/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608879744395/158047D5CFC30AFE6A2A50F64A2DA8F7BD4073B4/"
-        },
-        "points": 20,
-        "restrictions": {
-          "include": {
-            "unit": ["Sith Empire Troopers"]
-          }
-        }
-      },
-      {
-        "name": "EL-16HFE Fighter",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1021697756245234129/D1D2CFCCD4C29B15FEBC3BB12EE0E66292729C1F/",
-        "points": 25,
-        "restrictions": {
-          "include": {
-            "unit": ["Resistance Trench Fighters"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248448323/8992031636B30867375FF6724079096F6F95F5B0/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248448499/974E02AC778A5EFD4EF7F33F393B06B71ADF20A6/"
-        }
-      },
-      {
-        "name": "F-11ABA Sith Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1021698013227711861/16961898A803EC288A40070BDB7D141BC1906146/",
-        "points": 28,
-        "restrictions": {
-          "include": {
-            "unit": ["Jet Troopers"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698013227868656/38A393B4932FF16ABF01AAB99C280BA4C224FE25/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698013227868793/0A4C85E66B3E68C4DDCF3D191D1E9E8B809C0727/"
-        }
-      },
-      {
-        "name": "F-11D Assault Cannon Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277928461/7263E2C1EF01981353B16786CB01441C92A7D941/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824477681555675/1E4C571546078FEFFD4E753CBBC08EF18CBD0342/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824477681548557/DB63AB0044B89CB25D50A204A061D535CA20F495/"
-        },
-        "points": 30,
-        "restrictions": {
-          "include": {
-            "unit": ["Sith Empire Support Troopers"]
-          }
-        }
-      },
-      {
-        "name": "FN-2199",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1021696515357805228/702A97A7046BE5DAEF36AABF904646C94AABDD36/",
-        "points": 28,
-        "restrictions": {
-          "include": {
-            "unit": ["First Order Stormtroopers"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821972716827731/5B0D97A839084D07EA0B8A1F6C925732D300D681/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821972716828171/0331B4B577F867C2D647DDC63E4F201D400D679E/"
-        }
-      },
-      {
-        "name": "FWMB-10K Stormtrooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1022821770981190994/4B03222501F4E1716959B212056B70181DC339B9/",
-        "points": 28,
-        "restrictions": {
-          "include": {
-            "unit": ["First Order Stormtroopers"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804930752354/251CAAD6FBAED5982A2DE07F97E73DAC15AA9B0F/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804930752683/A8A5605318AA4D5D0E86706390784598DFE8E1D9/"
-        }
-      },
-      {
-        "name": "First Order Executioner",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1021696350890090133/D430B582E137E426633BE4D0EC35D97D71FB9819/",
-        "points": 24,
-        "restrictions": {
-          "include": {
-            "unit": ["First Order Stormtroopers"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804931312746/A2A7E0ED462A3CC61067CD54DD75FE3EDB6FBB96/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804931312990/768DB3CC7A9A7C481E90874F6D0EBA7B76830145/"
-        }
-      },
-      {
-        "name": "First Order Flametrooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1027324712401825470/9FE69AE8FFC0F1EE99DEC7C8BF0DF4C36021F2A8/",
-        "points": 22,
-        "restrictions": {
-          "include": {
-            "unit": ["First Order Stormtroopers"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804930743225/47AC918E4F8214D21DFA7F41A1BFDC7DDC03AEC0/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804930743458/9AE62864563BECCC50045802E4B9F010B9C34098/"
-        }
-      },
-      {
-        "name": "G125 Projectile Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1021698013227713390/EF8FABB6B92308584C31C4A822E62F2F5020EFFC/",
-        "points": 34,
-        "restrictions": {
-          "include": {
-            "unit": ["Jet Troopers"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698013227867905/C5D8EACB94ED7499B8B9396A430BE3E3B0074D3D/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698013227868129/0C5AB5D1F2332F71B7DFCD4F74272056F8D4A82A/"
-        }
-      },
-      {
-        "name": "Gi/9 Cannon Hired Gun",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742003564/A822E18141D6C082B017F73378B458F77F1685EF/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138166568/ED8EA2877D68277418CD413C22E7298490A0E88A/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138166740/961EBEFD298B956494AD8C52FAE4089A66129240/"
-        },
-        "points": 22,
-        "restrictions": {
-          "include": {
-            "unit": ["Hired Guns"]
-          }
-        }
-      },
-      {
-        "name": "Heavy Blaster Cannon Gunner",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736281792/283829A6193016BD5AF9264D1E90D59D07D7125A/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357847983/815BAE46D59A5AE4EE98449FF47A9F4E1F5FF4F7/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515357848221/4A5E3289B5C619501C33A169426DCEEE5F31C670/"
-        },
-        "points": 34,
-        "restrictions": {
-          "include": {
-            "unit": ["Death Watch Fireteam"]
-          }
-        }
-      },
-      {
-        "name": "Hutt Cartel lieutenant",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741194306/575F31C4867CAD2378D7FC8C57B97BE1BC7168C2/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132349796/F0D00662C6C5F6DC99EA86808B428D1A13E5F062/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132349987/DE29CB1DE563DCFE69E72C45F89F7BA994DA9599/"
-        },
-        "leader": true,
-        "points": 26,
-        "restrictions": {
-          "include": {
-            "unit": ["Hutt Cartel Troopers"]
-          }
-        }
-      },
-      {
-        "name": "Hyperstorm Heavy Cannon Gunner",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277928814/8CB3DD46BE7B2AFC9558DF5180F6FD6DAB46EFAE/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824477681557142/6A6BB38909200F986FCC00C6ED6D09B055D780BE/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824477681557325/B9CACA9DF2EB9B7AAC473686F3E8597B000E1387/"
-        },
-        "points": 32,
-        "restrictions": {
-          "include": {
-            "unit": ["Sith Empire Support Troopers"]
-          }
-        }
-      },
-      {
-        "name": "IQA-11 Sniper Droid",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742382638/9E6E5FD638CB2D2304CD6621F66CA7E1529785FC/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407432785196/AFC423350DB19E06E25D2B7B67DF95CA3323FBEF/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432781824/644CE23A0B74C79BF20698A408FCF00D319EA7BE/"
-        },
-        "points": 32,
-        "restrictions": {
-          "include": {
-            "unit": ["IG-86 Sentinel Droids"]
-          }
-        }
-      },
-      {
-        "name": "Jannah",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1022821770986743715/2D901A3B93E61AA15B16922B7C314BFE18FE079B/",
-        "points": 65,
-        "restrictions": {
-          "include": {
-            "unit": ["Orbak Riders"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770976479474/71199B4B530A5D511E21B37E7AAE4D28AEF8F799/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770976479691/41E9EEF26B5B57FE44F5ED0C4B2912F09827F465/"
-        }
-      },
-      {
-        "name": "Kronos-327",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742383051/E35635E0213C5BF6D3DECFF3DEBAEB53385737AE/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407432807943/6854E55A0F61C5DE97189B6CAC90202E6BC1F622/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432805568/E1F93A35700D25A3C33BA87AD4D64514795D6FDE/"
-        },
-        "leader": true,
-        "points": 34,
-        "restrictions": {
-          "include": {
-            "unit": ["IG-86 Sentinel Droids"]
-          }
-        }
-      },
-      {
-        "name": "M-45 Ion Fighter",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1017194020628455620/5C9E4D9872161408669629A2BD9455804F3BFBB7/",
-        "points": 27,
-        "restrictions": {
-          "include": {
-            "unit": ["Resistance Trench Fighters"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248443153/7D7FF98B537193A399A5974FF7CA73941E6D80AD/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248443360/6BD1A35DC4787C5086210BA1A0436B983B39B4CE/"
-        }
-      },
-      {
-        "name": "Mantellan Frontline Cannon Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277928133/6CF94D4B6DA81B997D2E3BC9438CB8254F39BC0D/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824477681558249/5B7DA9706523B65997C0F39E0E3BCF6FA82F7628/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824477681547387/758CB297CD1211353CBBC992035532A98F53893E/"
-        },
-        "points": 30,
-        "restrictions": {
-          "include": {
-            "unit": ["Sith Empire Support Troopers"]
-          }
-        }
-      },
-      {
-        "name": "Mercenary Assault Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735114176/44B42375B5C11B5BADA3029FC1BF45BBCE56575C/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365878231/A04BECDA5804E0A38FF974528C70AB5AAAE4B715/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365878394/8AD2A611C51D78184D8E4204A720C59EEC2C7755/"
-        },
-        "points": 18,
-        "restrictions": {
-          "include": {
-            "unit": ["Mercenary Assault Squad"]
-          }
-        }
-      },
-      {
-        "name": "Modified E-5C Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741194755/20A0EFE3551FB3F616037ECA2A6B085B32437E09/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132330046/E57A960285EF5FF9C8519B41BAF73C3AFE2E9910/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132330505/2C66A444F87C08CCD808F9EC32307C893552204A/"
-        },
-        "points": 24,
-        "restrictions": {
-          "include": {
-            "unit": ["Hutt Cartel Troopers"]
-          }
-        }
-      },
-      {
-        "name": "MPL-57 Ion Snowtrooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1027324712401811871/E72128C4177183A0F428A140EBA3B6A12803895E/",
-        "points": 24,
-        "restrictions": {
-          "include": {
-            "unit": ["First Order Stormtroopers"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804930745597/D46A49EBCC75A7E442CE5B9B393880CAA55411EC/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804930745893/C3D0240348A1F44EB8D086D4AC626DCCFA1DB209/"
-        }
-      },
-      {
-        "name": "Orback Rider",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1022821770986745583/D188E40D6063DA1246C0DD94216E458C45B6FDE6/",
-        "points": 45,
-        "restrictions": {
-          "include": {
-            "unit": ["Orbak Riders"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770976472837/B6A4F9FAEAF8F6DC50A4EB8CE30D1D9D62CE1477/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770976472996/354C4EE85A60585BD0FB817AFEE21D00E93799BA/"
-        }
-      },
-      {
-        "name": "Ordnance launcher trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742001131/D2429556F4177E933131B739E7E038AA5546B250/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138167432/E485629FA5F7F44891F3DE6ECF6C0F8726AD1AE3/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138184470/30F29A14D05E0FF6A5153C51E7DFC770706D0119/"
-        },
-        "points": 27,
-        "restrictions": {
-          "include": {
-            "unit": ["Hired Guns"]
-          }
-        }
-      },
-      {
-        "name": "Proton Charge Commando",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277967164/198C348A7F75677615C77AC57C0229F6B0934D03/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024261154211/0A0578275AD73052B08D31C272B3AD066484EFEB/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260988667/8B8E27DFEDD6DEBA4EFABD6E738D3B6AC3E925AB/"
-        },
-        "points": 30,
-        "restrictions": {
-          "include": {
-            "unit": ["Sith Empire Boarding Troopers", "Imperial Commandos"]
-          }
-        }
-      },
-      {
-        "name": "Rose Tico",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1021697620252778506/96583F29F6DDE41276C77D92C892C2DE8965A086/",
-        "leader": true,
-        "points": 28,
-        "restrictions": {
-          "include": {
-            "faction": ["Resistance"],
-            "rank": ["Corps"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697601906861807/C7CB31D9AFAFF6C7B2633663A2A33D939F4E8205/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697601906862116/99E8BDA93C81AD3875DFC214AA5E39DC4F5477A5/"
-        }
-      },
-      {
-        "name": "RSP-6 Paratrooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747551248/7EB35E562D1685283C46BCC74678C8B0573F68FE/",
-        "points": 29,
-        "restrictions": {
-          "include": {
-            "unit": ["Clone Paratroopers"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693415425547360/64A0DE5FC04770CADAEFA3F202A83EF0ACA1AABB/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
-        }
-      },
-      {
-        "name": "Salvaged T-21 Rider",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1022821770986744919/D39D941758BD3209F2D9F72B075DE5752FC2AD80/",
-        "points": 55,
-        "restrictions": {
-          "include": {
-            "unit": ["Orbak Riders"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770976478775/74F36986A6C7597A92FB07CBD80D29430F2ADC0C/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770976478988/8EA7C3063101B4163C223C1AA9D3FFD5196EED24/"
-        }
-      },
-      {
-        "name": "Sith Rifleman",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281908934/40B735C56C1C6EFF536F72A96FCB2E86EBA4D7B5/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933721582/A454C20F4D869C5BDCBB07E7DF297D3A97C518F1/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
-        },
-        "points": 20,
-        "restrictions": {
-          "include": {
-            "unit": ["Sith Troopers"]
-          }
-        }
-      },
-      {
-        "name": "Stolen RPS-6 Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738627942/4B5C5C7EE5C0A917920BC1ACD6D9BDC884C3F66F/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436116594/297A8181876F9899A0116189C171CB6DCF8F7E91/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436116780/2EDB6D1F02708B64292E99D8A6C1C2BA9772D6CD/"
-        },
-        "points": 25,
-        "restrictions": {
-          "include": {
-            "unit": ["Weequay Pirates"]
-          }
-        }
-      },
-      {
-        "name": "Tactial Shotgun Commando",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277958661/B7303152FFBCFF29BFD241865245D297469E6F17/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024261155036/D5997D5F703F00DB00BB6C2CB1C92B0BB3E4B972/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260988667/8B8E27DFEDD6DEBA4EFABD6E738D3B6AC3E925AB/"
-        },
-        "points": 30,
-        "restrictions": {
-          "include": {
-            "unit": ["Imperial Commandos"]
-          }
-        }
-      },
-      {
-        "name": "TL-50 Resistance Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752980632/3AC1DF926A9DF195B85993DE03C1BA837FF12038/",
-        "points": 26,
-        "restrictions": {
-          "include": {
-            "unit": ["Resistance Troopers"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324582151739582/7B71E9B3E009D0CE72542DCE4EE88F80A15975F1/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324582151739873/59E17839EF9DE940D822E980A6B8D17EAF323009/"
-        }
-      },
-      {
-        "name": "TL-50 Stormtrooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751871157/BC6D8D82C13ED515680AE0748BCBF8BBA1967D52/",
-        "points": 28,
-        "restrictions": {
-          "include": {
-            "unit": ["Stormtroopers"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324932748013140/6A82D4809AA884C3F5786210898CE813BC9789F9/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324932748013349/A449441B895CE926D13CE9D1501BFC9B12A08A9D/"
-        }
-      },
-      {
-        "name": "Trandoshan Blaster Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738629805/EEDC0DDF8D9737D6CFFDBAAEDDF73C2BC39DC9AF/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436115961/DBF66375F8D2143292D9BBDC3F6FF6AB46D7AB16/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112372/F530C8FD39C7DAC7766DF00F0087A82E8044DE0D/"
-        },
-        "points": 27,
-        "restrictions": {
-          "include": {
-            "unit": ["Weequay Pirates"]
-          }
-        }
-      },
-      {
-        "name": "Z6 Riot Baton Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1021696515357806642/44993426511AB7D0D10454600BEE354823F5CBCA/",
-        "points": 20,
-        "restrictions": {
-          "include": {
-            "unit": ["First Order Stormtroopers"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324932747749076/BC0B7C898A646CCDFC518280A48B7C82EECB54B1/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324932747749244/7BD30A42AAF722FC4D005E08EC5EB2BCBD938E22/"
-        }
-      },
-      {
-        "name": "Z-6B Resistance Trooper ",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752971387/1606CD1A3BD10A2FAF39558C7B36597840920010/",
-        "points": 22,
-        "restrictions": {
-          "include": {
-            "unit": ["Resistance Troopers"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324932752944952/1207D0D12B5971CC86CDAC845AB9487AFB0913E2/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324932752945165/7BFD62143549CA0DC0C9FDF7A251A8546AFB50DD/"
-        }
-      },
-      {
-        "name": "Z-6 StormTrooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751870825/96353DB410957633EF3D108F2BC58D4F84EBEC7E/",
-        "points": 25,
-        "restrictions": {
-          "include": {
-            "unit": ["Stormtroopers"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324932748082014/050A615D4A688CAF04806338E172186E1BEE93F5/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324932748082306/B60EBE5BB730F9B03EC541DDF15993BADBE2820F/"
-        }
-      }
-    ],
-    "Illicit": [
-      {
-        "name": "Black Market Weapon Modifications",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735317485/24DDC0FD309F0F75C04559832E888C0ED6E52CB1/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "type": ["Trooper"]
-          }
-        }
-      },
-      {
-        "name": "Black sun Assault mod",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742527952/354B544F4AB6ED4EA8FE90895DA7E62CC6D9DED9/",
-        "points": 5,
-        "restrictions": {
-          "include": {
-            "unit": ["EWHB-12 Heavy Blaster team"]
-          }
-        }
-      },
-      {
-        "name": "Ewok Bomb",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741833695/4345404F4A2F9E97DC140024285F113A8DDEAAE9/",
-        "points": 22,
-        "restrictions": {
-          "include": {
-            "unit": ["Beast Master"]
-          }
-        }
-      },
-      {
-        "name": "Glitterstim",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735317047/31F1D322D5E1C986DFB20E582590653A0B0CAF7F/",
-        "points": 5,
-        "restrictions": {
-          "include": {
-            "type": ["Trooper"]
-          }
-        }
-      },
-      {
-        "name": "Inspiring Monologue",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738474691/8D852B6879C8FF5C5F0A2883FC9A204FB8937979/",
-        "points": 5,
-        "restrictions": {
-          "include": {
-            "unit": ["Hondo Ohnaka"]
-          }
-        }
-      },
-      {
-        "name": "Lord of Pirates",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738474167/126CF97710D8C7F9BDFBB16BF051B1F8660C7263/",
-        "points": 15,
-        "restrictions": {
-          "include": {
-            "unit": ["Hondo Ohnaka"]
-          }
-        }
-      },
-      {
-        "name": "Outer Rim Modifications",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735317893/3A2F6E60B2980B2608C4DA9B029E1C4B2F257560/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "type": ["Droid Trooper", "Ground Vehicle", "Repulsor Vehicle"]
-          }
-        }
-      },
-      {
-        "name": "Personal Shield",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735181899/208D960208099BDF4461E2E09204169FF959FC52/",
-        "points": 8,
-        "restrictions": {
-          "include": {
-            "type": ["Trooper"]
-          }
-        }
-      },
-      {
-        "name": "Piercing Dart",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640417521/8FE5D7BA77D3E25ED3FB812B261AD3E3DD88EF10/",
-        "points": 6,
-        "restrictions": {
-          "include": {
-            "type": ["Mandalorian Trooper"]
-          }
-        }
-      },
-      {
-        "name": "Pirate Retrofit",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742527540/AA9771542B3B0F58F1D813AE833F6E230163C361/",
-        "points": 5,
-        "restrictions": {
-          "include": {
-            "unit": ["EWHB-12 Heavy Blaster team"]
-          }
-        }
-      },
-      {
-        "name": "Poison Dart",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640416768/843BE27BBC497AC58846ED0295BFC661E391BEDF/",
-        "points": 6,
-        "restrictions": {
-          "include": {
-            "type": ["Mandalorian Trooper"]
-          }
-        }
-      },
-      {
-        "name": "Rancor Tamer",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741834052/EE3F163A5E5986958BCE4A45AD91F861EB85459F/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "unit": ["Beast Master"]
-          }
-        }
-      },
-      {
-        "name": "Reputation of the Hutts",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741312392/906B601379C476DB20B6997F64A1B29916A421DB/",
-        "points": 7,
-        "restrictions": {
-          "include": {
-            "unit": ["Jabba The Hutt"]
-          }
-        }
-      },
-      {
-        "name": "Self-Destruct Sequencing",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735318468/FF453A532280D1626623E10338ED5D288FA47B6E/",
-        "points": 5,
-        "restrictions": {
-          "include": {
-            "type": ["Droid Trooper", "Ground Vehicle", "Repulsor Vehicle"]
-          }
-        }
-      },
-      {
-        "name": "Stimpack",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735182732/C3B2C7FA3F05FC71D5C3ED089A8037A92171A103/",
-        "points": 5,
-        "restrictions": {
-          "include": {
-            "type": ["Trooper"]
-          }
-        }
-      },
-      {
-        "name": "Wrist Mounted Disintegrator",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640426484/CAA3EE923F691577E92958B5BAA38AB8221EDF61/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "type": ["Mandalorian Trooper"]
-          }
-        }
-      },
-      {
-        "name": "Wrist Mounted Disruptor",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640427887/A13950D10FE563732533E3C91584E465D47F05F5/",
-        "points": 3,
-        "restrictions": {
-          "include": {
-            "type": ["Mandalorian Trooper"]
-          }
-        }
-      },
-      {
-        "name": "Wrist Mounted Slugthrower",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640413367/65913371690794787832DA2D5D970C42E484A5E0/",
-        "points": 6,
-        "restrictions": {
-          "include": {
-            "type": ["Mandalorian Trooper"]
-          }
-        }
-      },
-      {
-        "name": "Ysalamiri cage",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741834581/FDBF31BD0BD3997D1415E1409F8C4A82744019D9/",
-        "points": 8,
-        "restrictions": {
-          "include": {
-            "unit": ["Beast Master"]
-          }
-        }
-      }
-    ],
-    "Ordnance": [
-      {
-        "name": "Bunker Buster Missiles",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751975579/6613DFBE1168370B4DB2AA3BAC7CCDC8F2B1EEDD/",
-        "points": 5,
-        "restrictions": {
-          "include": {
-            "unit": ["Phase II Darktroopers"]
-          }
-        }
-      },
-      {
-        "name": "Carbonite Missiles",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638969743/EEA573B6F2E054B13E3A220888FFDC03906CA74C/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "unit": ["Missile Attack Launcher"]
-          }
-        }
-      },
-      {
-        "name": "Sabot Missiles",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751975146/7766942C8563D444E253FC2262E6E7DDE1A95F00/",
-        "points": 5,
-        "restrictions": {
-          "include": {
-            "unit": ["Phase II Darktroopers"]
-          }
-        }
-      },
-      {
-        "name": "Shrapnel Missiles",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751975982/EBFAC7D348F41D8A319B15EAF27ADF6F443DD56C/",
-        "points": 5,
-        "restrictions": {
-          "include": {
-            "unit": ["Phase II Darktroopers"]
-          }
-        }
-      }
-    ],
-    "Personnel": [
-      {
-        "name": "Clone Paratrooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747552501/731105BAC6B5011092706B93C5853B6B51317D55/",
-        "points": 16,
-        "restrictions": {
-          "include": {
-            "unit": ["Clone Paratroopers"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693290507042014/A16ED28591E7E27887C7BC119152B6AD889BFF9E/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
-        }
-      },
-      {
-        "name": "Extra Grenadier",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735129141/9805A2223DB725582E8105414121E4505895193F/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365824294/5F43B720E0198A078E25BA472E7DDBCA8F51CBEC/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365824481/27693FC709ADF50440623C6347A11151608D5E2F/"
-        },
-        "points": 11,
-
-        "restrictions": {
-          "include": {
-            "unit": ["Grenadier Squad"]
-          }
-        }
-      },
-      {
-        "name": "First Order Officer",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1022821664192153851/1A7BA1EA3DC4C4EC1903A3BD4D1777CCA4FA3C5E/",
-        "points": 22,
-        "leader": true,
-        "restrictions": {
-          "include": {
-            "faction": ["First Order"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821664192111404/0E625C7A4614D3BE5DF4DF9D78BA558C2B78803C/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821664192111727/770A7C77419D31361A4E7DF14655D4339B5333BE/"
-        }
-      },
-      {
-        "name": "First Order Stormtrooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1027324804931509424/141535D01679C2B839782C8AE821CA5C24AFBD2F/",
-        "points": 13,
-        "restrictions": {
-          "include": {
-            "unit": ["First Order Stormtroopers"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804926507457/5178F7589B3E8647E3FBFDE3C3C0829F284FA23D/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804926496614/9FECECAF48C7046C3714B33C4C16FFB773FCC94C/"
-        }
-      },
-      {
-        "name": "First Order Stormtrooper Officer",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1027324712401821977/D05282E16BB2E59EC7CD3482F256FE2F0F1921F3/",
-        "points": 15,
-        "leader": true,
-        "restrictions": {
-          "include": {
-            "unit": ["First Order Stormtroopers"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804930715422/16120934F642C553591C4773C4F9E4B21F167A52/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804930715848/CC1157E547C67A4FD8CF56868BFCD9EF3A04075D/"
-        }
-      },
-      {
-        "name": "Forward Observer",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735128538/8947A618AAA4A4A0D92B3C7C12E651A494FDEDA7/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984835690936/3C42012D036A5F420DD9ADD158E66901AB4A5671/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984835691208/1C0C86466F3298E9663CEE3961B7F3F6DBED4DD9/"
-        },
-        "points": 17,
-        "restrictions": {
-          "include": {
-            "unit": ["Grenadier Squad"]
-          }
-        }
-      },
-      {
-        "name": "General Caluan Emmat",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1021697756245233178/36866FDE340064CDE02A6C0BB423EA8CAD2B1ABC/",
-        "points": 20,
-        "leader": true,
-        "restrictions": {
-          "include": {
-            "faction": ["Resistance"],
-            "rank": ["Corps"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248463256/9A71FCC63F00BFF1B30323727AE4ECE40A797845/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248457898/6A102129E4F692F04E02D1269F913A4D22B22FBC/"
-        }
-      },
-      {
-        "name": "Geonosian Warrior",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746955018/3E851672C18FC4978BF8E7D82D3BB6E0D4433A9D/",
-        "points": 12,
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893317940526/D1A4E66DAA988ABE66C6D0014DD6D49047AA6697/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893317930470/4A9F58F7B8BC80AF279695655E38DD81A9236057/"
-        },
-        "restrictions": {
-          "include": {
-            "unit": ["Geonosian Warriors"]
-          }
-        }
-      },
-      {
-        "name": "Hired Gun",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742004196/087F0B1F89E7E79E87461EE5D2661B2585C52D4A/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138165871/C51E95633C934897949CFF29D8F9BCE471BF8FFA/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138166035/1BA43B16941621DB32750B2B3CDD35053996ABA9/"
-        },
-        "points": 9,
-        "restrictions": {
-          "include": {
-            "unit": ["Hired Guns"]
-          }
-        }
-      },
-      {
-        "name": "Hutt Cartel Sentry",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738629292/FE183D473B13C247AC36F6DD253B934B09655B34/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436124726/C43B4DBB33AABF8482E19400E53948B5ED032CCB/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436124875/9CB0C0F06DD8F10B227161EE26DD1B55F8F5BDD4/"
-        },
-        "leader": true,
-        "points": 23,
-        "restrictions": {
-          "include": {
-            "unit": ["Weequay Pirates"]
-          }
-        }
-      },
-      {
-        "name": "Hutt Cartel Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741193921/7F0C6BE42AE860AB77EB6C2BC779788371FE78B7/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132329491/14A83C22F3313876B13BB0A0016C687ED2E77D44/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132233662/46758BE4190670991AEEB84884D2C0926704577E/"
-        },
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "unit": ["Hutt Cartel Troopers"]
-          }
-        }
-      },
-      {
-        "name": "Imperial Supercommando",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751939006/CBC6F2FE8C1DF0F75561DAE45F1F721222BF52FB/",
-        "points": 23,
-        "restrictions": {
-          "include": {
-            "unit": ["Imperial Supercommandos"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982276859/C65AD83F5B3BE7D8787B3F0DC71C3637F257CF58/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982273931/809947D430BEB447CD2FA3E99DD31AF57C3E8F84/"
-        }
-      },
-      {
-        "name": "Paratrooper Medic",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747553122/09BE4CDAF6D1A40AED895C9DAC9B03EECA17E46A/",
-        "points": 29,
-        "restrictions": {
-          "include": {
-            "unit": ["Clone Paratroopers"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693415425401629/49D60D4EE5794A206AF8F604A68F58979CFEBC42/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693415425408778/BD84B4C5CAA84DDA6302739AD749CD29B1C39669/"
-        }
-      },
-      {
-        "name": "Resistance Trench Fighter",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1017194020628451982/E73E545FCA80240A75FBE0988782C8014F891577/",
-        "points": 13,
-        "restrictions": {
-          "include": {
-            "faction": ["Resistance Trench Fighters"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248442551/9D7BC64B0ECFEA79E16E695F4823085745EA8C51/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248440578/125E76600442E01E3AD18725563EA1BE4D63BEFA/"
-        }
-      },
-      {
-        "name": "Resistance Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752970508/02879490220A6F3BD0B3B501770CE6567C152BD1/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "unit": ["Resistance Troopers"]
-          }
-        },
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324582151467148/595A4E7837AB3D12604D3A2858D08496E4FCBEA5/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324582151467561/892B00728A9164598F3FBE91C0D7C0F8619FCB20/"
-        }
-      },
-      {
-        "name": "Sith Empire Boarding Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277786308/E222A61B5021B9FC2E56A8A957633B8BD2384CDB/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608884994661/01F7CD51333718A8A814885CF5A93B2A84651652/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
-        },
-        "points": 12,
-        "restrictions": {
-          "include": {
-            "unit": ["Sith Empire Boarding Troopers"]
-          }
-        }
-      },
-      {
-        "name": "Sith Empire Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277742848/35DD1780CE5A8F446954CC178C0C05089A10B21B/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608878992636/D833E26E44A7763FAEFBE2430390376F9160E931/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608878877171/C209E7E6493A8465F8FD60DE6566AA6BA2C745ED/"
-        },
-        "points": 11,
-        "restrictions": {
-          "include": {
-            "unit": ["Sith Empire Troopers"]
-          }
-        }
-      },
-      {
-        "name": "Sith Sorcerer",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278055781/ED051F07880B0030B6DE21C04E01E640FEAD93C2/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061823163250038/32C72D2D0F766BFD34626E6A8944954C50CC0D77/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061823163250299/7A3E3550E4630C1BF03CF91847C63638AB684434/"
-        },
-        "points": 35,
-        "restrictions": {
-          "include": {
-            "unit": ["Sith Acolytes"]
-          }
-        }
-      },
-      {
-        "name": "Sith Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281908575/338762E958A0C98B0AB49C47AA6A715893E4548B/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933703057/89125C10F7477148926E221D7D01FC48B49D2502/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
-        },
-        "points": 11,
-        "restrictions": {
-          "include": {
-            "unit": ["Sith Troopers"]
-          }
-        }
-      },
-      {
-        "name": "Sith Warrior",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278056315/1665856EDAB96AF7A8C172511E6599CD901D4E71/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885796271/427E4FBA584A22712C84414761D3EEBB1AE714E7/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608885695776/F5A3AA78554B8F3CB86314E552D94D65C0080F0C/"
-        },
-        "points": 35,
-        "restrictions": {
-          "include": {
-            "unit": ["Sith Acolytes"]
-          }
-        }
-      },
-      {
-        "name": "Veteran Sergeant",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277744958/3610B8D3EB6E459B5BF3C7F97B0E7B2B9AA4CBE1/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608881242939/0D60224C8880F4609ADFC4B901EC92EEA545B235/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608881243790/F0D722D6703135FDF3BB2B7F3105FCAA49DB5284/"
-        },
-        "leader": true,
-        "points": 25,
-        "restrictions": {
-          "include": {
-            "unit": ["Sith Empire Troopers"]
-          }
-        }
-      },
-      {
-        "name": "Weequay Pirate",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738628849/92249CF6F8DC12990B7073346AEF4DE3F3C5BB43/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436114050/3985CF5B2D5C91AEF263706C20E4C84D7401F1BE/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112951/28554A829163EDA67DDE90D1CF137C093FF8A9AC/"
-        },
-        "points": 11,
-        "restrictions": {
-          "include": {
-            "unit": ["Weequay Pirates"]
-          }
-        }
-      }
-    ],
-    "Pilot": [
-      {
-        "name": "Blitz Programming",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743574266/360A7A5E48D4A43CC8BEB06ACAFA9E2DEBF73B3D/",
-        "points": 12,
-        "restrictions": {
-          "include": {
-            "unit": ["SD-4K Assassin Droid"]
-          }
-        }
-      },
-      {
-        "name": "Defoliator Lok Durd",
-        "displayName": "Lok Durd",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743617101/58D618F0C66FFCDC5FEBF39BC32D54D6BA55EB30/",
-        "points": 9,
-        "restrictions": {
-          "include": {
-            "unit": ["Defoliator Deployment Tank"]
-          }
-        }
-      },
-      {
-        "name": "Defoliator T-Series Tactical Droid Pilot",
-        "displayName": "T-Series Tactical Droid Pilot",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743616760/DF7B027C96C111F6170C6DD30E32DC1FBBE08AEE/",
-        "points": 5,
-        "restrictions": {
-          "include": {
-            "unit": ["Defoliator Deployment Tank"]
-          }
-        }
-      },
-      {
-        "name": "Excitable Pirate",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743063563/DECCDDEB113FF6F7E278657E96EB142AEE9690B7/",
-        "points": 15,
-        "restrictions": {
-          "include": {
-            "unit": ["WLO-5 Battle Tank"]
-          }
-        }
-      },
-      {
-        "name": "Hawkeye",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747619367/B0EFDF7F817DC850C3A28D1CD885213958C2248E/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "unit": ["LA-AT/I Gunship"]
-          }
-        }
-      },
-      {
-        "name": "Hutt Cartel Pilot",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743063098/6FA89F40EA19F2FA891BD06D60B6DC06539C1212/",
-        "points": 15,
-        "restrictions": {
-          "include": {
-            "unit": ["WLO-5 Battle Tank"]
-          }
-        }
-      },
-      {
-        "name": "Nightsister Rider",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742458550/DA4B94232A6C585F9052738F990C70095E579256/",
-        "points": 30,
-        "restrictions": {
-          "include": {
-            "unit": ["Rancor"]
-          }
-        }
-      },
-      {
-        "name": "Oddball",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747618963/6FE86EFBC23C8FDFDB87FBE066C60CBD32FF1DFE/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "unit": ["LA-AT/I Gunship"]
-          }
-        }
-      },
-      {
-        "name": "Pirate Hotshot",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556639096066/A06D6ABDA4E9B1B1F2A63187D6B24F13D5D283A5/",
-        "points": 15,
-        "restrictions": {
-          "include": {
-            "unit": ["Canderous Class Assault Tank"]
-          }
-        }
-      },
-      {
-        "name": "Pirate Speed Freak",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556639095451/373D5F83FB4E8F4D3223A3CAD3E6A8E661FAAC2F/",
-        "points": 8,
-        "restrictions": {
-          "include": {
-            "unit": ["Canderous Class Assault Tank"]
-          }
-        }
-      },
-      {
-        "name": "Rose Tico",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1021697620252778721/621B535E20B29F253B38AD3548C986EE0DB42CCF/",
-        "points": 8,
-        "restrictions": {
-          "include": {
-            "faction": ["Resistance"]
-          }
-        }
-      },
-      {
-        "name": "Stealth Programming",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743573731/95CA7A7627F55B39157D6FE5493ECF8996D2C685/",
-        "points": 18,
-        "restrictions": {
-          "include": {
-            "unit": ["SD-4K Assassin Droid"]
-          }
-        }
-      },
-      {
-        "name": "Veteran Gunner",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747586823/256792792FFE8D876759E9A894F76F489BFDE968/",
-        "points": 6,
-        "restrictions": {
-          "include": {
-            "unit": ["AT-AP"]
-          }
-        }
-      },
-      {
-        "name": "Veteran Mechanic",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638970650/AE724920A75FF2F1D840AC3DE707166D67EA0323/",
-        "points": 8,
-        "restrictions": {
-          "include": {
-            "unit": ["Missile Attack Launcher"]
-          }
-        }
-      },
-      {
-        "name": "Veteran Tank Pilot",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556639094597/6678DD776757AAFAFA216FB7538DA7BC35147757/",
-        "points": 5,
-        "restrictions": {
-          "include": {
-            "unit": ["Canderous Class Assault Tank"]
-          }
-        }
-      },
-      {
-        "name": "Warthog",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747618630/E00C8B7A4F81CCD6F2A12747031B7D62D05857E3/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "unit": ["LA-AT/I Gunship"]
-          }
-        }
-      }
-    ],
-    "Relic": [
-      {
-        "name": "Sith Holocron",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747372001/0447B19DFCA692F5AC2D176A7C6C7A1CB53A156B/",
-        "points": 15
-      }
-    ],
-    "Training": [
-      {
-        "name": "Advanced Assault Training",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640415256/3E0DA25CB2B44F7093E46DADA1965C0DBD3C703A/",
-        "points": 5,
-        "restrictions": {
-          "include": {
-            "type": ["Mandalorian Trooper"]
-          }
-        }
-      },
-      {
-        "name": "Blend In",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735182379/DD072454059CA2BB5CB206848D0BCBF656F494F9/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "faction": ["Scum"],
-            "rank": ["Commander", "Operative", "Special Forces"]
-          }
-        }
-      },
-      {
-        "name": "Brutality",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741408425/6FED2B70FD2FCEFC6A1A8249888003F3C9798118/",
-        "points": 10
-      },
-      {
-        "name": "Conditioning",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1027325137553694727/5A2D2C8BBA135A33871093554B186278F54ACF70/",
-        "points": 5,
-        "restrictions": {
-          "include": {
-            "faction": ["First Order"],
-            "rank": ["Corps", "Special Forces"]
-          }
-        }
-      },
-      {
-        "name": "Conditioning other",
-        "displayName": "Conditioning",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1027325137553694727/5A2D2C8BBA135A33871093554B186278F54ACF70/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "faction": ["First Order"],
-            "rank": ["Commander", "Operative", "Support", "Heavy"]
-          }
-        }
-      },
-      {
-        "name": "Disarming Slash",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747373016/011CE3497BCC2229C114CDBF69464D3FB6E16B26/",
-        "points": 10
-      },
-      {
-        "name": "Hasty Exit",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747373759/AF9520B70176F54DCB2B098735D1D3F468E9F442/",
-        "points": 3
-      },
-      {
-        "name": "Faithful Companion",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735164302/4C5E96A3397E6BD2F8C07A61AA9B25FDC0D8C031/",
-        "points": 8,
-        "restrictions": {
-          "include": {
-            "unit": ["Beast Master", "Silri"]
-          }
-        }
-      },
-      {
-        "name": "Geonosian Brain Worms",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746957609/4564866DD4465ADC1224AC20C8A82A2895D19FE9/",
-        "points": 0,
-        "restrictions": {
-          "include": {
-            "unit": ["Geonosian Warriors"]
-          }
-        }
-      },
-      {
-        "name": "Rising Phoenix Training",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640409422/F8AF40A8E8F4C87CA364A0ADADA7281F20F8F0D7/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "type": ["Mandalorian Trooper"]
-          }
-        }
-      }
-    ]
-  },
-  "commands": {
-    "Sith Empire": [
-      {
-        "name": "Oppressive Tactics",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278110637/7EF1FEF7DCEB65C84A89E72110F107932A7CE783/",
-        "pip": 1
-      },
-      {
-        "name": "Legacy of Vaiken",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278110292/436DDD7EE789790446C0C4DB7F79A24843F7273A/",
-        "pip": 3
-      }
-    ]
-  },
-  "battlefield": {},
-  "objects": {}
-}
+    },
+    "commands": {
+      "Sith Empire": [
+        {
+          "name": "Oppressive Tactics",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278110637/7EF1FEF7DCEB65C84A89E72110F107932A7CE783/",
+          "pip": 1
+        },
+        {
+          "name": "Legacy of Vaiken",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278110292/436DDD7EE789790446C0C4DB7F79A24843F7273A/",
+          "pip": 3
+        }
+      ]
+    },
+    "battlefield": {},
+    "objects": {}
+  }

--- a/contrib/cards/homebrew.json
+++ b/contrib/cards/homebrew.json
@@ -1,5283 +1,5283 @@
 {
-    "units": {
-      "Empire": {
-        "Operative": [
-          {
-            "name": "Gar Saxon",
-            "title": "Ferocius and Merciless Warrior",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751698926/DEEC78B093B0018CAB33C87DC0888B05EF646E68/",
-            "size": "small",
-            "type": "Mandalorian Trooper",
-            "points": 120,
-            "speed": 3,
-            "upgrades": {
-              "Training": 2,
-              "Comms": 1,
-              "Gear": 1,
-              "Armament": 2
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982271779/BBF522FC361772E237872CCC9E983F4A7CD58838/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982271948/1595F95FC7DB45109C0C2BCBE8A06B0F487FD04E/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "A Man of Opportunities",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751699409/6A9728D6816A10B7B0EADBC2193008793FB4A3F8/",
-                "pip": 1
-              },
-              {
-                "name": "Jetpack Charge",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751699906/29D9FAE52580C82BC543ACF392E46E98D23533AB/",
-                "pip": 2
-              },
-              {
-                "name": "Viceroy of Mandalore",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751700204/E379AF4A3824F8CFFB8EFAED55B651116AFE5125/",
-                "pip": 3
-              }
-            ]
-          }
-        ],
-        "Special Forces": [
-          {
-            "name": "Imperial Supercommandos",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751938598/EA4F3008844B6528784403937811449891C14FCE/",
-            "size": "small",
-            "type": "Mandalorian Trooper",
-            "points": 76,
-            "speed": 2,
-            "upgrades": {
-              "Personnel": 1,
-              "Training": 2,
-              "Comms": 1,
-              "Armament": 2
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982273795/D117C3122139FF5A93AAB4E5DCD2455FF70508F1/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982273931/809947D430BEB447CD2FA3E99DD31AF57C3E8F84/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982274574/BFFC62F32FE65628DB446AAA3674E5C49F92DE2F/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982273931/809947D430BEB447CD2FA3E99DD31AF57C3E8F84/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982275923/F4BDE2E8B1C496AFAB7DCF11728CA5AD58EC55FE/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982273931/809947D430BEB447CD2FA3E99DD31AF57C3E8F84/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982276438/B609AA7C947FFDBFFFDE022D21A4029EF4428282/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982273931/809947D430BEB447CD2FA3E99DD31AF57C3E8F84/"
-              }
-            ]
-          }
-        ],
-        "Support": [
-          {
-            "name": "AT-LDT",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751888859/BEC4E39876A92E0FFC2504196992E2072E99BDE8/",
-            "size": "large",
-            "type": "Ground Vehicle",
-            "points": 70,
-            "speed": 1,
-            "upgrades": {
-              "Comms": 1,
-              "Ordnance": 1,
-              "Generator": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1055478574361579189/41CE0402F950AB518DB08E026AF96F46804E5AAB/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1055478574361579329/ABE5D81D7D16FF3DF9D9EA1247787AF86A112C61/"
-              }
-            ]
+  "units": {
+    "Empire": {
+      "Operative": [
+        {
+          "name": "Gar Saxon",
+          "title": "Ferocius and Merciless Warrior",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751698926/DEEC78B093B0018CAB33C87DC0888B05EF646E68/",
+          "size": "small",
+          "type": "Mandalorian Trooper",
+          "points": 120,
+          "speed": 3,
+          "upgrades": {
+            "Training": 2,
+            "Comms": 1,
+            "Gear": 1,
+            "Armament": 2
           },
-          {
-            "name": "Phase II Darktroopers",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751974310/FADC3793016675ADF27F22082439F243F5CFF323/",
-            "size": "medium",
-            "type": "Droid Trooper",
-            "points": 110,
-            "speed": 1,
-            "upgrades": {
-              "Ordnance": 2,
-              "Comms": 1,
-              "Gear": 1
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982271779/BBF522FC361772E237872CCC9E983F4A7CD58838/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982271948/1595F95FC7DB45109C0C2BCBE8A06B0F487FD04E/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "A Man of Opportunities",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751699409/6A9728D6816A10B7B0EADBC2193008793FB4A3F8/",
+              "pip": 1
             },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455180041796/806FD35D077836E2B21585294CA1F31F3D20C5EF/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455180028599/BF2A5BE67D0934FF1785E154F766FBA82950A84B/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455180096325/2AB8CE3FE8B9FFFEC50C420D918E23A0DCF200B1/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455180028599/BF2A5BE67D0934FF1785E154F766FBA82950A84B/"
-              }
-            ]
-          }
-        ],
-        "Heavy": [
-          {
-            "name": "XX-7 Heavy Turbo Laser",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751922250/1D0ACF27CE08CFA865080B62DD8C0E12B87CA802/",
-            "size": "huge",
-            "type": "Emplacement Trooper",
-            "points": 90,
-            "speed": 0,
-            "upgrades": {
-              "Comms": 1,
-              "Generator": 1
+            {
+              "name": "Jetpack Charge",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751699906/29D9FAE52580C82BC543ACF392E46E98D23533AB/",
+              "pip": 2
             },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028454512723115814/E2D62C42F65FA7C8D53DF84C32E2AF7A706CF227/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028454512723115925/1BBA13C56E26EC363E68E2E0A87AD0D00B3B2F9E/"
-              }
-            ]
-          }
-        ]
-      },
-      "First Order": {
-        "Commander": [
-          {
-            "name": "Captain Phasma",
-            "title": "Ruthless Leader",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081143260/D95314875641B7FB3C4EF84083544C623CD1A682/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 95,
-            "speed": 2,
-            "upgrades": {
-              "Command": 2,
-              "Training": 1,
-              "Armament": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804925773451/29E9C01AADB63D0F11307AC6DF9FE7F0C29178CD/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804925773688/AA999386C07D280297E4E55F78BE951C22CC4765/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Traitor!",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081145254/8867B053273BC9DBBB46FDC464881998DF372B1A/",
-                "pip": 1
-              },
-              {
-                "name": "So Good To Have You Back",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081145863/40A8C433BC0D8BBBFBC44BCCF8D9BBBF465CE231/",
-                "pip": 2
-              },
-              {
-                "name": "On My Command...",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081146194/C55577A1151D80D0A283097F5FFE5596258520D0/",
-                "pip": 3
-              }
-            ]
+            {
+              "name": "Viceroy of Mandalore",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751700204/E379AF4A3824F8CFFB8EFAED55B651116AFE5125/",
+              "pip": 3
+            }
+          ]
+        }
+      ],
+      "Special Forces": [
+        {
+          "name": "Imperial Supercommandos",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751938598/EA4F3008844B6528784403937811449891C14FCE/",
+          "size": "small",
+          "type": "Mandalorian Trooper",
+          "points": 76,
+          "speed": 2,
+          "upgrades": {
+            "Personnel": 1,
+            "Training": 2,
+            "Comms": 1,
+            "Armament": 2
           },
-          {
-            "name": "First Order Officer",
-            "title": "Cruel Superior",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081388976/28890DF10C50786D86509A5E6E9014EDFB18178A/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 50,
-            "speed": 2,
-            "upgrades": {
-              "Command": 1,
-              "Gear": 1
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982273795/D117C3122139FF5A93AAB4E5DCD2455FF70508F1/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982273931/809947D430BEB447CD2FA3E99DD31AF57C3E8F84/"
             },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821664192111404/0E625C7A4614D3BE5DF4DF9D78BA558C2B78803C/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821664192111727/770A7C77419D31361A4E7DF14655D4339B5333BE/"
-              }
-            ]
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982274574/BFFC62F32FE65628DB446AAA3674E5C49F92DE2F/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982273931/809947D430BEB447CD2FA3E99DD31AF57C3E8F84/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982275923/F4BDE2E8B1C496AFAB7DCF11728CA5AD58EC55FE/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982273931/809947D430BEB447CD2FA3E99DD31AF57C3E8F84/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982276438/B609AA7C947FFDBFFFDE022D21A4029EF4428282/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982273931/809947D430BEB447CD2FA3E99DD31AF57C3E8F84/"
+            }
+          ]
+        }
+      ],
+      "Support": [
+        {
+          "name": "AT-LDT",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751888859/BEC4E39876A92E0FFC2504196992E2072E99BDE8/",
+          "size": "large",
+          "type": "Ground Vehicle",
+          "points": 70,
+          "speed": 1,
+          "upgrades": {
+            "Comms": 1,
+            "Ordnance": 1,
+            "Generator": 1
           },
-          {
-            "name": "General Hux",
-            "title": "First Order High Commander",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081169876/CB65E6B92A868A8379B108FF8AF217970564DECC/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 75,
-            "speed": 2,
-            "upgrades": {
-              "Command": 2,
-              "Flaw": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324932753815007/08A3CB2CCDEDD302548596EF866CF64E5E0AFB75/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324932753720403/40A7224F1345DCD440F78BD1669290C07059002E/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Orbital Bombardment ",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081172704/D53673C6656A92D080288EBC0C0F6A7C6760626C/",
-                "pip": 1
-              },
-              {
-                "name": "Tied on the End of a String",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081174703/A647478FFD9A384A559221E190389D2AC56D902D/",
-                "pip": 2
-              },
-              {
-                "name": "Acquiesces to Disorder!",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081176167/0D2A9F919346BEDA9602EF0803ADADEEFB4F9F4C/",
-                "pip": 3
-              }
-            ],
-            "required": ["I Don't Care if You Win"]
-          }
-        ],
-        "Operative": [
-          {
-            "name": "Bazine Netal",
-            "title": "Skilled Mercenary and Spy",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081110689/34878CC455F7F58C190A27DEEFAAD326F411F137/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 85,
-            "speed": 2,
-            "upgrades": {
-              "Training": 2,
-              "Gear": 1,
-              "Grenades": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027325137554369094/426567AD530CBB53A36B4DA286606A8028036940/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821664190500251/60F46C12E0D02DE01D36B03BDF1E8ECAFD604F87/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "The Perfect Weapon",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081134318/95DFAC48AF2895CBD541779163F6F58781816CE8/",
-                "pip": 1
-              },
-              {
-                "name": "They Die Or Disappear",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081134688/F073799B09F8A31C076CA224E1B5BD6C8C75106A/",
-                "pip": 2
-              },
-              {
-                "name": "Inform The First Order",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081135367/1425B91FE3B59882B80BB27197F86C066C5DBF46/",
-                "pip": 3
-              }
-            ]
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1055478574361579189/41CE0402F950AB518DB08E026AF96F46804E5AAB/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1055478574361579329/ABE5D81D7D16FF3DF9D9EA1247787AF86A112C61/"
+            }
+          ]
+        },
+        {
+          "name": "Phase II Darktroopers",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751974310/FADC3793016675ADF27F22082439F243F5CFF323/",
+          "size": "medium",
+          "type": "Droid Trooper",
+          "points": 110,
+          "speed": 1,
+          "upgrades": {
+            "Ordnance": 2,
+            "Comms": 1,
+            "Gear": 1
           },
-          {
-            "name": "Kylo Ren",
-            "title": "Fallen Apprentice",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081182228/D92A0F8C9F86CF7DEA222B23C6172250083EAB29/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 140,
-            "speed": 2,
-            "upgrades": {
-              "Force": 2,
-              "Training": 1,
-              "Flaw": 1
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455180041796/806FD35D077836E2B21585294CA1F31F3D20C5EF/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455180028599/BF2A5BE67D0934FF1785E154F766FBA82950A84B/"
             },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804925562786/E8A84B89A9397EDE6466F969084F683316C98D64/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804925562981/94795F169138667E0322FE1E28F68E2B8B7F4C37/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Finish What You Started",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081184101/51986EF40283FA440878CF7C1DD65104FF4A65B9/",
-                "pip": 1
-              },
-              {
-                "name": "I'll Show You the Dark Side",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081186038/6DE22BF4C255C7D6213E01F2B101CB7EA969D68F/",
-                "pip": 2
-              },
-              {
-                "name": "Mind Probe",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081187404/50F791DA2817CC1E8C690138FE028CA17B1B51D5/",
-                "pip": 3
-              }
-            ],
-            "required": ["I'm Being Torn Apart"]
-          }
-        ],
-        "Corps": [
-          {
-            "name": "First Order Stormtroopers",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081335160/5F935176EDBFB5C657AFA3681E67CC2C9F20BC24/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 52,
-            "speed": 2,
-            "upgrades": {
-              "Heavy Weapon": 1,
-              "Personnel": 1,
-              "Training": 1,
-              "Gear": 1,
-              "Grenades": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804926496354/534247FC18865263C1D30BC8C906CB39C93B0394/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804926496614/9FECECAF48C7046C3714B33C4C16FFB773FCC94C/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804926504208/94BA6801EC3D5C7915A803C8DB037D55499DA148/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804926496614/9FECECAF48C7046C3714B33C4C16FFB773FCC94C/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804926505290/B0670893C896898E6BE4CAB01744CE00F1FFE52B/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804926496614/9FECECAF48C7046C3714B33C4C16FFB773FCC94C/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804926506313/1AF44B793BDE12347BA28238D08E48E507CFBD02/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804926496614/9FECECAF48C7046C3714B33C4C16FFB773FCC94C/"
-              }
-            ]
-          }
-        ],
-        "Special Forces": [
-          {
-            "name": "Elite Praetorian Guards",
-            "image": "http://cloud3.steamusercontent.com/ugc/1862817412081432797/70B4BE3AC3FDE23388AFCD4D48844DD102463B12/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 80,
-            "speed": 2,
-            "upgrades": {
-              "Heavy Weapon": 1,
-              "Training": 2,
-              "Gear": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817957003761532/B9A39E219D561F0CFF064BD65083EF2B03FE2408/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817957003761811/4348E66B49C37DBE90E2798DDBCDAC46ADB90020/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817957003762298/2506A4C1DB297710118290CFCEB8FBCE61A371CA/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817957003761811/4348E66B49C37DBE90E2798DDBCDAC46ADB90020/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817957003762782/37B88231894CD5B671EFD926554F8143F593FD86/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817957003761811/4348E66B49C37DBE90E2798DDBCDAC46ADB90020/"
-              }
-            ]
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455180096325/2AB8CE3FE8B9FFFEC50C420D918E23A0DCF200B1/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455180028599/BF2A5BE67D0934FF1785E154F766FBA82950A84B/"
+            }
+          ]
+        }
+      ],
+      "Heavy": [
+        {
+          "name": "XX-7 Heavy Turbo Laser",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751922250/1D0ACF27CE08CFA865080B62DD8C0E12B87CA802/",
+          "size": "huge",
+          "type": "Emplacement Trooper",
+          "points": 90,
+          "speed": 0,
+          "upgrades": {
+            "Comms": 1,
+            "Generator": 1
           },
-          {
-            "name": "Jet Troopers",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081228934/0854F9987A9760340D1CFB61EA0360C669DB60A3/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 20,
-            "speed": 3,
-            "heavyWeaponTeam": true,
-            "upgrades": {
-              "Heavy Weapon": 1,
-              "Training": 1,
-              "Comms": 1,
-              "Gear": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698013227866981/5EA3E02AC241512021988DBE0EC44754960D7C1E/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698013227867246/FB14C11D0A31B44E68FDEF0CAF9D3CCE7D140EF7/"
-              }
-            ]
-          }
-        ],
-        "Support": [
-          {
-            "name": "125-Z Treadspeeder Bikes",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081161332/82657FF9895270D7FB5B46FFEC762DE81575BFC3/",
-            "size": "medium",
-            "type": "Repulsor Vehicle",
-            "points": 85,
-            "speed": 2,
-            "upgrades": {
-              "Comms": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770981171565/A72EE65BB1B64233BC73B5A19F8BEEB49B6D25C2/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770981171714/24D19968CC914CDDF4318CD7F4D6A4A8C6453857/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1776099479274350301/4B9837939C2036E21527782F78E06152B3BFD831/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770981179713/F1CAD4EA45F501FA427BFC3194823758D23CAB4C/"
-              }
-            ]
-          }
-        ],
-        "Heavy": [
-          {
-            "name": "AT-ST",
-            "displayName": "First Order AT-ST",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081421585/4B0F0B47465016ACD271DAEFE93F062C79776DDF/",
-            "size": "huge",
-            "type": "Ground Vehicle",
-            "points": 170,
-            "speed": 2,
-            "upgrades": {
-              "Pilot": 1,
-              "Hardpoint": 3,
-              "Comms": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817412080755222/3B92EACA1DE861874A44E0001F4686FB7BA30CA0/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817412080755364/E8C5A3482E6C2FFA2AF18518E3F78823CAD68236/"
-              }
-            ]
-          },
-          {
-            "name": "Light Infantry Utility Vehicle",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081200983/383E193D0A6B5D69AB817D4584828A40B0B25C77/",
-            "size": "huge",
-            "type": "Repulsor Vehicle",
-            "points": 75,
-            "speed": 2,
-            "upgrades": {
-              "Pilot": 1,
-              "Crew": 1,
-              "Hardpoint": 1,
-              "Comms": 1,
-              "Generator": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027325137553435779/3A8FDD7CE7E77EA1D206645EEC453C509B3BD6F2/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027325137553435979/8778AF380A0A56B19CD1EA4BC88266803292180E/"
-              }
-            ]
-          }
-        ]
-      },
-      "Rebel": {
-        "Commander": [
-          {
-            "name": "General Rieekan",
-            "title": "Founding Member of the Alliance",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640752085723/9E5DE6BB4E45204DC3A997830A4DC8068C69CABD/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 80,
-            "speed": 2,
-            "upgrades": {
-              "Command": 2,
-              "Gear": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698230624925896/947BD1C75A604FAD92CB77ECAB27AC5109EB7F00/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698230624926095/54D107149A5C01B99334D873DC0D2B172AB71DA7/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Rapid Response",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640752086080/BC550A52E3D05D8FFB63D4673FD71BCAD35FC13C/",
-                "pip": 1
-              },
-              {
-                "name": "Launch Patrols",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640752086446/2245AED04413455E4469534F5D70B03D02DD184C/",
-                "pip": 2
-              },
-              {
-                "name": "Armored Assault",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640752086781/B8BD73E178BA6F4492F8F9C5110E921BDB1ADA3A/",
-                "pip": 3
-              }
-            ]
-          }
-        ]
-      },
-      "Republic": {
-        "Commander": [
-          {
-            "name": "Mace Windu",
-            "title": "Master Jedi",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747447768/91A80BEC147782188809554C9E3E1C89E38D0A8C/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 200,
-            "speed": 2,
-            "upgrades": {
-              "Force": 3,
-              "Command": 1,
-              "Training": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455187825660/20318CF5820801C8D087056BFFF3B448DD1D24C0/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455187825926/3024C576BF271F52A8E09E226B9CE33A850279B5/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "This Party's Over",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747448183/4C67DCF52EA1A41CE347DFA72F1F249E6D2C990B/",
-                "pip": 1
-              },
-              {
-                "name": "High Jedi General",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747448594/5712552FEBB895EB97EFB122230A64DFC888F30D/",
-                "pip": 2
-              },
-              {
-                "name": "Shatterpoint",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747448920/DE303A6D36A7845AD8B10767827027D50EA8738E/",
-                "pip": 3
-              }
-            ]
-          },
-          {
-            "name": "Commander Cody",
-            "title": "Marshal Commander of the 212th",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747469835/A6730D0E28DBDA4AC78F4590BF0C5F1D46083322/",
-            "size": "small",
-            "type": "Clone Trooper",
-            "points": 110,
-            "speed": 2,
-            "upgrades": {
-              "Command": 1,
-              "Training": 1,
-              "Gear": 1,
-              "Armament": 1,
-              "Grenades": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893322692719/36CE1B78678368B94938143D4CEA2773F93F363A/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893322728253/2649AA8D8F66C02A791A73B8AFAD18C25B40A394/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Blast Him",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747470658/793EFE2139085E54F9F85AAC92274E621C66DC6E/",
-                "pip": 1
-              },
-              {
-                "name": "Good Man That Cody",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747471029/C0DD76F36655C93C8C105652951B3B74FCDC202D/",
-                "pip": 2
-              },
-              {
-                "name": "You Must Realize That You Are Doomed",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747471461/265DF114E68306DF604691C110042DDB00C84DAC/",
-                "pip": 3
-              }
-            ]
-          }
-        ],
-        "Operative": [
-          {
-            "name": "Ahsoka Tano",
-            "title": "Stubborn Padawan",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747500577/DCDE4281DCAD8EC68919759915AB4DF09EAB5546/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 110,
-            "speed": 2,
-            "upgrades": {
-              "Force": 2
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817412091474935/EE39ED83BE15C1003350940C488EAEB4D6E9A96D/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817412091472250/A731A2DF0028A305625B39844340B899A3D97A5A/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Twin Lightsabers",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747502894/3AE99D7998FF7322CA29DCF7BAE0B72D459F9110/",
-                "pip": 1
-              },
-              {
-                "name": "Anakin's Apprentice",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747503725/0A7361854FBF8757DA002A670DBAA45BDDFD76D4/",
-                "pip": 2
-              },
-              {
-                "name": "Independant Adept",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747504272/935C0A5511D2455D302753EC8DEE0A9AF0326CB6/",
-                "pip": 3
-              }
-            ]
-          },
-          {
-            "name": "Commander Colt",
-            "title": "Rancor Batallion",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747527226/26A8CE439ADC2BDB1C9EE783B4013366CC9F97A8/",
-            "size": "small",
-            "type": "Clone Trooper",
-            "points": 90,
-            "speed": 2,
-            "upgrades": {
-              "Training": 1,
-              "Comms": 1,
-              "Gear": 2,
-              "Grenades": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693415431516051/4EAB6085C2D2D6C176B3C9847E2F1F228CEFE7BB/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693415431516248/89D5E03C721391A7CBC7930180396F3B14E5273F/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Legacy Of A Legend",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747528124/18B118F66C532CAF69CC82877EC177C68A9A5278/",
-                "pip": 1
-              },
-              {
-                "name": "Shock Traps",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747528435/A7754C5F989DC2C48860EA1F8DDFC671FCD90338/",
-                "pip": 2
-              },
-              {
-                "name": "Shoulder to Shoulder",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747528812/CFDDAA0DDD1CB89C937F8B47D672B78CF44D19D5/",
-                "pip": 3
-              }
-            ]
-          }
-        ],
-        "Special Forces": [
-          {
-            "name": "Clone Paratroopers",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747550450/AB6335C9C96E10F6D70F161BCDFC89FDB2934C57/",
-            "size": "small",
-            "type": "Clone Trooper",
-            "points": 68,
-            "speed": 2,
-            "upgrades": {
-              "Heavy Weapon": 1,
-              "Personnel": 1,
-              "Training": 1,
-              "Comms": 1,
-              "Gear": 1,
-              "Grenades": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693290507071203/040CF6A943C83588994E5BD8C0DDB793F6DE9875/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693415425506623/121AA3B4552A900E92161C97E55443D4040D7886/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693290507016826/760576DD3D314CB88313B54E105FB561009F8502/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693290506836632/AE0366ABB62BED44CC56CB5F25D5C6478592EBBF/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
-              }
-            ]
-          },
-          {
-            "name": "Republic Commandos",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747569673/F45852AF875FCB41E9BB5B23FFACC1029A8E548C/",
-            "size": "small",
-            "type": "Clone Trooper",
-            "points": 100,
-            "speed": 2,
-            "upgrades": {
-              "Training": 1,
-              "Comms": 1,
-              "Gear": 1,
-              "Armament": 2,
-              "Grenades": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455182355861/149A0196C96C1D78830C56F479A27BF825E9C6AB/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455182206940/096195C231ECC170C0963163315EFADABC01D5D7/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455182228456/B086CF963F81B78DCBE9E0893013169CF6454817/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455182206940/096195C231ECC170C0963163315EFADABC01D5D7/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455182280894/C546CADEC6AD3A41EFFC07CCD86AAE1EFB325BC7/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455182206940/096195C231ECC170C0963163315EFADABC01D5D7/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455182431253/81E98F267170F435E05AA7ED621A04F6476DC3B0/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455182206940/096195C231ECC170C0963163315EFADABC01D5D7/"
-              }
-            ]
-          }
-        ],
-        "Heavy": [
-          {
-            "name": "AT-AP",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747585288/91E17B9FFBE325EE7E46C3F18DF4E613EF60E6A3/",
-            "size": "epic",
-            "type": "Ground Vehicle",
-            "points": 165,
-            "speed": 1,
-            "upgrades": {
-              "Pilot": 1,
-              "Hardpoint": 2,
-              "Comms": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756243525814/22DBD5FF8C4A887FF7DBFD977F190A7192C1D4B7/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756243525957/D334BA41B51D1DD235E2A5ED14F1EEACC9CD9EEF/"
-              }
-            ]
-          },
-          {
-            "name": "LA-AT/I Gunship",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747615420/DD22D969B4D59595325925BD059DBF83F295F406/",
-            "size": "epic",
-            "type": "Repulsor Vehicle",
-            "points": 190,
-            "speed": 2,
-            "upgrades": {
-              "Pilot": 1,
-              "Hardpoint": 2,
-              "Ordnance": 1,
-              "Comms": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028454854943442054/64C9040DF30E7980A9E9F22FD7A56D5C84052167/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028454854943501740/E509E21CEB3321071E6F56B006F24C1D919B6F3B/"
-              }
-            ]
-          }
-        ]
-      },
-      "Resistance": {
-        "Commander": [
-          {
-            "name": "Finn",
-            "title": "First Order Defector",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752987105/4E0911D06D60474448E5EF5CFB340A7CA015C62D/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 110,
-            "speed": 2,
-            "upgrades": {
-              "Command": 1,
-              "Comms": 1,
-              "Gear": 1,
-              "Armament": 1,
-              "Counterpart": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770985763040/56F6F436F140391F26FB16960E2D6CD57FB14B71/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770985763307/FB7EDB7C8D248BF873C1405012C99CC32C9FEBAA/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Big Deal",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752986056/CDC39A7E6D1022EC938F8F8A599EE7513650A574/",
-                "pip": 1
-              },
-              {
-                "name": "Come Get It",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752985107/DEB9D333DCC6E48F6855736D9E28A806719CE0E0/",
-                "pip": 2
-              },
-              {
-                "name": "I am with the Resistance",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752983093/53828D3EB704897C38DD09ECE6E0083DEB51146F/",
-                "pip": 3
-              }
-            ]
-          },
-          {
-            "name": "Poe Dameron",
-            "title": "Reckless Flyboy",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1022821770975464596/6EDA2DD86069BD1A0B3B2690B5397BC3FC01C228/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 100,
-            "speed": 2,
-            "upgrades": {
-              "Command": 1,
-              "Training": 1,
-              "Comms": 1,
-              "Gear": 1,
-              "Counterpart": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770984969371/73F6B8B3D8D4C55321CBCE3D8B75E5A7E5B25A94/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770984969603/8925F3262BB3FE97EC31D45DAE964400AE8A528F/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "We are the Spark",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1022821770975465215/89BB4AAD301785869E3A3C44CFB2745F511C8FE8/",
-                "pip": 1
-              },
-              {
-                "name": "Dead Heros",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1022821770975470651/B99A6006460BC0A2B198BBE3CE6BA403E3B1AB7A/",
-                "pip": 2
-              },
-              {
-                "name": "I Need a Pilot",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1022821770975471416/4ED3DFBB9E55FC22BA5F9A7E2B1D5B5229CE9C79/",
-                "pip": 3
-              }
-            ]
-          }
-        ],
-        "Operative": [
-          {
-            "name": "Rey",
-            "title": "Force Prodigy",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1022821770981203693/E3069DE71ED495326B84393B00F82E021420E753/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 125,
-            "speed": 2,
-            "upgrades": {
-              "Force": 1,
-              "Training": 1,
-              "Gear": 1,
-              "Armament": 1,
-              "Counterpart": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804925013057/F62D7D1921B435B28DDB56BD129BB39D1FB2C2FD/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324712401180346/5DD131A4135CF4C90A2D42D264F3FAB332155AB3/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "The Force Awakens",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1027324582151432669/7A2F43C29C19033B13852F63165D64A18D766544/",
-                "pip": 1
-              },
-              {
-                "name": "You Came back For Me",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1027324582151438024/BC43E151F85D06C17D0602947648984AA604E08F/",
-                "pip": 2
-              },
-              {
-                "name": "I Think I Can Handle Myself",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752998047/158965EE8DD63D9BD1A1F43BC7E51993538FC7E3/",
-                "pip": 3
-              }
-            ]
-          },
-          {
-            "name": "BB-8",
-            "title": "A Clever Little Droid",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1022824296871784130/E6058352DDF98D626EC56C53D97FBD31675E6898/",
-            "size": "small",
-            "type": "Droid Trooper",
-            "points": 45,
-            "speed": 2,
-            "upgrades": {
-              "Comms": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068157620585/9E7930221D8CD87F6338B9D4B58F4D3F824D08C0/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068157620780/493748852320ED988465533F8BC49FEA2672A9E8/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Happy Beeps",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157653789/55772CA9D24676C0367BBAC6F831F03E0340F4EB/",
-                "pip": 1
-              },
-              {
-                "name": "Keep an eye on this kid",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157657298/77DAA5AFFEDD096EC568637DC3777E4696DE7D9D/",
-                "pip": 1
-              },
-              {
-                "name": "Engineering Expertise",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157658855/8B72242F4B9650FC1DBE591F7FE32D574808DAA1/",
-                "pip": 2
-              },
-              {
-                "name": "Never Underestimate a Droid",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157658236/1E07FA41D1449A2991220D2733B1F51D2565C4F7/",
-                "pip": 2
-              },
-              {
-                "name": "A Mutual Understanding",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1022824296871786871/AF5D00FAB14B8C70B843DFB4BD18D6EFC9F8ADD1/",
-                "pip": 2
-              },
-              {
-                "name": "Impromptu Imposter",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157655413/18B1636E2055305E94F285684921B2FDAA773450/",
-                "pip": 2
-              },
-              {
-                "name": "Good Things Come Back",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1022824296871785786/4EA05DE445200A52D753CD1A023028FE0B5F0A0D/",
-                "pip": 3
-              },
-              {
-                "name": "Deus Ex Machina",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157655832/49730DEF4AAD9BF0481CA578387F21D074A104D8/",
-                "pip": 3
-              }
-            ]
-          },
-          {
-            "name": "R2-D2",
-            "title": "Hero Of A Thousand Devices",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1022821770981205050/4D72685715DF8671198FA4BC591397371BC96665/",
-            "size": "small",
-            "type": "Droid Trooper",
-            "points": 45,
-            "speed": 1,
-            "upgrades": {
-              "Counterpart": 1,
-              "Comms": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/776232727456806966/EFBA4A71BFE748A2868C14B82DA3A7B0D559874A/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/777357228032306302/F5CA6FC54A8625E261F123D73792DE36D74E1686/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Blast Off!",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564037063/A7AE3401CB3A51A58A8682BBCD8D6F6C104804AF/",
-                "pip": 1
-              },
-              {
-                "name": "Impromptu Immolation",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564035209/4C4829AE9D1B01B14F2D4FDE2C6D3935D8055954/",
-                "pip": 2
-              },
-              {
-                "name": "Smoke Screen",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564033033/7FC32081CE8646476E7B0C475F452AA629BA7713/",
-                "pip": 3
-              }
-            ]
-          }
-        ],
-        "Corps": [
-          {
-            "name": "Resistance Troopers",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1027324582151747849/0DC6B237D0C8CC16BE47236FF1B5268D403945C1/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 30,
-            "speed": 2,
-            "upgrades": {
-              "Heavy Weapon": 1,
-              "Personnel": 1,
-              "Gear": 1,
-              "Grenades": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804924627970/AE0B4993C8FA598D93829CF55F0E0A6415ACBBFB/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324582151454188/1EC7453DFA3870ADCA468AD5A9257330B58CF8F4/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324582151456311/376D681EDE4D18D355A359F47C49551B6AC5EBAA/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324582151456617/9EBFAB9697DE7A1435FF501C6F39BBCC3B244BCB/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324582151464621/CEB3271C1C9E43C30C41206E919ACA9AFFB45247/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324582151464893/EF78574A7DFC9EBC7EC9FB76B27BA5F846B8F97D/"
-              }
-            ]
-          },
-          {
-            "name": "Resistance Trench Fighters",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1017194020628449858/1DC8646D5B2D0F5ABF7828732E6DE923F301DE46/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 39,
-            "speed": 2,
-            "upgrades": {
-              "Heavy Weapon": 1,
-              "Personnel": 1,
-              "Training": 1,
-              "Gear": 1,
-              "Grenades": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248440350/60BC7FB4B3F6B327003DAB9B924C5EC98FA67C4B/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248444916/D62AC2DD70775BA5025900AC76975C4AB45A54CC/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248441473/F330E21469E4FF560B9E8892E784C14373697F16/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248440578/125E76600442E01E3AD18725563EA1BE4D63BEFA/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248442051/472D72BABB02CCA9F99639F83E21A9D3AF83BB14/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248440578/125E76600442E01E3AD18725563EA1BE4D63BEFA/"
-              }
-            ]
-          }
-        ],
-        "Special Forces": [
-          {
-            "name": "Salvaged B2 Battle droids",
-            "title": "Defenders of the Colossus",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1021698068155819425/F5A156E66B986DA76D65B649D689496C6A4BB79A/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 64,
-            "speed": 2,
-            "upgrades": {
-              "Heavy Weapon": 1,
-              "Comms": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/775105953849586118/94F967F21EA7E390A200C4BDA5581D07DBB37AC2/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/775105953849585789/91A639AB9F57BE393683DA53212E395886307C52/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/775105953849586430/E5941CF7A3631E6D4A28832AE489A4340C96B0B9/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/775105953849585789/91A639AB9F57BE393683DA53212E395886307C52/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/775105953849586226/9326AD8D3EC80CC53F4BF2D156014978DCD715D9/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/775105953849585789/91A639AB9F57BE393683DA53212E395886307C52/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/775105953849586324/B5D59E535AFA2BF99FCA3C584E28FA500ADB89BD/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/775105953849585789/91A639AB9F57BE393683DA53212E395886307C52/"
-              }
-            ]
-          }
-        ],
-        "Support": [
-          {
-            "name": "Orbak Riders",
-            "heavyWeaponTeam": true,
-            "image": "http://cloud-3.steamusercontent.com/ugc/1022821770986742661/33B78DBDC2B4A466B810D5299DB14745FAFB1E68/",
-            "size": "medium",
-            "type": "Creature Trooper",
-            "points": 45,
-            "speed": 2,
-            "upgrades": {
-              "Heavy Weapon": 1,
-              "Comms": 1,
-              "Gear": 2
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770976478153/4E00BD588837F87DDA2828DC092CEEE3BEDCC7A3/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770976472996/354C4EE85A60585BD0FB817AFEE21D00E93799BA/"
-              }
-            ]
-          },
-          {
-            "name": "Rose Tico",
-            "title": "Skilled Technician",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1021697620253184171/055BD7F8C30E5D043104316A572B1846227F6DC5/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 50,
-            "speed": 2,
-            "upgrades": {
-              "Comms": 1,
-              "Gear": 2,
-              "Counterpart": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697601906861807/C7CB31D9AFAFF6C7B2633663A2A33D939F4E8205/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697601906862116/99E8BDA93C81AD3875DFC214AA5E39DC4F5477A5/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Saving What We Love",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1021697620253191671/458068FD2D398FA6C7540EEFF383BD8E39509350/",
-                "pip": 3
-              }
-            ]
-          }
-        ],
-        "Heavy": [
-          {
-            "name": "V-4X-D Ski Speeder",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1021697620252781965/A29532E1391479BD4424DEE3CD7130CC5927AB08/",
-            "size": "epic",
-            "type": "Repulsor Vehicle",
-            "points": 140,
-            "speed": 3,
-            "upgrades": {
-              "Pilot": 1,
-              "Hardpoint": 1,
-              "Comms": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804931072163/80F5B756EF0C02455B5C31CD1A608DD51B9108BD/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804925084213/855D3C37D204F44B1840665B50CCCB73A7CD62D2/"
-              }
-            ]
-          },
-          {
-            "name": "V-232 Turret",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157670378/DB2D6E46CD982AE3C38EA63F93939CDC2EECA984/",
-            "size": "huge",
-            "type": "Ground Vehicle",
-            "points": 100,
-            "speed": 0,
-            "upgrades": {
-              "Comms": 1,
-              "Generator": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068157631207/B54652720E993614D7AD481BD4A1B8236561DCAA/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756247150301/5C9F0E6F01394012B925C60CC4D8548E66B05427/"
-              }
-            ]
-          }
-        ]
-      },
-      "Revans Sith Empire": {
-        "Commander": [
-          {
-            "name": "Darth Revan",
-            "title": "Fallen Lord",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281811934/A5A06CC61DE1B518F307931E848ED0F2F84DBE3C/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 220,
-            "speed": 2,
-            "upgrades": {
-              "Force": 3
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933832570/34E443C62233F9BFAB5A1A56848C92AF12D16DB0/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933823285/EE9DA185779FAC54191A9DC0353E57D542CF6EE9/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Slayer of Mandalore",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281812320/441136636E20A3C920D22041163506AC74BD9E34/",
-                "pip": 1
-              },
-              {
-                "name": "I am the Dark Lord of the Sith",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281812673/A864BC3FB16C88EF914102FA82EBE360D05B7016/",
-                "pip": 2
-              },
-              {
-                "name": "The Fallen Lords",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281813019/D00A57B0F11280E97F8A27269F9F39A031001D38/",
-                "pip": 3
-              }
-            ]
-          },
-          {
-            "name": "Darth Malak",
-            "title": "Treacherous Apprentice",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281873194/CE73E7B8BE4C4C155231F3BBEE4F857395F1C174/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 195,
-            "speed": 2,
-            "upgrades": {
-              "Force": 2
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933880695/1D163F620C1BF4639F889CE39C1DCB6E8ED159E9/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933876696/ED5A556257FEA5E3EA9AD18215604CB599E132C2/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "This is but a Taste of the Dark Side",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281873643/108B3E63FB5AAE3E70915C74CB0CEADB660F1899/",
-                "pip": 1
-              },
-              {
-                "name": "You Will Forever Stand Alone",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281874073/CC8FEB5E5D0934D8C0FA1A3E8752A656D6EE849E/",
-                "pip": 2
-              },
-              {
-                "name": "Wipe this planet from the face of the galaxy",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281874384/99D8B33D2B2422AFD4D24953C07B352DD585F493/",
-                "pip": 3
-              }
-            ]
-          }
-        ],
-        "Operative": [
-          {
-            "name": "Calo Nord",
-            "title": "Nefarious Bounty Hunter",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412068777865/AD645A6CA22119B08159D249FF1FAA79A9ABF568/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 90,
-            "speed": 2,
-            "upgrades": {
-              "Training": 2,
-              "Gear": 1,
-              "Grenades": 1,
-              "Armament": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817412068837885/8382AD2EDA22D520AF2FFAF89E3D4CF044EB2E71/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817412068838066/B01C1691D062FFBDAF364DFA926330D8F0C107C5/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Updated Contract",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412068780726/450A5AD57585FD96262A630B2C7CC574CA293F41/",
-                "pip": 1
-              },
-              {
-                "name": "I am hard to kill",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412068781019/5958B05B2457B2A3F1BFDA10269F84EDBA1DC7B4/",
-                "pip": 2
-              },
-              {
-                "name": "One. Two. Three.",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1862817412068781429/29B9885FB2E1E129E6F684472C7281B09617EB46/",
-                "pip": 3
-              }
-            ]
-          }
-        ],
-        "Corps": [
-          {
-            "name": "Sith Troopers",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281907874/694CCAFD2FB6C6ADA01DAB52DCEFB6CE4DBAB1D0/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 44,
-            "speed": 2,
-            "upgrades": {
-              "Heavy Weapon": 1,
-              "Personnel": 1,
-              "Gear": 1,
-              "Grenades": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933591216/236BEBCCFA8E4701879F66DE28E7E61EB71696DA/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933675175/1561AB6D3E5FCD7952FC0B2A76BEF1B14D75D00D/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933538068/07579EBF0F9C9A7BD0DBC30EFE30BEEF1FB31D33/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933630508/AF5621F9AAF5556EADD9373D4C8F7DE5C3A6D95D/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
-              }
-            ]
-          }
-        ]
-      },
-      "Scum": {
-        "Commander": [
-          {
-            "name": "Tyber Zann",
-            "title": "Cold, Methodical, and Ruthless",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735070640/74612E44D0AF4F505937EE2E0DAF21C08EB4E15B/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 140,
-            "speed": 2,
-            "upgrades": {
-              "Command": 1,
-              "Training": 1,
-              "Illicit": 1,
-              "Gear": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365775807/337D2A5009DD4A91F0A469B418D4C77867FDF52D/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365776115/8606DE28865E723D2343D17F890A99959E25AC8F/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Orbital Bombardment",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735071380/B7CEA3F14638418D63BEFF3F7A611F5078D31667/",
-                "pip": 1
-              },
-              {
-                "name": "Corruption is My Weapon",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735071871/7524B10AD4DB25DAA1E5F5F0275A58DE9C3EC666/",
-                "pip": 2
-              },
-              {
-                "name": "Everyone Has a Price",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735072378/3A407CC85B615E03763D5F22E7116CA3FB217F0B/",
-                "pip": 3
-              }
-            ]
-          },
-          {
-            "name": "Urai Fen",
-            "title": "Loyal Lieutenant",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735039360/1B0C02842ADDAA687687E529BE8B33983CAD933F/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 90,
-            "speed": 2,
-            "upgrades": {
-              "Training": 2,
-              "Illicit": 1,
-              "Gear": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984835649865/8FC3F2E4E22555D72BDF283AD0E686537F33A043/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984835650100/057E08B03AAE7CA89B585D8916BB25023B63341A/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Strike and Fade",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735040340/32D15FA78098AB05AD6D98B51631935EC6DEC3C3/",
-                "pip": 1
-              },
-              {
-                "name": "The Consortium Commands It",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735041426/F309B5F10C9F44B3E9FE50A42FAD541185DEE9A5/",
-                "pip": 2
-              },
-              {
-                "name": "No Mission is too Dangerous",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735047596/1516182BE8ED3D0635F56F830C4FB85F869C477C/",
-                "pip": 3
-              }
-            ]
-          },
-          {
-            "name": "Defiler",
-            "title": "Under Cover Agent",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735208736/794BBDD282201AA4D82C0B728D90073E6CAF423C/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 90,
-            "speed": 2,
-            "upgrades": {
-              "Training": 1,
-              "Gear": 1,
-              "Armament": 1,
-              "Illicit": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515362210843/CDD5E72C8CE5B42739060E6ADC81DC64751294F0/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515362211007/246011C13B53F2A881968B8996802F50B33D075F/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "I Like Explosions",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735209433/1B7DC25C849E9B7D2657E40E71FF198B8588381F/",
-                "pip": 1
-              },
-              {
-                "name": "Nothing Stops Me",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735210006/8EAEC185C0C43B5D6099ED763E9B3D4FC5C493A5/",
-                "pip": 2
-              },
-              {
-                "name": "I Stand In the Shadows",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735210753/1BF727CB55BFAB8151A9F9A368C91C6B76248636/",
-                "pip": 3
-              }
-            ]
-          },
-          {
-            "name": "Pre Vizsla",
-            "title": "Defender of Tradition",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640671157/50ED9FE9885FBF3530E3BF5D7E2ECA85E331972F/",
-            "size": "small",
-            "type": "Mandalorian Trooper",
-            "points": 165,
-            "speed": 3,
-            "upgrades": {
-              "Command": 1,
-              "Training": 2,
-              "Illicit": 1,
-              "Gear": 1,
-              "Armament": 2
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886396178/07FB37CA0A11552BEF96C3DCA10AF232C65AF7B6/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886396372/35E5047903DC30F882B40719809ECF90DBC65A5A/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Blade Launcher",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640671650/36CC81AF419D113B28FC5AB7CF6B3210085DFB45/",
-                "pip": 1
-              },
-              {
-                "name": "Warlord of Mandalore",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640672041/2F91858F91AB3648DDEF429A5C1C584D129634C1/",
-                "pip": 2
-              },
-              {
-                "name": "Rise of the Death Watch",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640672498/BED2FE1183721CCB1A1B623A6C4DED69383DA739/",
-                "pip": 3
-              }
-            ]
-          },
-          {
-            "name": "Jabba The Hutt",
-            "title": "Vile Gangster",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741311873/1C5E99B44B0F2BAB89FF0F00315D88DCAC991BBE/",
-            "size": "large",
-            "type": "Trooper",
-            "points": 180,
-            "speed": 1,
-            "upgrades": {
-              "Command": 2,
-              "Counterpart": 1,
-              "Illicit": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984838965716/328A3D3A0AFDA83FC55E8DDCAF62845FFF80CF64/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984838965864/2C27448D99B31E0730B60E10427A6009A6AEF1C7/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Appetite for Violence",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741312832/9DD7CEC7F0A4BBEC81E368726BA5A07E4F81AD9D/",
-                "pip": 1
-              },
-              {
-                "name": "Sinister Belly Laugh",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741313391/27122DF6EB3315976464D7B481537EE5E1E58D94/",
-                "pip": 2
-              },
-              {
-                "name": "Big Shot Gangster",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741313883/86E8818123FD0C01DA7890E271BE897212D4733D/",
-                "pip": 3
-              }
-            ]
-          },
-          {
-            "name": "Hondo Ohnaka",
-            "title": "Self-Serving Pirate",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738473397/8A62072BB1AFA3D4BF14CC3BA56EB1C2F1614F46/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 90,
-            "speed": 2,
-            "upgrades": {
-              "Command": 1,
-              "Illicit": 3,
-              "Armament": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697601906780896/650CF3405CD4106C46B9CB7F0B8C3884B62CD278/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697601906781011/E61558EE4DCDF12D33E98940751D940381181C93/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "No Longer Profitable!",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738477182/571BC50F3C1ABB05DAF75F3BE004DCEBD4C27DD7/",
-                "pip": 1
-              },
-              {
-                "name": "Drive a Big Tank",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738476702/E723D8E97412E2B9E422741F4E2225D5B8A146C8/",
-                "pip": 2
-              },
-              {
-                "name": "Insolence! We are Pirates!",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738475852/69D3EE2DF1CDA15E4BDC49F143CE2DD621B8553F/",
-                "pip": 3
-              }
-            ]
-          }
-        ],
-        "Operative": [
-          {
-            "name": "Silri",
-            "title": "Dark Witch",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735151492/82278C71E894B0710E02376909241ECAAD41F8C7/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 150,
-            "speed": 2,
-            "upgrades": {
-              "Force": 1,
-              "Training": 2,
-              "Illicit": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984835654759/B33E7C3B1D34E7DDAC7B617DC466F12FF66774E1/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984835654931/3ACEDEC6F99A311A245C7492883DAB9720D05348/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "I Shall Rip Out Their Souls",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735165967/E52C14F2A96A0DDA785B12C9400F47E9E5E2F4A7/",
-                "pip": 1
-              },
-              {
-                "name": "Come Closer",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735165400/6E97DF5AC3BF3172E316DD409240AA04BD4C6DE4/",
-                "pip": 2
-              },
-              {
-                "name": "They Will Know Fear",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735164916/B6CDD990B416AE4B7897AB3A27E35ACD4A46DE07/",
-                "pip": 3
-              }
-            ]
-          },
-          {
-            "name": "Bo-Katan Kryze",
-            "title": "Death Watch Lieutenant",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640560685/8771A2D7895F003917A4CD9D170E7D5FBAA81D65/",
-            "size": "small",
-            "type": "Mandalorian Trooper",
-            "points": 120,
-            "speed": 3,
-            "upgrades": {
-              "Training": 2,
-              "Gear": 1,
-              "Armament": 2
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886421665/441B37D17213CA1B82174A8988ED23AA2D59336E/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886421832/BBE3592A7496E444E116271913178A8ED41F5323/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Poison Dart",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640561281/E6C9BE0EB9F4357B31FB1459E8615D85BBE6F660/",
-                "pip": 1
-              },
-              {
-                "name": "Fierce and Deadly",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640561707/6E91E487B7F9AD4225A336081B4AB58F4AAB3CD2/",
-                "pip": 2
-              },
-              {
-                "name": "Memorable and Funny Quote",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640562097/E3FFDCB0E1AC2EB8E690C90C0599AA093788759C/",
-                "pip": 3
-              }
-            ]
-          },
-          {
-            "name": "Dengar",
-            "title": "Payback",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743206950/10A169A5029EDFC4ACA82E73B8BA7D4777BB499D/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 105,
-            "speed": 2,
-            "upgrades": {
-              "Training": 1,
-              "Illicit": 1,
-              "Gear": 2
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982050300/7F58F09A4EBE2B1D4036CA35ECD771FAC087027F/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982050497/14DBD099731E973681F538C811E89F52971C6258/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Ello Darlin",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743207736/AC879456E5C89349EDE04DC810B7437A49F9017B/",
-                "pip": 1
-              },
-              {
-                "name": "Thats Not a Knife",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743208077/F604A72BAD8ADED41170B6134687C8792E272C0B/",
-                "pip": 2
-              },
-              {
-                "name": "Credits are Calling my Name",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743208459/015271D4636D4659598040A7A33AABA2A7373863/",
-                "pip": 3
-              }
-            ]
-          },
-          {
-            "name": "Greedo",
-            "title": "Mercenary of Misfortune",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741745161/DE21A067535ADD00F083F96CE00AEF706CDBC1B3/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 60,
-            "speed": 2,
-            "upgrades": {
-              "Training": 2,
-              "Gear": 1,
-              "Grenades": 1,
-              "Flaw": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697128192156760/0799D47F8ABA442104B92441C2EE558246DD447B/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697128192156907/44D809B717035663BCC53BBF8B6C34E47F27D953/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Maclunky!",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741745870/4D9A87A50635EFDD25A2E01B381D20FC3B23D0E7/",
-                "pip": 1
-              },
-              {
-                "name": "Oonta Goota?",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741746363/52B7999E4C27DFA029632DF034C633BD94B6ECE3/",
-                "pip": 2
-              },
-              {
-                "name": "E Chu Ta",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741747117/E0DD4D0E9489424A42EF020B57AFCB2E34CC3935/",
-                "pip": 3
-              }
-            ],
-            "required": ["I'll Bet You Have"]
-          },
-          {
-            "name": "IG-88",
-            "title": "Calculating Assassin",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743156483/4AB94765581EEA7C01F1C931649279C0820A18D6/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 130,
-            "speed": 1,
-            "upgrades": {
-              "Training": 1,
-              "Illicit": 1,
-              "Gear": 2,
-              "Grenades": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982048942/6855349E653C6F4E0433AF56E1554F75F307CBF3/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982049139/F1EB5D96934D784828CAD32E88CFD581446B6041/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Toxic Dioxis Despenser",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743157480/AC5FF98814A9D017737A5C5FEDE3FD7E401A7D4D/",
-                "pip": 1
-              },
-              {
-                "name": "Defensive Programming",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743157867/DBE4FB014B259FD7B2E4C6774D766C557735F320/",
-                "pip": 2
-              },
-              {
-                "name": "I Destroy, Therefore I Endure",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743158259/1693B7E0EECA04393914E8566B892A1E0052039F/",
-                "pip": 3
-              }
-            ]
-          }
-        ],
-        "Corps": [
-          {
-            "name": "Grenadier Squad",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735128053/8071373F43B26B004A85BB1423AE10D8BA9FA2D9/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 33,
-            "speed": 2,
-            "upgrades": {
-              "Personnel": 1,
-              "Illicit": 1,
-              "Comms": 1,
-              "Gear": 1,
-              "Grenades": 2
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365822891/9245AC0020E31C369AE4129B35D0BA467A01F2B4/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365823446/E94BC334A0B2F95CFB75FEDC3A0FEDF2FFD5A970/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365824294/5F43B720E0198A078E25BA472E7DDBCA8F51CBEC/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365824481/27693FC709ADF50440623C6347A11151608D5E2F/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365824294/5F43B720E0198A078E25BA472E7DDBCA8F51CBEC/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365824481/27693FC709ADF50440623C6347A11151608D5E2F/"
-              }
-            ]
-          },
-          {
-            "name": "Hutt Cartel Troopers",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741193364/B2A9024FE737F3E6CAC757C062FAE63B180020F4/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 40,
-            "speed": 2,
-            "upgrades": {
-              "Heavy Weapon": 1,
-              "Personnel": 1,
-              "Illicit": 1,
-              "Grenades": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132327065/C97ECB0137975A84387D1450B76E656DD3A34CC6/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132327244/97AF50B5FA4E76262E8F7A6BBCBF465FD8D13210/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132328895/00FFC141D583FDE6EB27DCEF374C6EA79E4BC8DC/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132233662/46758BE4190670991AEEB84884D2C0926704577E/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132328408/9323E551FA703709CF34056F60EB7B9808DBBC6F/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132233662/46758BE4190670991AEEB84884D2C0926704577E/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132327863/05220805319D5F586AF2C45288D1880BBCF5B1D4/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132233662/46758BE4190670991AEEB84884D2C0926704577E/"
-              }
-            ]
-          },
-          {
-            "name": "Weequay Pirates",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738627390/5CC1A1E67FA0FB421324802CFFF43AEBF54CC512/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 44,
-            "speed": 2,
-            "upgrades": {
-              "Heavy Weapon": 1,
-              "Personnel": 1,
-              "Illicit": 2,
-              "Grenades": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436112170/7B9627FA526DBD9262F7B82066DF7F5BDF1E5B76/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112951/28554A829163EDA67DDE90D1CF137C093FF8A9AC/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436113638/F31ACA002873CE6039E4A0438F29423E59383C71/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112951/28554A829163EDA67DDE90D1CF137C093FF8A9AC/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436114564/440659EBF9A36F6A6E2C7E4C7AE6B2C6A6DBFABD/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112951/28554A829163EDA67DDE90D1CF137C093FF8A9AC/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436115021/ECE24BA2DD41BC0C0EA4638CF553ABDE1969DC4C/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112951/28554A829163EDA67DDE90D1CF137C093FF8A9AC/"
-              }
-            ]
-          },
-          {
-            "name": "Hired Guns",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741999970/AEA964040C9423D7CB3BBFE8E6127BFF6D9B4B16/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 36,
-            "speed": 2,
-            "upgrades": {
-              "Heavy Weapon": 1,
-              "Personnel": 1,
-              "Illicit": 1,
-              "Armament": 1,
-              "Grenades": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138162716/6618383926180465FB60EC9786E27A680C85BFC9/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138162922/C28DD0F623633DABFC9748FFE85A4AFA8D6010DE/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138162195/FB52D7D4C013778E22F5FB391B8506E10F7C8126/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138163807/FF1D50425F0F472D96EA277636EC08E98F969A4F/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138164240/210C9B6E98EBF1F2648A855CDFFEA405E75AFB82/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138164385/1460EF2F670C31A209FB8FD428800D727F310A9F/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138164936/04CD0F0BF910DC7E078F67D680411F0B948714C2/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138165334/AEF9F43EDE77B3E981B4EE3CFA26869D27B45CE0/"
-              }
-            ]
-          }
-        ],
-        "Special Forces": [
-          {
-            "name": "Mercenary Assault Squad",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735112958/CA567516B908134719A9891C1855E81C88E39E7E/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 72,
-            "speed": 1,
-            "upgrades": {
-              "Heavy Weapon": 1,
-              "Training": 1,
-              "Illicit": 1,
-              "Gear": 1,
-              "Armament": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365876771/3C9BD90A0E8E6BA277A1133D1AF61B2D44C2DEB0/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365877132/5DEAE7FFFF586E0ACBFD5BB29AF4869E6D675044/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365880281/45B6B327A692DBFDE6D5E5F642EB7FEBBC2A0A4F/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365878394/8AD2A611C51D78184D8E4204A720C59EEC2C7755/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365879761/026D7FD22C9074A12068AE05CE293EBB833FC70E/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365878394/8AD2A611C51D78184D8E4204A720C59EEC2C7755/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365879295/EC66EBB1550D6D61DAC1AC96CAE92A0273B06A45/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365878394/8AD2A611C51D78184D8E4204A720C59EEC2C7755/"
-              }
-            ]
-          },
-          {
-            "name": "Infiltrators",
-            "title": "Strike Team",
-            "heavyWeaponTeam": true,
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638837280/E9F99045D6B7FA98055D860B700FB5402373070B/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 22,
-            "speed": 2,
-            "upgrades": {
-              "Heavy Weapon": 1,
-              "Training": 1,
-              "Illicit": 1,
-              "Comms": 1,
-              "Gear": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068156464007/651A73813208989A1D36777648388ABBF2F11376/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068156464181/1FABB24F11BA883FEB5A7CB16CB7EAE86CB50402/"
-              }
-            ]
-          },
-          {
-            "name": "Death Watch Fireteam",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736281138/4153C964147552CEAC2E3E23A51ED5358BC5C424/",
-            "size": "small",
-            "type": "Mandalorian Trooper",
-            "points": 54,
-            "speed": 3,
-            "upgrades": {
-              "Heavy Weapon": 1,
-              "Training": 1,
-              "Illicit": 1,
-              "Comms": 1,
-              "Gear": 1,
-              "Armament": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886427483/34A3605CA2B2D8280D40991583D41D7D1B3F0E31/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886427771/60D6CA1D97D822A2222E4FAF614931265B7B0AF2/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886435784/9A83A99579A78DF53A23E3FFB79C07798E4F3C5C/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886427771/60D6CA1D97D822A2222E4FAF614931265B7B0AF2/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886429750/5D62ADB1200B1AD16A0349AF87E757F40E720115/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886427771/60D6CA1D97D822A2222E4FAF614931265B7B0AF2/"
-              }
-            ]
-          },
-          {
-            "name": "Nite Owls",
-            "title": "Bo-Katan's Elite",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736216918/59B584E476FCEAE304E4E3152B4BF12843AE9214/",
-            "size": "small",
-            "type": "Mandalorian Trooper",
-            "points": 60,
-            "speed": 3,
-            "upgrades": {
-              "Training": 1,
-              "Illicit": 1,
-              "Comms": 1,
-              "Gear": 1,
-              "Armament": 1,
-              "Grenades": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357880094/FFFBDA79DE3B6192926EFCDFC257708C2A360562/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515357880292/78883B5B08CCDC0B7BC4EF36D45DAB06E9057FEB/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357881561/B365369415AE0FB6A96E69817D76D9BAD1366038/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515357880292/78883B5B08CCDC0B7BC4EF36D45DAB06E9057FEB/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357880886/06542D3BD6F03DC43D9E675680F86F2964B210F9/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515357880292/78883B5B08CCDC0B7BC4EF36D45DAB06E9057FEB/"
-              }
-            ]
-          },
-          {
-            "name": "Gamorrean Gaurds",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741407333/B5A53DE0F8D6ECC08CCD913669E3AB7D846F9320/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 75,
-            "speed": 2,
-            "upgrades": {
-              "Heavy Weapon": 1,
-              "Training": 1,
-              "Illicit": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407431269414/974FE237CC3CE17AEC2C321DBB69DE340A0D962F/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407431269590/C7A08ECB6A962EC390A208C771B6A8AF513AE685/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407431271048/84FBE9C70610660263F4FE0424E1C02C401A945B/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407431270422/909F25E16D76BF99AE8122963CEE8BAD7ECFD15A/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407431270243/80653030A9E58BF9637ED105E4F63598082B2D9E/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407431270422/909F25E16D76BF99AE8122963CEE8BAD7ECFD15A/"
-              }
-            ]
-          },
-          {
-            "name": "Beast Master",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741833198/7B472992DE2786ABF9B11852AC28F1BBE3EFF7BF/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 20,
-            "speed": 1,
-            "upgrades": {
-              "Training": 1,
-              "Comms": 1,
-              "Illicit": 1,
-              "Gear": 1,
-              "Counterpart": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696827920718216/511748ACB39B86DB07F412D61B8BC0706C09A5C5/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696827920718383/E67A519C2234A19CB159E833352376586A237A07/"
-              }
-            ]
-          },
-          {
-            "name": "IG-86 Sentinel Droids",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742381727/F1DAD4DF93EE4BE12C4E2E2BC1D7BADF29BAD32A/",
-            "size": "small",
-            "type": "Droid Trooper",
-            "points": 80,
-            "speed": 2,
-            "upgrades": {
-              "Heavy Weapon": 1,
-              "Training": 1,
-              "Illicit": 1,
-              "Gear": 1,
-              "Grenades": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407432785617/C21E190F258AC17A01C5D096C890DFA3B988759D/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432785832/186A72B65075EEA56ED2C3D1DC80718E987884B5/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407433051929/749E23C3D0FD9CE738CEA98802F52CA8B64ADABE/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432785832/186A72B65075EEA56ED2C3D1DC80718E987884B5/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407433051436/F1EA8C6D3CCB8278F7775C7AB78AD996DFC24291/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432785832/186A72B65075EEA56ED2C3D1DC80718E987884B5/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407433050963/ED218EC8188C166AFEE1E1DE86351BE786E764D7/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432785832/186A72B65075EEA56ED2C3D1DC80718E987884B5/"
-              }
-            ]
-          },
-          {
-            "name": "IG-86 Sentinel Droids",
-            "title": "Strike Team",
-            "displayName": "Sentinel Droids (Strike Team)",
-            "heavyWeaponTeam": true,
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742381186/83833409E9638CCAE4D3E135DD7DE7C3F50BF6B2/",
-            "size": "small",
-            "type": "Droid Trooper",
-            "points": 25,
-            "speed": 2,
-            "upgrades": {
-              "Heavy Weapon": 1,
-              "Training": 1,
-              "Illicit": 1,
-              "Comms": 1,
-              "Gear": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407432785617/C21E190F258AC17A01C5D096C890DFA3B988759D/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432785832/186A72B65075EEA56ED2C3D1DC80718E987884B5/"
-              }
-            ]
-          }
-        ],
-        "Support": [
-          {
-            "name": "Droideka MKII",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638672297/9A21A780F96BA78A849FD5FFF320FF4D0581259A/",
-            "size": "medium",
-            "type": "Ground Vehicle",
-            "points": 110,
-            "speed": 1,
-            "upgrades": {
-              "Comms": 1,
-              "Hardpoint": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365798378/BE8A6530AC8273FFE4549147A2F83C7A77BA5597/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365798566/72991BC6227C745C3157A2328EEFDF4F1671924D/"
-              }
-            ]
-          },
-          {
-            "name": "EWHB-12 Heavy Blaster team",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742525705/7188974BC1594CD7D0B2D6775629F3933FE40E62/",
-            "displayName": "EWHB-12 Team",
-            "size": "medium",
-            "type": "Emplacement Trooper",
-            "points": 60,
-            "speed": 1,
-            "upgrades": {
-              "Comms": 1,
-              "Illicit": 1,
-              "Generator": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756243818494/7211F52034FC36725841F968E5F2B991F8C10274/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756243792095/065CF347E346B773F8F93F81B0048E6A6A67A2C1/"
-              }
-            ]
-          }
-        ],
-        "Heavy": [
-          {
-            "name": "Cuddles",
-            "title": "Ferocious One",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735162413/20647BC13446FAA4A0951E6E9D5003D9904557E9/",
-            "size": "huge",
-            "type": "Creature Trooper",
-            "points": 135,
-            "speed": 1,
-            "upgrades": {
-              "Creature": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984835661685/1668BEEE179A260B9988D3C60872160FF93CEE51/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984835661821/7B52CEEC4169ACB4A32C0489D4A878BC72030DE2/"
-              }
-            ]
-          },
-          {
-            "name": "Canderous Class Assault Tank",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738556639132725/E48531757B6B7D582D3D3AD313D790E21FAD2655/",
-            "size": "epic",
-            "type": "Repulsor Vehicle",
-            "points": 180,
-            "speed": 1,
-            "upgrades": {
-              "Pilot": 1,
-              "Comms": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231133144508/4BB9CD650D4795CEB6C81CBB95AB31DA7365F7EF/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231133144655/86527E20BE4B11B688A7F14894775EBE347C475B/"
-              }
-            ]
-          },
-          {
-            "name": "Missile Attack Launcher",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738556639035496/5F41C143C5ADE4631FFDC497CD8053BF7F0F9E43/",
-            "size": "epic",
-            "type": "Repulsor Vehicle",
-            "points": 140,
-            "speed": 1,
-            "upgrades": {
-              "Pilot": 1,
-              "Ordnance": 2,
-              "Comms": 1,
-              "Hardpoint": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698013227951332/BDA59EEE85EBD5AE628E38AC9B0C539D59DC9525/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698013227951474/8641BEED6BF44F70975F6F27093477327361567C/"
-              }
-            ]
-          },
-          {
-            "name": "Rancor",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742458068/53A90269FBB599680D91DA51225BE59738A8C049/",
-            "size": "huge",
-            "type": "Creature Trooper",
-            "points": 155,
-            "speed": 1,
-            "upgrades": {
-              "Pilot": 1,
-              "Creature": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696827920773360/FA78C7E63C77DD4A9CDF435A2DCE83BEE4235B82/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696827920773489/CCC8F655681A6962AA133E4DB9D4EBD8B3D487AD/"
-              }
-            ]
-          },
-          {
-            "name": "WLO-5 Battle Tank",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743059742/E6358D1656688B41E351113B72177D770264FB6B/",
-            "size": "epic",
-            "type": "Repulsor Vehicle",
-            "points": 125,
-            "speed": 2,
-            "upgrades": {
-              "Pilot": 1,
-              "Hardpoint": 1,
-              "Illicit": 1,
-              "Comms": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436416564/7E56BA386FDC26CB14047F335B62C19995B4AA5E/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436416842/1C5A975045A289BF43FBDC29DC3F2BD0ED7E1E0C/"
-              }
-            ]
-          }
-        ]
-      },
-      "Separatist": {
-        "Commander": [
-          {
-            "name": "Darth Sidious",
-            "title": "Master of Manipulation",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743518519/E404C02C62D579D5E0385EEDCB318DC45FFF7D13/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 240,
-            "speed": 2,
-            "upgrades": {
-              "Force": 3,
-              "Command": 1,
-              "Training": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824153235918382/C6629B635DB0B3D04D345B83AE6A0DA0EF4CDDBC/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824153235918510/4CE73F1347AA53974D94CADE1B77D9875694299C/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Power! Unlimited Power!",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743519427/23500514817BCDB46436B493396E941FD5FFE6E7/",
-                "pip": 1
-              },
-              {
-                "name": "Execute Order 66",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743519790/0A304E9ECB85D8BCC65B1FA93658FC87D98DC96D/",
-                "pip": 2
-              },
-              {
-                "name": "A Surprise, To Be Sure",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743520163/A584E2B66E09368C6E89485F7C44DBA8CEA2A0D5/",
-                "pip": 3
-              }
-            ]
-          }
-        ],
-        "Operative": [
-          {
-            "name": "Sun Fac",
-            "title": "Archduke's Chief Lieutenant",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746952332/B95C799020F79D219FFDF62FF12C7EFB302E3920/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 105,
-            "speed": 3,
-            "upgrades": {
-              "Command": 1,
-              "Training": 2
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318234636/1ECC7AF43F26DDE2A82E90A54DCE2956F02A27F0/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893318234765/77E9C34FC82B00D2C3E96A60AF29948CBEC88784/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Enforcer of the Swarm",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746960145/1E5AA4E032A934D62D4DBA0FB0C892E07603F8D7/",
-                "pip": 1
-              }
-            ]
-          }
-        ],
-        "Corps": [
-          {
-            "name": "Geonosian Warriors",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746956460/10EC43D13EC18AB52E30175D8E015E2C233EC310/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 48,
-            "speed": 3,
-            "upgrades": {
-              "Heavy Weapon": 1,
-              "Personnel": 1,
-              "Training": 1,
-              "Armament": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318078184/8B5466E18846FE7CF66B17BC0A657A0208855F03/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893318078962/DEB31D473979E7DE679F9564781A76B0E8E522FD/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318071468/13869F37C5ED6881ED97E16D300ED50175E1C007/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893317930470/4A9F58F7B8BC80AF279695655E38DD81A9236057/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318070141/E59D21FBF0E1DCE0AA6CF1B9574AB6BDF26438FC/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893317930470/4A9F58F7B8BC80AF279695655E38DD81A9236057/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318076612/BCD33D7FAFC2C324271FB92894740CACEFF7ED9D/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893317930470/4A9F58F7B8BC80AF279695655E38DD81A9236057/"
-              }
-            ]
-          }
-        ],
-        "Support": [
-          {
-            "name": "LM-432 Crabdroid",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743527286/34BE0F9B234F769983BE410CB8D2D94B695D5840/",
-            "size": "medium",
-            "type": "Ground Vehicle",
-            "points": 90,
-            "speed": 2,
-            "upgrades": {
-              "Comms": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455020027815604/10F9822A314D818E81C27CE272E1F52E50B6EBF3/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455020027816841/367B15AD633665E238815516DF8E82AC4EFAA34B/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455020027819432/1A96D256F849409A6F2157F0A896967146B7A13C/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455020027816841/367B15AD633665E238815516DF8E82AC4EFAA34B/"
-              }
-            ]
-          },
-          {
-            "name": "LR1K Sonic Cannon",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746955793/8D7F4A2BA75689F096F5D44BC4AB28B6BBDBC062/",
-            "size": "large",
-            "type": "Emplacement Trooper",
-            "points": 75,
-            "speed": 0,
-            "upgrades": {
-              "Comms": 1,
-              "Generator": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318385775/0D78686C63C10B04D2BA172B26F125D007034C0C/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893318369456/484B53AD87428BCF7E190DB1A763640373914353/"
-              }
-            ]
-          },
-          {
-            "name": "Octuptarra Tri-Droid",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743539441/5709DCD601EB0694A3CA0DA71D1BCC1D3C2A0F87/",
-            "size": "large",
-            "type": "Ground Vehicle",
-            "points": 60,
-            "speed": 2,
-            "upgrades": {
-              "Hardpoint": 1,
-              "Comms": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455403164598593/5A7C010653DBCE628FE44C40B0915C460164945A/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455403164542430/B2F1D02EDF736CAE38008DD4CEF11F2394AB18B4/"
-              }
-            ]
-          },
-          {
-            "name": "SD-4K Assassin Droid",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412069008204/589A89C815CF960153728A928496992538741916/",
-            "size": "large",
-            "type": "Ground Vehicle",
-            "points": 70,
-            "speed": 2,
-            "upgrades": {
-              "Programming": 1,
-              "Comms": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1055478180707369319/5222F20E44E450F944F7C39E59C16359C9743A60/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1055478180707368539/DDBADF81B279336EBE157E67F2ECAB3B6C8A037A/"
-              }
-            ]
-          },
-          {
-            "name": "Sharpshooter Droideka",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743586301/1CCF100C94512AE1CB7D788234024FDC86B16A29/",
-            "size": "medium",
-            "type": "Ground Vehicle",
-            "points": 110,
-            "speed": 1,
-            "upgrades": {
-              "Comms": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455553732191897/63312F1C4D01590EDA8153640DDF31260E7A27E2/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455553732192021/2D0E1C0D65555EF7A52443E3000E0979A287E077/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455553732192630/7B686F1D43905244043848E1240DA5B112F92A09/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455553732192021/2D0E1C0D65555EF7A52443E3000E0979A287E077/"
-              }
-            ]
-          }
-        ],
-        "Heavy": [
-          {
-            "name": "Defoliator Deployment Tank",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743614358/8A82032A999FD9F81E83CA8925B0C8AC301D07FD/",
-            "size": "epic",
-            "type": "Repulsor Vehicle",
-            "points": 155,
-            "speed": 1,
-            "upgrades": {
-              "Pilot": 1,
-              "Hardpoint": 1,
-              "Ordnance": 1,
-              "Comms": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893327245472/0E4E57241F7F12B74598D3D83A5D501E5586315F/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893327220558/8D3108FC26DE5361995CDDB2CE24CE004F69F1C9/"
-              }
-            ]
-          },
-          {
-            "name": "HMP Droid Gunship",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743692190/E87C41BC6C6F5797FA124D17C0F5C0FCB15769B0/",
-            "size": "epic",
-            "type": "Repulsor Vehicle",
-            "points": 155,
-            "speed": 2,
-            "upgrades": {
-              "Hardpoint": 1,
-              "Ordnance": 2,
-              "Comms": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028454854943605642/C9B582DDD3BD0DD6A4C0C3AB35E91064DFF77C42/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028454854943586665/C0F6961CFFA9F8E15FB5F6B6538AE5C404DD40B4/"
-              }
-            ]
-          },
-          {
-            "name": "IG-227 Hailfire-Class Droid Tank",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743648691/D8401535639FA435BD7D89A4DC8A9CEF8E077529/",
-            "size": "huge",
-            "type": "Ground Vehicle",
-            "points": 110,
-            "speed": 3,
-            "upgrades": {
-              "Hardpoint": 1,
-              "Comms": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455516900984588/FD6A321B7F88D5680A3AF647417BA4BB5E74EAEF/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455516901771593/595DBAC62796FE3C66973A218C72DDCEC3B4B05B/"
-              }
-            ]
-          },
-          {
-            "name": "Octuptarra Magna Tri-Droid",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743670386/A2A33692DAFB2F4BE77EE01ABEAB89F7B7CA1228/",
-            "size": "epic",
-            "type": "Ground Vehicle",
-            "points": 180,
-            "speed": 2,
-            "upgrades": {
-              "Hardpoint": 1,
-              "Comms": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455403164753290/F8E53798804F16BA75E428DF4DE94D930DB0F20A/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455403164542430/B2F1D02EDF736CAE38008DD4CEF11F2394AB18B4/"
-              }
-            ]
-          },
-          {
-            "name": "OG-9 Homing Spider Droid",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743679867/D32CA64107D6C9D10B086FE2335D8CC6A545F90C/",
-            "size": "epic",
-            "type": "Ground Vehicle",
-            "points": 140,
-            "speed": 1,
-            "upgrades": {
-              "Comms": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455403167048357/2192FD561FA2D05EB86CC3AE445499640E570E21/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455403164322367/DB9DC63C0285A43C8547D724F882063227910D89/"
-              }
-            ]
-          }
-        ]
-      },
-      "Sith Empire": {
-        "Commander": [
-          {
-            "name": "Darth Malgus",
-            "title": "Prodigy of Battle",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277562476/E42383A66E46621D98A52DA5D0BD1C7FBAD02AB9/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 190,
-            "speed": 2,
-            "upgrades": {
-              "Force": 3,
-              "Training": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824296871909914/CC551973C1E900C1153BB015BED7EE408646DF78/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231133343207/A24CBD9CC466137A560F72A00359E34DF0083071/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Furious Charge",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277563415/5A0861160BA5F979A8F0C216F494C9925D5538BB/",
-                "pip": 1
-              },
-              {
-                "name": "Visions of Doubt",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277563761/ECD4F9155C9E74C1B70403FD0F547B55070F205C/",
-                "pip": 2
-              },
-              {
-                "name": "Force Maelstrom",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277564474/A1645474FAA791583F23BC7FFE299704AA112FCF/",
-                "pip": 3
-              }
-            ]
-          },
-          {
-            "name": "Lord Adraas",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277602848/B56DEFFD7CC8988D8568476DE4E0C7E59908A6E1/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 120,
-            "speed": 2,
-            "upgrades": {
-              "Force": 2
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885833891/AE635515661DD84861ADF0CF4FC48052FD3DEF87/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608885695776/F5A3AA78554B8F3CB86314E552D94D65C0080F0C/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Counting Corpses",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277603245/63BC127864462C645D997822348332C2053CD8C8/",
-                "pip": 1
-              },
-              {
-                "name": "Spearheading the Assault",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277603553/067F6633690E6A14497AA7AA0164F0B93F773C2D/",
-                "pip": 2
-              },
-              {
-                "name": "Claiming Victory",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277603895/1237D55EFD6265C9922C8B7DEC76F46AD20608C4/",
-                "pip": 3
-              }
-            ]
-          },
-          {
-            "name": "Shae Vizla",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277698530/3A31084E01120F5B0F53A17C0B6F3ECBD2FD6DA6/",
-            "size": "small",
-            "type": "Mandalorian Trooper",
-            "points": 135,
-            "speed": 3,
-            "upgrades": {
-              "Training": 2,
-              "Gear": 1,
-              "Armament": 2
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642366438145/53BAD2A0BECE84168DD54692576AFFD8D43A9962/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642366438391/C107A0534E3BC5211416290AD53F4EB4482E021B/"
-              }
-            ],
-            "commands": [
-              {
-                "name": "Flame Burst",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277699041/E5D63FF435C115846E9863192F7A61EBABCD0DE4/",
-                "pip": 1
-              },
-              {
-                "name": "Mandalore The Avenger",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277699427/213D174E2B02C59A9774F14990693D661012BA30/",
-                "pip": 2
-              },
-              {
-                "name": "Whatever...",
-                "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277699707/C145698341E7B15563A59265F2D6D63A1F16E340/",
-                "pip": 3
-              }
-            ]
-          }
-        ],
-        "Corps": [
-          {
-            "name": "Sith Empire Troopers",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277742096/C1DC5A839A9F754B2EECA3F022F05A30C182F003/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 44,
-            "speed": 2,
-            "upgrades": {
-              "Heavy Weapon": 1,
-              "Personnel": 1,
-              "Training": 1,
-              "Grenades": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608878956135/77C5F51565475CEB63D9A0A0E97F3616EC17992E/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608878877171/C209E7E6493A8465F8FD60DE6566AA6BA2C745ED/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608878992636/D833E26E44A7763FAEFBE2430390376F9160E931/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608878877171/C209E7E6493A8465F8FD60DE6566AA6BA2C745ED/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608879652119/A6E9D1CC7FCF34BF844B1847503E21E60C007A21/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608878877171/C209E7E6493A8465F8FD60DE6566AA6BA2C745ED/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608878917211/A6984255B6241D8A292F4785C28A87E134354C9A/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608878877171/C209E7E6493A8465F8FD60DE6566AA6BA2C745ED/"
-              }
-            ]
-          },
-          {
-            "name": "Sith Empire Boarding Troopers",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277785197/971E0418CD2A7CE414F629E2AFEE3B684B99BA46/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 48,
-            "speed": 2,
-            "upgrades": {
-              "Personnel": 1,
-              "Heavy Weapon": 1,
-              "Training": 1,
-              "Comms": 1,
-              "Grenades": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885319465/2474308EBBDD92BDF8D331691E4F47EB4E1D9D7B/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885051525/BE73F7CADC7D35B297FE86A2C7C13532B33BED20/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885219099/28222F723E524C776ADFD8BF4072B274D5DD6513/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885271840/AEB99C8ABF425086732389D43FA67625C6E6C4CB/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
-              }
-            ]
-          },
-          {
-            "name": "Sith Empire Support Troopers",
-            "heavyWeaponTeam": true,
-            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277927003/D6339601058975760755CFB0F0FEE8ED3B6A4372/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 30,
-            "speed": 2,
-            "upgrades": {
-              "Heavy Weapon": 1,
-              "Training": 1,
-              "Comms": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824477681546677/855DD1F57D897B360CCA3F12DDB4449E0D116255/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824477681548557/DB63AB0044B89CB25D50A204A061D535CA20F495/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824477681548370/AFD42783EB041326C035DDB002BF34928A1AE002/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824477681548557/DB63AB0044B89CB25D50A204A061D535CA20F495/"
-              }
-            ]
-          }
-        ],
-        "Special Forces": [
-          {
-            "name": "Imperial Commandos",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277957842/94E04A758D860C9A7FCFE6D6356AA07DBFD811FD/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 72,
-            "speed": 2,
-            "upgrades": {
-              "Heavy Weapon": 1,
-              "Gear": 1,
-              "Training": 1,
-              "Comms": 1,
-              "Grenades": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024260308213/15A8FC12EB8192B2272D639557ED336BAF9718BE/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260606126/9430D9F19B59E68648F5261C8162A66C253EDDC0/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024261188154/B23F2669D0C619618D89D2BCF50E701363CDB26B/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260988667/8B8E27DFEDD6DEBA4EFABD6E738D3B6AC3E925AB/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024260446504/E46DFA85E16AF894A710D4F6714BA84BC9C6BBB3/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260606126/9430D9F19B59E68648F5261C8162A66C253EDDC0/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024260532062/6D98D9E28283E02F34B203849A11F420D1A1C99E/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260606126/9430D9F19B59E68648F5261C8162A66C253EDDC0/"
-              }
-            ]
-          },
-          {
-            "name": "Sith Acolytes",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278054907/1EA779D6C64F1883A9EF450C1424A0459EF087F9/",
-            "size": "small",
-            "type": "Trooper",
-            "points": 78,
-            "speed": 2,
-            "upgrades": {
-              "Personnel": 1,
-              "Training": 1,
-              "Force": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1012691837448680455/252DCD7E06B5083BBE6CABCA4F8349D6DCE46498/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608885695776/F5A3AA78554B8F3CB86314E552D94D65C0080F0C/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885701810/42CE6863B9D31E7EDDA1C4DEEC0C52F6DFEBB0D1/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608885695776/F5A3AA78554B8F3CB86314E552D94D65C0080F0C/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885733918/43DD4CBAEAD756429F47BAF24133A3D97CEA9DA6/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608885695776/F5A3AA78554B8F3CB86314E552D94D65C0080F0C/"
-              }
-            ]
-          }
-        ],
-        "Support": [
-          {
-            "name": "War Droid MK I",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278072181/D3BB57A041FA5490F372A792EEF35A344BD68FCD/",
-            "size": "medium",
-            "type": "Ground Vehicle",
-            "points": 110,
-            "speed": 1,
-            "upgrades": {
-              "Comms": 1
-            },
-            "minis": [
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697620253289667/85745104AA0C94936FA804B87EA1A61938161B79/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697620253289816/7245F236A07C662A6AA471AA89E323417AB7D604/"
-              },
-              {
-                "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697620253290925/09820A879BC9DB027D438A7F0051F90D558A3D97/",
-                "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697620253289816/7245F236A07C662A6AA471AA89E323417AB7D604/"
-              }
-            ]
-          }
-        ]
-      }
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028454512723115814/E2D62C42F65FA7C8D53DF84C32E2AF7A706CF227/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028454512723115925/1BBA13C56E26EC363E68E2E0A87AD0D00B3B2F9E/"
+            }
+          ]
+        }
+      ]
     },
-    "upgrades": {
-      "Armament": [
-        {
-          "name": "Amped up A-280's",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742002345/F99AB12D9FC7810EC0868DEA0DD3EEFBB15D686E/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "unit": ["Hired Guns"]
-            }
-          }
-        },
-        {
-          "name": "Anakin's Lightsaber",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1027324932753002794/C0A0C19E79DAF7B4B11E6DCEE218AB2F4C385966/",
-          "points": 25,
-          "restrictions": {
-            "include": {
-              "unit": ["Finn"]
-            }
-          }
-        },
-        {
-          "name": "Anakin's Lightsaber Rey",
-          "displayName": "Anakin's Lightsaber",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1027324932753002794/C0A0C19E79DAF7B4B11E6DCEE218AB2F4C385966/",
-          "points": 20,
-          "restrictions": {
-            "include": {
-              "unit": ["Rey"]
-            }
-          }
-        },
-        {
-          "name": "BB-8 Grappling cord",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157660515/A2C7648C32E4AF4B631D2C498E6C76CC97B25925/",
-          "points": 0,
-          "restrictions": {
-            "include": {
-              "unit": ["BB-8"]
-            }
-          }
-        },
-        {
-          "name": "Cody's DC-15a",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747470278/1615C1C3D7C36AA201B25F52D99215DC4D12195C/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "unit": ["Commander Cody"]
-            }
-          }
-        },
-        {
-          "name": "Defilers Blaster",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735211533/50044D04BF35EAE0926C6A86936DC5A2DA95B0FD/",
-          "points": 15,
-          "restrictions": {
-            "include": {
-              "unit": ["Defiler"]
-            }
-          }
-        },
-        {
-          "name": "DC-17m Anti-Armor Config",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747570525/CACD6285B8098528A1E23C5AA68F3EB68076B4DF/",
-          "points": 18,
-          "restrictions": {
-            "include": {
-              "unit": ["Republic Commandos"]
-            }
-          }
-        },
-        {
-          "name": "DC-17m Sniper Rifle Config",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747571113/0AA95599A43D23EDBDA63F1835698A1CBAC6D746/",
-          "points": 20,
-          "restrictions": {
-            "include": {
-              "unit": ["Republic Commandos"]
-            }
-          }
-        },
-        {
-          "name": "Defilers Slug Thrower",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735211196/02C8A1B676C2CFC2A17BFB8819B8C6981DAD74D7/",
-          "points": 15,
-          "restrictions": {
-            "include": {
-              "unit": ["Defiler"]
-            }
-          }
-        },
-        {
-          "name": "DXR-6 Focused Fire Config",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735115917/9E0BA5F8013B1491D5EF74BED3C484BA0F3052AB/",
-          "flip": {
-            "name": "DXR-6 Power Shot Config",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735116297/419AF3D6925D7004CA92BE249969A1BFB42B9742/"
-          },
-          "points": 8,
-          "restrictions": {
-            "include": {
-              "unit": ["Mercenary Assault Squad"]
-            }
-          }
-        },
-        {
-          "name": "Elite Wrist Mounted Flamethrower",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640412575/1F3B56925DC71E5FAFDD405CF117B72CC0DB3B42/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "type": ["Mandalorian Trooper"],
-              "rank": ["Commander", "Operative"]
-            }
-          }
-        },
-        {
-          "name": "Gauntlet Blades",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640410174/FF136859D9C64EFC2B33CEDF111204596228A4B0/",
-          "points": 6,
-          "restrictions": {
-            "include": {
-              "unit": ["Bo-Katan Kryze"]
-            }
-          }
-        },
-        {
-          "name": "Hondo's Electrostaff",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738475192/6004D55A77E10329CE6EABD01DE46D1BB2DF1572/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "unit": ["Hondo Ohnaka"]
-            }
-          }
-        },
-        {
-          "name": "Illegally Modified E-11's",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742002948/59F017866F7B7293C00FED3BA937D371B7E71C0A/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "unit": ["Hired Guns"]
-            }
-          }
-        },
-        {
-          "name": "Quicksilver Baton",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081144482/1AA3BE94F83F1BE4DE2D135E655B5C1D811B327F/",
-          "flip": {
-            "name": "Chromium SE-44 Blaster",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081144665/EE6A1C8395737CB64EA6529ECFC1D00146A350FC/"
-          },
-          "points": 15,
-          "restrictions": {
-            "include": {
-              "unit": ["Captain Phasma"]
-            }
-          }
-        },
-        {
-          "name": "Static Pikes",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746953521/48A9A9BFC5662EA0496E1533D16AAE84DB4CCE48/",
-          "points": 6,
-          "restrictions": {
-            "include": {
-              "unit": ["Geonosian Warriors"]
-            }
-          }
-        },
-        {
-          "name": "Vibroblade",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412068779530/6BC0F180AB6278302B59DFDC3C381F048CFA28D7/",
-          "points": 12,
-          "restrictions": {
-            "include": {
-              "unit": ["Calo Nord"]
-            }
-          }
-        },
-        {
-          "name": "Wrist Rocket",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640428446/AE6DB75F1A3643AF7DCB7CA1BA8DAFF87E7A5C8A/",
-          "points": 6,
-          "restrictions": {
-            "include": {
-              "type": ["Mandalorian Trooper"]
-            }
-          }
-        },
-        {
-          "name": "Whistling Birds",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640411728/A3BCBA7C1B49EE5B996A55A8FC6CB581A9EAA96C/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "type": ["Mandalorian Trooper"],
-              "rank": ["Commander", "Operative"]
-            }
-          }
-        },
-        {
-          "name": "Wrist Mounted Blasters",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640413937/745B5BEAD23640A8222A54287029ACF70F9A81EE/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "type": ["Mandalorian Trooper"]
-            }
-          }
-        },
-        {
-          "name": "Wrist Mounted Flamethrower",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640416270/08971192288A83DD208F4D91D02703E094090133/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "type": ["Mandalorian Trooper"]
-            }
-          }
-        },
-        {
-          "name": "Z-6 Riot Control baton",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752981376/8F2F3430452BDBD8DD78E48243BCECEA994DF1AC/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "unit": ["Finn"]
-            }
-          }
-        }
-      ],
-      "Command": [
-        {
-          "name": "Racketeering",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735072829/84C080C8B919D06884AF3BC12ADDB58B524C5271/",
-          "points": 5,
-          "restrictions": {
-            "include": {
-              "unit": ["Tyber Zann"]
-            }
-          }
-        }
-      ],
-      "Comms": [
-        {
-          "name": "B1's Datapad",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1021698068155822603/B74DFBDE71FC462A482C92AF02C57AD2C6373E0F/",
-          "points": 6,
-          "restrictions": {
-            "include": {
-              "unit": ["Salvaged B2 Battle Droids"]
-            }
-          }
-        },
-        {
-          "name": "Proximity Signal",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743573243/8687C5FADEF63558D5088A664E51ACF3C9D3D172/",
-          "points": 6,
-          "restrictions": {
-            "include": {
-              "unit": ["SD-4K Assassin Droid"]
-            }
-          }
-        }
-      ],
-      "Counterpart": [
-        {
-          "name": "BB-8",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1022824296871784739/BA69ED4E4B2926D1C9E5FB255791569EB5AA7A05/",
-          "points": 25,
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068157620585/9E7930221D8CD87F6338B9D4B58F4D3F824D08C0/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068157620780/493748852320ED988465533F8BC49FEA2672A9E8/"
-          },
-          "restrictions": {
-            "include": {
-              "faction": ["Resistance"],
-              "unit": ["Rose Tico", "Rey", "Poe Dameron", "Finn", "R2-D2"]
-            }
-          }
-        },
-        {
-          "name": "C-3PO",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1616219505080628828/F6A01DB4DFDB1A518FC4E373D72237AB1B31300B/",
-          "points": 15,
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/776232727456807069/DE7E32B39455DB5111769436FD0C5BFDA3841268/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/777357228032306506/D60CB8A1159723917EF1831D4042318A67458A7A/"
-          },
-          "restrictions": {
-            "include": {
-              "unit": ["R2-D2"]
-            }
-          }
-        },
-        {
-          "name": "Salacious B. Crumb",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741310541/C8ADFE085EC634C8766C303BD1F89D230BEADEBE/",
-          "points": 10,
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984838966754/DCEED639BB3AA1D36A2AF82B26708EF4007A3583/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984838966978/51C97B6161C17AE3229372F0C26331EAD0D44200/"
-          },
-          "restrictions": {
-            "include": {
-              "unit": ["Jabba The Hutt"]
-            }
-          }
-        },
-        {
-          "name": "Vornskr's",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741832560/CFA25E88275C65CC80ACE518A3DBDB2C4235E061/",
-          "points": 15,
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697620252875766/48FF7F717DEA00FCE1E830FD4FA888494433370A/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697620252875970/2006E4E0DA5EA0DEEEB1B3982D975944B8F9DC7B/"
-          },
-          "restrictions": {
-            "include": {
-              "unit": ["Beast Master"]
-            }
-          }
-        }
-      ],
-      "Crew": [
-        {
-          "name": "F-11D Blaster Rifle Gunner",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081208241/F230A7C4DE9FBF543B9DD9F4CB370A7D59B44BAA/",
-          "points": 7,
-          "restrictions": {
-            "include": {
-              "unit": ["Light Infantry Utility Vehicle"]
-            }
-          }
-        },
-        {
-          "name": "First Order Officer ",
-          "displayName": "First Order Officer",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081214064/11B6F493E9AFB18F34739932FD21874F50EA6E7E/",
-          "points": 8,
-          "restrictions": {
-            "include": {
-              "unit": ["Light Infantry Utility Vehicle"]
-            }
-          }
-        }
-      ],
-      "Flaw": [
-        {
-          "name": "I Don't Care if You Win",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081176926/A624D3D4A4BF45129F3D140BA5FFEFEF471065B9/",
-          "points": 0
-        },
-        {
-          "name": "I'll Bet You Have",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741747564/7E279CBA3100D1D5A3E4B5D9EBD362D57373ABE8/",
-          "points": 0
-        },
-        {
-          "name": "I'm Being Torn Apart",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081188353/E86EB5CB8B87C8CE341CD77CD32CD8A6A5FA3B67/",
-          "points": 0
-        }
-      ],
-      "Force": [
-        {
-          "name": "Acolyte Force Lightning",
-          "displayName": "Force Lightning",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278090576/86604BC87F9AB158776F63811C23AB3AE058722A/",
-          "points": 5,
-          "restrictions": {
-            "include": {
-              "faction": ["Sith Empire"]
-            }
-          }
-        },
-        {
-          "name": "Chain Lightning",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278091219/1C7C89C5537F9B248294B44DADC5F24D181892C2/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "faction": ["Sith Empire"]
-            }
-          }
-        },
-        {
-          "name": "Force Dash",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747371109/7290AD045A9201DA40F367CAD1FF04C1615B9851/",
-          "points": 9
-        },
-        {
-          "name": "Force Lightning",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747371606/231C69EF773D74B95CCC5EB34F1EB96C1119FA98/",
-          "points": 12,
-          "restrictions": {
-            "include": {
-              "alignment": ["Dark"]
-            }
-          }
-        },
-        {
-          "name": "Force Rend",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747370532/B97ADF8AC0302E13A315C68402376409B45A5FFE/",
-          "points": 17,
-          "restrictions": {
-            "include": {
-              "alignment": ["Dark"]
-            }
-          }
-        },
-        {
-          "name": "Force Statis",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747369898/5CC327BAEB59E3B817B71AFF6EC21D3E14ADB4A2/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "alignment": ["Dark"]
-            }
-          }
-        },
-        {
-          "name": "Maglus Force Lightning",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277562964/22A352A0E0EF8FE27B1DF1F19C08A80CE1564B3C/",
-          "points": 5,
-          "restrictions": {
-            "include": {
-              "unit": ["Darth Malgus"]
-            }
-          }
-        }
-      ],
-      "Gear": [
-        {
-          "name": "Bacta Auto-Dispenser",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747571812/21DA4C0C9811D5252F4FAB4E7F10B358FC74C2BA/",
-          "points": 20,
-          "restrictions": {
-            "include": {
-              "unit": ["Republic Commandos"]
-            }
-          }
-        },
-        {
-          "name": "Calo Nord's Battle Armor",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412068780383/4FE70939384B8CD88DC852C8CAED0D21BAF3C367/",
-          "points": 35,
-          "restrictions": {
-            "include": {
-              "unit": ["Calo Nord"]
-            }
-          }
-        },
-        {
-          "name": "Electro Grappling Line",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640414601/68D77CCDC40F2F1F103F1AF7568727FA6F9E8CE9/",
-          "points": 3,
-          "restrictions": {
-            "include": {
-              "type": ["Mandalorian Trooper"]
-            }
-          }
-        },
-        {
-          "name": "JT-12 Jetpack",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747527633/AF0E4FAA5C2D92BD45DC40252B9ADAB003A5FC5F/",
-          "points": 5,
-          "restrictions": {
-            "include": {
-              "unit": ["Commander Colt"]
-            }
-          }
-        },
-        {
-          "name": "Jump pack",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751974753/5AF713EB09F4AFDF88B76C8CB9F54CE4D0BEB7D8/",
-          "points": 0,
-          "restrictions": {
-            "include": {
-              "unit": ["Phase II Darktroopers"]
-            }
-          }
-        },
-        {
-          "name": "Personal Combat Shield",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640410953/DEF506B2DB3747BF1DD5ABBECEB36764450D0B7C/",
-          "points": 15,
-          "restrictions": {
-            "include": {
-              "type": ["Mandalorian Trooper"]
-            }
-          }
-        },
-        {
-          "name": "Target Designator",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638971560/0F6F9FB93CD712E0D2B5916DE3392EF98BDAB3DC/",
-          "points": 6,
-          "restrictions": {
-            "include": {
-              "faction": ["Scum"]
-            }
-          }
-        },
-        {
-          "name": "Vambrace Reloader",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640415774/E6C7E28AAA6C1EC3CB460AE5947F2AAE2960EF15/",
-          "points": 3,
-          "restrictions": {
-            "include": {
-              "type": ["Mandalorian Trooper"]
-            }
-          }
-        }
-      ],
-      "Generator": [
-        {
-          "name": "Class-5B1 Duplex Generator",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747375028/7DEFD098875FF94FD712C2FB42C37218AE5F95D9/",
-          "points": 10
-        },
-        {
-          "name": "GNK-series Power Droid",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747374218/EBE238DB2CCD3F06AC1CC96325D04FEE2B5ECD1C/",
-          "points": 5
-        },
-        {
-          "name": "Ion Generator",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747374603/462C32A767195B287E9FFCFC73BD0FA798F982DF/",
-          "points": 10
-        },
-        {
-          "name": "Scavenged Generator",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1022824296871788518/1BB5B0A6D3E8BDA3F3E66F6ED7B4E30BC24C4C3E/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "faction": ["Resistance", "Rebel"]
-            }
-          }
-        },
-        {
-          "name": "Targeted Generator",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742526797/6A85F0CB99FE4DB7DCFD7DA3EDF1E04B4D1A56DC/",
-          "points": 7,
-          "restrictions": {
-            "include": {
-              "unit": ["EWHB-12 Heavy Blaster team"]
-            }
-          }
-        }
-      ],
-      "Grenades": [
-        {
-          "name": "Cluster Grenades",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640427155/BAB17778B9558A117B7672B361169E1429B8FFBD/",
-          "points": 5,
-          "restrictions": {
-            "include": {
-              "type": ["Mandalorian Trooper"]
-            }
-          }
-        },
-        {
-          "name": "Cryoban Grenade",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747372562/020D8C7E51888C66929A5C68BC64CF2A0751AB96/",
-          "points": 10
-        },
-        {
-          "name": "Concussive Discs",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743157047/93145CADA2644E48715594A16814C0B588B09264/",
-          "points": 7,
-          "restrictions": {
-            "include": {
-              "unit": ["IG-88"]
-            }
-          }
-        }
-      ],
-      "Hardpoint": [
-        {
-          "name": "Auto Loader",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638973875/12A8A6DAC58F8AD954452CFC4B0DC38ED932407B/",
-          "points": 5,
-          "restrictions": {
-            "include": {
-              "unit": ["Missile Attack Launcher"]
-            }
-          }
-        },
-        {
-          "name": "Chain-Fed Missile Launcher",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743540463/2FDD9391217B4D3C83489ACFC70B5D4D70D828AF/",
-          "points": 8,
-          "restrictions": {
-            "include": {
-              "unit": ["Octuptarra Tri-Droid"]
-            }
-          }
-        },
-        {
-          "name": "D-93 Incinerator",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081207055/8CE886D73E5632DFB6B71F21AEE082B90DB862B2/",
-          "points": 24,
-          "restrictions": {
-            "include": {
-              "unit": ["Light Infantry Utility Vehicle"]
-            }
-          }
-        },
-        {
-          "name": "Ball Turrets",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747617309/E7A1C86302FE190A75A859B3405353D24B56AA93/",
-          "points": 20,
-          "restrictions": {
-            "include": {
-              "unit": ["LA-AT/I Gunship"]
-            }
-          }
-        },
-        {
-          "name": "Defoliator Missile Launcher",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743618077/FD3FF4AAAA791E2B578007273E93859B7FA12E6E/",
-          "points": 28,
-          "restrictions": {
-            "include": {
-              "unit": ["Defoliator Deployment Tank"]
-            }
-          }
-        },
-        {
-          "name": "Dorsal Laser Cannon",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747586054/E0CA1658DB7AB53E43598B3506A980E595D78AA8/",
-          "points": 16,
-          "restrictions": {
-            "include": {
-              "unit": ["AT-AP"]
-            }
-          }
-        },
-        {
-          "name": "Enhanced Stabilizers",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747587543/837CEB0047D91D5ADEB112F08F19C456609042D9/",
-          "points": 14,
-          "restrictions": {
-            "include": {
-              "unit": ["AT-AP"]
-            }
-          }
-        },
-        {
-          "name": "Enhanced Targeting Computer",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743649603/CC9BB61488A9EDD358521E3E62D73A316BC07F23/",
-          "points": 8,
-          "restrictions": {
-            "include": {
-              "unit": ["IG-227 Hailfire-Class Droid Tank"]
-            }
-          }
-        },
-        {
-          "name": "EWHB-12 Blaster Turret",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743064886/381FF3A3AED8050E5BDF1E3A4EC6B6DC2608B4EE/",
-          "points": 28,
-          "restrictions": {
-            "include": {
-              "unit": ["WLO-5 Battle Tank"]
-            }
-          }
-        },
-        {
-          "name": "Expanded Launch Tubes",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638975154/0F3C24800735B4BB8E0B156258FF032116C503F0/",
-          "points": 4,
-          "restrictions": {
-            "include": {
-              "unit": ["Missile Attack Launcher"]
-            }
-          }
-        },
-        {
-          "name": "Fire Direction Center",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638972654/A3E6D0BCB701B2DEFB788DA9CEB3F163F4025EEF/",
-          "points": 8,
-          "restrictions": {
-            "include": {
-              "unit": ["Missile Attack Launcher"]
-            }
-          }
-        },
-        {
-          "name": "FWMB-10 Megablaster",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081201870/567FD6D4762C52C8EA448858D8E030A5D9846683/",
-          "points": 35,
-          "restrictions": {
-            "include": {
-              "unit": ["Light Infantry Utility Vehicle"]
-            }
-          }
-        },
-        {
-          "name": "Ion Cannon",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638673967/DCE9270CEAD120F4DD068CDF23C326E2371DC75C/",
-          "points": 15,
-          "restrictions": {
-            "include": {
-              "unit": ["Droideka MKII"]
-            }
-          }
-        },
-        {
-          "name": "Magna Chain-Fed Missile Launcher",
-          "displayName": "Chain-Fed Missile Launcher",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743671604/F03AE6E7CE4E84CDA2D22BBD7B6A2BE97F45437B/",
-          "points": 20,
-          "restrictions": {
-            "include": {
-              "unit": ["Octuptarra Magna Tri-Droid"]
-            }
-          }
-        },
-        {
-          "name": "Magna Plague Carrier",
-          "displayName": "Plague Carrier",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743671273/2C55E19F1F47BABA103DCA4ECA92471CEA8D503A/",
-          "points": 5,
-          "restrictions": {
-            "include": {
-              "unit": ["Octuptarra Magna Tri-Droid"]
-            }
-          }
-        },
-        {
-          "name": "MS-1 Medium Laser Turret",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743066443/2CF2905266AA4BDE3F40F755F800CB0E0A3392A6/",
-          "points": 20,
-          "restrictions": {
-            "include": {
-              "unit": ["WLO-5 Battle Tank"]
-            }
-          }
-        },
-        {
-          "name": "Plague Carrier",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743540072/7D3F2EBDCE33584ED931379EFF49B8A3E26789C7/",
-          "points": 15,
-          "restrictions": {
-            "include": {
-              "unit": ["Octuptarra Tri-Droid"]
-            }
-          }
-        },
-        {
-          "name": "Proton Missile Launcher",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743617683/7B7D562698834D3ACEC51A5BC5BC6B148F4C55A4/",
-          "points": 20,
-          "restrictions": {
-            "include": {
-              "unit": ["Defoliator Deployment Tank"]
-            }
-          }
-        },
-        {
-          "name": "Raised Mono-Ski",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1021697620252782821/C642C07229E6BDCA7AA79F99D34328383622F962/",
-          "flip": {
-            "name": "Lowered Mono-Ski",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1021697620252782950/AE54FB7E97854E2621BC3F9EB314F432DBE1EC75/"
-          },
-          "points": 0,
-          "restrictions": {
-            "include": {
-              "unit": ["V-4X-D Ski Speeder"]
-            }
-          }
-        },
-        {
-          "name": "Rapid Fire Launchers",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743649159/0BAF4A7EC12DAC1AEB13A22120D2D3B1FA1BC0B6/",
-          "points": 14,
-          "restrictions": {
-            "include": {
-              "unit": ["IG-227 Hailfire-Class Droid Tank"]
-            }
-          }
-        },
-        {
-          "name": "Sealed Blast Shields",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747617819/F41341A8EA3FDEBA78238EC8298691A0E2C5248C/",
-          "points": 0,
-          "restrictions": {
-            "include": {
-              "unit": ["LA-AT/I Gunship"]
-            }
-          }
-        },
-        {
-          "name": "Transport Rack",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743692647/47DDE4B573774D76E0DD110994DEEF3C2F0406BB/",
-          "points": 20,
-          "restrictions": {
-            "include": {
-              "unit": ["HMP Droid Gunship"]
-            }
-          }
-        },
-        {
-          "name": "Tri Laser Cannons",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638674750/6057A2DACA2F104F889921E46FF3AC717DE4B962/",
-          "points": 25,
-          "restrictions": {
-            "include": {
-              "unit": ["Droideka MKII"]
-            }
-          }
-        },
-        {
-          "name": "Wing Ball Turrets",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747616297/2753260BCF4BD591144C4D74769F5E982D4E9D10/",
-          "points": 14,
-          "restrictions": {
-            "include": {
-              "unit": ["LA-AT/I Gunship"]
-            }
-          }
-        }
-      ],
-      "Heavy Weapon": [
-        {
-          "name": "ACP Trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735115264/1D92758AC20C28AA48019DCD564E31D271B20A2C/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068156270983/519A43ACE1F5461D51AA1BA81ADF4A5C37BEF9E4/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068156271135/318D90BCDE4E3E362797A38823A21FF17FAF651E/"
-          },
-          "points": 30,
-          "restrictions": {
-            "include": {
-              "unit": ["Mercenary Assault Squad"]
-            }
-          }
-        },
-        {
-          "name": "B1",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1021698068155818428/717521A597961079FBE4E4121DECAF4F0ED00471/",
-          "points": 16,
-          "restrictions": {
-            "include": {
-              "unit": ["Salvaged B2 Battle droids"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/785234780869166347/AA861F86A0B74CF335533E425A6CBACB99395A09/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/785234780869166529/263C2AB95B1743539EC2CBDE40B0A14B1F5E5693/"
-          }
-        },
-        {
-          "name": "BD-1 Vibroaxe Guard",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741407943/466AB5745404A77F5156D5AF55160CCB52545A50/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407431287477/62E1591E99BD747C7C130C3D4B5F70CA6FFA34B2/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407431272263/BBD5D7D12BC2B61E0C88AA50721BDD40AF766FF7/"
-          },
-          "points": 25,
-          "restrictions": {
-            "include": {
-              "unit": ["Gamorrean Gaurds"]
-            }
-          }
-        },
-        {
-          "name": "Beam Blaster Elite",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746958937/58D737AAB1676A6450C545CEE6299DBC19AF6E59/",
-          "points": 38,
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318091926/A474DAED7A90C67374FC60462D9A34FA7A29261F/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893318085783/83580E45A97E753127E6E4D5E221E5227B35E6A4/"
-          },
-          "restrictions": {
-            "include": {
-              "unit": ["Geonosian Warriors"]
-            }
-          }
-        },
-        {
-          "name": "Blaster Lance Droid",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742382205/FD43E6FF2AEF649B5A4A59B02630F602BEAE2C42/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407432789217/7FA6CC4082ED2BA4F96DB4A6A32DC268B55A924A/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432781824/644CE23A0B74C79BF20698A408FCF00D319EA7BE/"
-          },
-          "points": 30,
-          "restrictions": {
-            "include": {
-              "unit": ["IG-86 Sentinel Droids"]
-            }
-          }
-        },
-        {
-          "name": "Boarding Shotgun Trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277786673/D0232B6BBE5FA4816C85DF20383B0892B8151979/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692419888092880/788628E64550196C6371C2B129FEB590CC2691DE/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
-          },
-          "points": 24,
-          "restrictions": {
-            "include": {
-              "unit": ["Sith Empire Boarding Troopers"]
-            }
-          }
-        },
-        {
-          "name": "Commander Pyre",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081379697/2F3B002E5BB2D13118DF5330C9BE7BA27B84D749/",
-          "points": 30,
-          "leader": true,
-          "restrictions": {
-            "include": {
-              "faction": ["First Order"],
-              "rank": ["Corps"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027325137553590946/9E9D1E1798483BDDE43862B03D2424FB7B68EBB0/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027325137553591247/46CE15787E0615D89B2D6931B1BCDE53F1D2B954/"
-          }
-        },
-        {
-          "name": "Concussion Rifle Trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735114688/7F06A4AA27BBEFE8D08FF392CB8E7E8FC4083F6B/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068156271785/233649FA9B56D451B97E71E706C777AD529B0810/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068156271944/671F0E7483F7DA3D92D551E5042698EE06E510EB/"
-          },
-          "points": 30,
-          "restrictions": {
-            "include": {
-              "unit": ["Mercenary Assault Squad"]
-            }
-          }
-        },
-        {
-          "name": "Cycler Rifle Sniper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638840781/F5E96AC72E6D27DDA4AAC1467261D01B33AAD476/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068156464799/C000C8B3CF81A11687F6B39574ACE73A8FEF1A28/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068156464974/774C639F2300D7816E654D8276585556DEAD6432/"
-          },
-          "points": 30,
-          "restrictions": {
-            "include": {
-              "unit": ["Infiltrators"]
-            }
-          }
-        },
-        {
-          "name": "CY-M Carbine Geonosian",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746958335/3F471B7803B243D2ED9C1A3E69C86655874E3AAE/",
-          "points": 25,
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318084126/7B0D406E30E73FC005FA1AB1258738A91908E9D0/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893318095905/A0476F5F976ACE1C0BCE6F1D5C12085DBF6628B7/"
-          },
-          "restrictions": {
-            "include": {
-              "unit": ["Geonosian Warriors"]
-            }
-          }
-        },
-        {
-          "name": "DC-15 Paratrooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747551847/74C7612A3CD055BEF6F7ED101DCC13AC2EF96D2F/",
-          "points": 34,
-          "restrictions": {
-            "include": {
-              "unit": ["Clone Paratroopers"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693290506984196/E1DADD867AD088A500B4D44B6966A1BDA6F1A62A/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
-          }
-        },
-        {
-          "name": "Death Watch Duelist",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736282375/F5A9EF30A976727C91F3C880E7B603D827086B6F/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357841451/50164A1C84E6D119BC45BDD31C8209ED7D9A0F29/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515357841757/1DC29C81D9DFCB2FB7D8A3B2EA2F2ABD3F416396/"
-          },
-          "points": 25,
-          "restrictions": {
-            "include": {
-              "unit": ["Death Watch Fireteam"]
-            }
-          }
-        },
-        {
-          "name": "Death Watch Fireteam Trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736282915/B810832E8ACDF94B56D90DE60C159FE0A5FF77D2/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357844380/B08FE1606E634293EBE16FFD9541B5F7C801E2CF/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886427771/60D6CA1D97D822A2222E4FAF614931265B7B0AF2/"
-          },
-          "points": 18,
-          "restrictions": {
-            "include": {
-              "unit": ["Death Watch Fireteam"]
-            }
-          }
-        },
-        {
-          "name": "Death Watch Marksman",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736284088/EF0FB8D721EE6297963990219E9FC01B1A0AB940/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886436522/D0CBBE1EB66E7A3FEECA1A6DF0FEF6F352287404/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886436834/E27641C0A96264724D710A4B3F912F543CF9413E/"
-          },
-          "points": 34,
-          "restrictions": {
-            "include": {
-              "unit": ["Death Watch Fireteam"]
-            }
-          }
-        },
-        {
-          "name": "Detonite Charge Saboteur",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638839094/D0D81BD4107CD9647D5C041676865BAA1CFF027D/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068156470652/C2D7BF3AADDECA01B8C5442DF6419D2F1FF2389B/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068156470835/5E87EEBFF97975FF1A8985808C26B645EC53CAAC/"
-          },
-          "points": 28,
-          "restrictions": {
-            "include": {
-              "unit": ["Infiltrators"]
-            }
-          },
-          "additionalObjects": ["Proton Charge Token"]
-        },
-        {
-          "name": "Disruptor Rifle Trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277743519/060D5A5B2B512DF5E41BD6923EF07C064EEC1E7C/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608881149656/B3DDF1010726FDC59F24ACC4375251D7919F6135/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608881150442/1B5AD6129AC8D180D97CFE93ACE1DC7E49119F04/"
-          },
-          "points": 22,
-          "restrictions": {
-            "include": {
-              "unit": ["Sith Empire Troopers"]
-            }
-          }
-        },
-        {
-          "name": "DLA-13 Trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277745430/15ED754DCBAE03022CE8D08671C057280FE90B7F/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608879755028/53718ACF3D389983D1CF2630D761DF90121CDA5A/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608879744395/158047D5CFC30AFE6A2A50F64A2DA8F7BD4073B4/"
-          },
-          "points": 20,
-          "restrictions": {
-            "include": {
-              "unit": ["Sith Empire Troopers"]
-            }
-          }
-        },
-        {
-          "name": "EL-16HFE Fighter",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1021697756245234129/D1D2CFCCD4C29B15FEBC3BB12EE0E66292729C1F/",
-          "points": 25,
-          "restrictions": {
-            "include": {
-              "unit": ["Resistance Trench Fighters"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248448323/8992031636B30867375FF6724079096F6F95F5B0/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248448499/974E02AC778A5EFD4EF7F33F393B06B71ADF20A6/"
-          }
-        },
-        {
-          "name": "Electro-chain Whip Guard",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081435049/EE1C47B91E05240A23E58D4E5A905843DC1AECD6/",
-          "points": 30,
-          "restrictions": {
-            "include": {
-              "unit": ["Elite Praetorian Guards"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817957003764515/0FDC98B926F47CE64FE6407AACBCD29E5F1A8C78/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817957003763776/D3F6005987B0D827683E0B7EB3E482E8D5213424/"
-          }
-        },
-        {
-          "name": "F-11ABA Sith Trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081229621/9B54F3E6AD5E11523D82D0152FE273FA459E7FDD/",
-          "points": 28,
-          "restrictions": {
-            "include": {
-              "unit": ["Jet Troopers"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698013227868656/38A393B4932FF16ABF01AAB99C280BA4C224FE25/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698013227868793/0A4C85E66B3E68C4DDCF3D191D1E9E8B809C0727/"
-          }
-        },
-        {
-          "name": "F-11D Assault Cannon Trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277928461/7263E2C1EF01981353B16786CB01441C92A7D941/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824477681555675/1E4C571546078FEFFD4E753CBBC08EF18CBD0342/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824477681548557/DB63AB0044B89CB25D50A204A061D535CA20F495/"
-          },
-          "points": 30,
-          "restrictions": {
-            "include": {
-              "unit": ["Sith Empire Support Troopers"]
-            }
-          }
-        },
-        {
-          "name": "FN-2199",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081374822/8CF5DD30B49BCDA674B5A2E7343C421C7D367A1E/",
-          "points": 28,
-          "restrictions": {
-            "include": {
-              "unit": ["First Order Stormtroopers"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821972716827731/5B0D97A839084D07EA0B8A1F6C925732D300D681/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821972716828171/0331B4B577F867C2D647DDC63E4F201D400D679E/"
-          }
-        },
-        {
-          "name": "FWMB-10K Heavy Trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081336883/0386F13822F48C2CE6086861FAF8FA18C862645C/",
-          "points": 24,
-          "restrictions": {
-            "include": {
-              "unit": ["First Order Stormtroopers"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804930752354/251CAAD6FBAED5982A2DE07F97E73DAC15AA9B0F/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804930752683/A8A5605318AA4D5D0E86706390784598DFE8E1D9/"
-          }
-        },
-        {
-          "name": "First Order Executioner",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081370859/0CC06F999D1152E6D2591DC70C58F75D70310DAC/",
-          "points": 24,
-          "restrictions": {
-            "include": {
-              "unit": ["First Order Stormtroopers"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804931312746/A2A7E0ED462A3CC61067CD54DD75FE3EDB6FBB96/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804931312990/768DB3CC7A9A7C481E90874F6D0EBA7B76830145/"
-          }
-        },
-        {
-          "name": "First Order Flametrooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081363087/EACBFEE7B2FAB08DAA79F044AA8933BB6B2C7000/",
-          "points": 22,
-          "restrictions": {
-            "include": {
-              "unit": ["First Order Stormtroopers"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804930743225/47AC918E4F8214D21DFA7F41A1BFDC7DDC03AEC0/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804930743458/9AE62864563BECCC50045802E4B9F010B9C34098/"
-          }
-        },
-        {
-          "name": "G125 Projectile Trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081230342/5DB2636553D599B55D5642F3235445BC77C6BFEA/",
-          "points": 34,
-          "restrictions": {
-            "include": {
-              "unit": ["Jet Troopers"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698013227867905/C5D8EACB94ED7499B8B9396A430BE3E3B0074D3D/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698013227868129/0C5AB5D1F2332F71B7DFCD4F74272056F8D4A82A/"
-          }
-        },
-        {
-          "name": "Gi/9 Cannon Hired Gun",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742003564/A822E18141D6C082B017F73378B458F77F1685EF/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138166568/ED8EA2877D68277418CD413C22E7298490A0E88A/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138166740/961EBEFD298B956494AD8C52FAE4089A66129240/"
-          },
-          "points": 22,
-          "restrictions": {
-            "include": {
-              "unit": ["Hired Guns"]
-            }
-          }
-        },
-        {
-          "name": "Heavy Blaster Cannon Gunner",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736281792/283829A6193016BD5AF9264D1E90D59D07D7125A/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357847983/815BAE46D59A5AE4EE98449FF47A9F4E1F5FF4F7/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515357848221/4A5E3289B5C619501C33A169426DCEEE5F31C670/"
-          },
-          "points": 34,
-          "restrictions": {
-            "include": {
-              "unit": ["Death Watch Fireteam"]
-            }
-          }
-        },
-        {
-          "name": "Hutt Cartel lieutenant",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741194306/575F31C4867CAD2378D7FC8C57B97BE1BC7168C2/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132349796/F0D00662C6C5F6DC99EA86808B428D1A13E5F062/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132349987/DE29CB1DE563DCFE69E72C45F89F7BA994DA9599/"
-          },
-          "leader": true,
-          "points": 26,
-          "restrictions": {
-            "include": {
-              "unit": ["Hutt Cartel Troopers"]
-            }
-          }
-        },
-        {
-          "name": "Hyperstorm Heavy Cannon Gunner",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277928814/8CB3DD46BE7B2AFC9558DF5180F6FD6DAB46EFAE/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824477681557142/6A6BB38909200F986FCC00C6ED6D09B055D780BE/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824477681557325/B9CACA9DF2EB9B7AAC473686F3E8597B000E1387/"
-          },
-          "points": 32,
-          "restrictions": {
-            "include": {
-              "unit": ["Sith Empire Support Troopers"]
-            }
-          }
-        },
-        {
-          "name": "IQA-11 Sniper Droid",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742382638/9E6E5FD638CB2D2304CD6621F66CA7E1529785FC/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407432785196/AFC423350DB19E06E25D2B7B67DF95CA3323FBEF/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432781824/644CE23A0B74C79BF20698A408FCF00D319EA7BE/"
-          },
-          "points": 32,
-          "restrictions": {
-            "include": {
-              "unit": ["IG-86 Sentinel Droids"]
-            }
-          }
-        },
-        {
-          "name": "Jannah",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1022821770986743715/2D901A3B93E61AA15B16922B7C314BFE18FE079B/",
-          "points": 65,
-          "restrictions": {
-            "include": {
-              "unit": ["Orbak Riders"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770976479474/71199B4B530A5D511E21B37E7AAE4D28AEF8F799/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770976479691/41E9EEF26B5B57FE44F5ED0C4B2912F09827F465/"
-          }
-        },
-        {
-          "name": "Kronos-327",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742383051/E35635E0213C5BF6D3DECFF3DEBAEB53385737AE/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407432807943/6854E55A0F61C5DE97189B6CAC90202E6BC1F622/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432805568/E1F93A35700D25A3C33BA87AD4D64514795D6FDE/"
-          },
-          "leader": true,
-          "points": 34,
-          "restrictions": {
-            "include": {
-              "unit": ["IG-86 Sentinel Droids"]
-            }
-          }
-        },
-        {
-          "name": "M-45 Ion Fighter",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1017194020628455620/5C9E4D9872161408669629A2BD9455804F3BFBB7/",
-          "points": 27,
-          "restrictions": {
-            "include": {
-              "unit": ["Resistance Trench Fighters"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248443153/7D7FF98B537193A399A5974FF7CA73941E6D80AD/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248443360/6BD1A35DC4787C5086210BA1A0436B983B39B4CE/"
-          }
-        },
-        {
-          "name": "Mantellan Frontline Cannon Trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277928133/6CF94D4B6DA81B997D2E3BC9438CB8254F39BC0D/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824477681558249/5B7DA9706523B65997C0F39E0E3BCF6FA82F7628/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824477681547387/758CB297CD1211353CBBC992035532A98F53893E/"
-          },
-          "points": 30,
-          "restrictions": {
-            "include": {
-              "unit": ["Sith Empire Support Troopers"]
-            }
-          }
-        },
-        {
-          "name": "Mercenary Assault Trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735114176/44B42375B5C11B5BADA3029FC1BF45BBCE56575C/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365878231/A04BECDA5804E0A38FF974528C70AB5AAAE4B715/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365878394/8AD2A611C51D78184D8E4204A720C59EEC2C7755/"
-          },
-          "points": 18,
-          "restrictions": {
-            "include": {
-              "unit": ["Mercenary Assault Squad"]
-            }
-          }
-        },
-        {
-          "name": "Modified E-5C Trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741194755/20A0EFE3551FB3F616037ECA2A6B085B32437E09/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132330046/E57A960285EF5FF9C8519B41BAF73C3AFE2E9910/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132330505/2C66A444F87C08CCD808F9EC32307C893552204A/"
-          },
-          "points": 24,
-          "restrictions": {
-            "include": {
-              "unit": ["Hutt Cartel Troopers"]
-            }
-          }
-        },
-        {
-          "name": "MPL-57 Ion Stormtrooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081352987/219CD748E9D94C081BC63179004FEAF74A821088/",
-          "points": 24,
-          "restrictions": {
-            "include": {
-              "unit": ["First Order Stormtroopers"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804930745597/D46A49EBCC75A7E442CE5B9B393880CAA55411EC/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804930745893/C3D0240348A1F44EB8D086D4AC626DCCFA1DB209/"
-          }
-        },
-        {
-          "name": "Orback Rider",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1022821770986745583/D188E40D6063DA1246C0DD94216E458C45B6FDE6/",
-          "points": 45,
-          "restrictions": {
-            "include": {
-              "unit": ["Orbak Riders"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770976472837/B6A4F9FAEAF8F6DC50A4EB8CE30D1D9D62CE1477/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770976472996/354C4EE85A60585BD0FB817AFEE21D00E93799BA/"
-          }
-        },
-        {
-          "name": "Ordnance launcher trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742001131/D2429556F4177E933131B739E7E038AA5546B250/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138167432/E485629FA5F7F44891F3DE6ECF6C0F8726AD1AE3/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138184470/30F29A14D05E0FF6A5153C51E7DFC770706D0119/"
-          },
-          "points": 27,
-          "restrictions": {
-            "include": {
-              "unit": ["Hired Guns"]
-            }
-          }
-        },
-        {
-          "name": "Proton Charge Commando",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277967164/198C348A7F75677615C77AC57C0229F6B0934D03/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024261154211/0A0578275AD73052B08D31C272B3AD066484EFEB/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260988667/8B8E27DFEDD6DEBA4EFABD6E738D3B6AC3E925AB/"
-          },
-          "points": 30,
-          "restrictions": {
-            "include": {
-              "unit": ["Sith Empire Boarding Troopers", "Imperial Commandos"]
-            }
-          },
-          "additionalObjects": ["Proton Charge Token"]
-        },
-        {
-          "name": "Rose Tico",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1021697620252778506/96583F29F6DDE41276C77D92C892C2DE8965A086/",
-          "leader": true,
-          "points": 28,
-          "restrictions": {
-            "include": {
-              "faction": ["Resistance"],
-              "rank": ["Corps"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697601906861807/C7CB31D9AFAFF6C7B2633663A2A33D939F4E8205/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697601906862116/99E8BDA93C81AD3875DFC214AA5E39DC4F5477A5/"
-          }
-        },
-        {
-          "name": "RSP-6 Paratrooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747551248/7EB35E562D1685283C46BCC74678C8B0573F68FE/",
-          "points": 29,
-          "restrictions": {
-            "include": {
-              "unit": ["Clone Paratroopers"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693415425547360/64A0DE5FC04770CADAEFA3F202A83EF0ACA1AABB/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
-          }
-        },
-        {
-          "name": "Salvaged T-21 Rider",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1022821770986744919/D39D941758BD3209F2D9F72B075DE5752FC2AD80/",
-          "points": 55,
-          "restrictions": {
-            "include": {
-              "unit": ["Orbak Riders"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770976478775/74F36986A6C7597A92FB07CBD80D29430F2ADC0C/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770976478988/8EA7C3063101B4163C223C1AA9D3FFD5196EED24/"
-          }
-        },
-        {
-          "name": "Sith Rifleman",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281908934/40B735C56C1C6EFF536F72A96FCB2E86EBA4D7B5/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933721582/A454C20F4D869C5BDCBB07E7DF297D3A97C518F1/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
-          },
-          "points": 20,
-          "restrictions": {
-            "include": {
-              "unit": ["Sith Troopers"]
-            }
-          }
-        },
-        {
-          "name": "Smart Rocket Trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081347253/3C29E016BF3A1401C14EE4B73127663E916A14F2/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817412080915363/ECDC62217B6E15167C6E1CCFD38F0FDA4E424C7A/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817412080915548/72D86514E3B30EBE60DFEF4D7E5EBE63FCFCD01B/"
-          },
-          "points": 28,
-          "restrictions": {
-            "include": {
-              "unit": ["First Order Stormtroopers"]
-            }
-          }
-        },
-        {
-          "name": "Stolen RPS-6 Trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738627942/4B5C5C7EE5C0A917920BC1ACD6D9BDC884C3F66F/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436116594/297A8181876F9899A0116189C171CB6DCF8F7E91/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436116780/2EDB6D1F02708B64292E99D8A6C1C2BA9772D6CD/"
-          },
-          "points": 25,
-          "restrictions": {
-            "include": {
-              "unit": ["Weequay Pirates"]
-            }
-          }
-        },
-        {
-          "name": "Tactial Shotgun Commando",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277958661/B7303152FFBCFF29BFD241865245D297469E6F17/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024261155036/D5997D5F703F00DB00BB6C2CB1C92B0BB3E4B972/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260988667/8B8E27DFEDD6DEBA4EFABD6E738D3B6AC3E925AB/"
-          },
-          "points": 30,
-          "restrictions": {
-            "include": {
-              "unit": ["Imperial Commandos"]
-            }
-          }
-        },
-        {
-          "name": "TL-50 Resistance Trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752980632/3AC1DF926A9DF195B85993DE03C1BA837FF12038/",
-          "points": 26,
-          "restrictions": {
-            "include": {
-              "unit": ["Resistance Troopers"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324582151739582/7B71E9B3E009D0CE72542DCE4EE88F80A15975F1/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324582151739873/59E17839EF9DE940D822E980A6B8D17EAF323009/"
-          }
-        },
-        {
-          "name": "TL-50 Stormtrooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751871157/BC6D8D82C13ED515680AE0748BCBF8BBA1967D52/",
-          "points": 28,
-          "restrictions": {
-            "include": {
-              "unit": ["Stormtroopers"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324932748013140/6A82D4809AA884C3F5786210898CE813BC9789F9/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324932748013349/A449441B895CE926D13CE9D1501BFC9B12A08A9D/"
-          }
-        },
-        {
-          "name": "Trandoshan Blaster Trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738629805/EEDC0DDF8D9737D6CFFDBAAEDDF73C2BC39DC9AF/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436115961/DBF66375F8D2143292D9BBDC3F6FF6AB46D7AB16/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112372/F530C8FD39C7DAC7766DF00F0087A82E8044DE0D/"
-          },
-          "points": 27,
-          "restrictions": {
-            "include": {
-              "unit": ["Weequay Pirates"]
-            }
-          }
-        },
-        {
-          "name": "Vibro-arbir Blade Guard",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081435867/C1A0F6BB89AB4B4C2C2857491FFD840AA82AFFA6/",
-          "points": 25,
-          "restrictions": {
-            "include": {
-              "unit": ["Elite Praetorian Guards"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817957003763616/5D2007C0F4115E9406A2A83D98E4D4D3275E168F/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817957003763776/D3F6005987B0D827683E0B7EB3E482E8D5213424/"
-          }
-        },
-        {
-          "name": "Riot Control Trooper (Offensive)",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081343404/198C195A7C6538264754E6ED65810E699941909B/",
-          "flip": {
-            "name": "Riot Control Trooper (Defensive)",
-            "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081343586/AFEAA0E712AC4720D360E2A44E8DD5DCC5AD2F3E/"
-          },
-          "points": 22,
-          "restrictions": {
-            "include": {
-              "unit": ["First Order Stormtroopers"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324932747749076/BC0B7C898A646CCDFC518280A48B7C82EECB54B1/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324932747749244/7BD30A42AAF722FC4D005E08EC5EB2BCBD938E22/"
-          }
-        },
-        {
-          "name": "Z-6B Resistance Trooper ",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752971387/1606CD1A3BD10A2FAF39558C7B36597840920010/",
-          "points": 22,
-          "restrictions": {
-            "include": {
-              "unit": ["Resistance Troopers"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324932752944952/1207D0D12B5971CC86CDAC845AB9487AFB0913E2/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324932752945165/7BFD62143549CA0DC0C9FDF7A251A8546AFB50DD/"
-          }
-        },
-        {
-          "name": "Z-6 StormTrooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751870825/96353DB410957633EF3D108F2BC58D4F84EBEC7E/",
-          "points": 25,
-          "restrictions": {
-            "include": {
-              "unit": ["Stormtroopers"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324932748082014/050A615D4A688CAF04806338E172186E1BEE93F5/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324932748082306/B60EBE5BB730F9B03EC541DDF15993BADBE2820F/"
-          }
-        }
-      ],
-      "Illicit": [
-        {
-          "name": "Black Market Weapon Modifications",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735317485/24DDC0FD309F0F75C04559832E888C0ED6E52CB1/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "type": ["Trooper"]
-            }
-          }
-        },
-        {
-          "name": "Black sun Assault mod",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742527952/354B544F4AB6ED4EA8FE90895DA7E62CC6D9DED9/",
-          "points": 5,
-          "restrictions": {
-            "include": {
-              "unit": ["EWHB-12 Heavy Blaster team"]
-            }
-          }
-        },
-        {
-          "name": "Ewok Bomb",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741833695/4345404F4A2F9E97DC140024285F113A8DDEAAE9/",
-          "points": 22,
-          "restrictions": {
-            "include": {
-              "unit": ["Beast Master"]
-            }
-          },
-          "additionalObjects": ["Proton Charge Token"]
-        },
-        {
-          "name": "Glitterstim",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735317047/31F1D322D5E1C986DFB20E582590653A0B0CAF7F/",
-          "points": 5,
-          "restrictions": {
-            "include": {
-              "type": ["Trooper"]
-            }
-          }
-        },
-        {
-          "name": "Inspiring Monologue",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738474691/8D852B6879C8FF5C5F0A2883FC9A204FB8937979/",
-          "points": 5,
-          "restrictions": {
-            "include": {
-              "unit": ["Hondo Ohnaka"]
-            }
-          }
-        },
-        {
-          "name": "Lord of Pirates",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738474167/126CF97710D8C7F9BDFBB16BF051B1F8660C7263/",
-          "points": 15,
-          "restrictions": {
-            "include": {
-              "unit": ["Hondo Ohnaka"]
-            }
-          }
-        },
-        {
-          "name": "Outer Rim Modifications",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735317893/3A2F6E60B2980B2608C4DA9B029E1C4B2F257560/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "type": ["Droid Trooper", "Ground Vehicle", "Repulsor Vehicle"]
-            }
-          }
-        },
-        {
-          "name": "Personal Shield",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735181899/208D960208099BDF4461E2E09204169FF959FC52/",
-          "points": 8,
-          "restrictions": {
-            "include": {
-              "type": ["Trooper"]
-            }
-          }
-        },
-        {
-          "name": "Piercing Dart",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640417521/8FE5D7BA77D3E25ED3FB812B261AD3E3DD88EF10/",
-          "points": 6,
-          "restrictions": {
-            "include": {
-              "type": ["Mandalorian Trooper"]
-            }
-          }
-        },
-        {
-          "name": "Pirate Retrofit",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742527540/AA9771542B3B0F58F1D813AE833F6E230163C361/",
-          "points": 5,
-          "restrictions": {
-            "include": {
-              "unit": ["EWHB-12 Heavy Blaster team"]
-            }
-          }
-        },
-        {
-          "name": "Poison Dart",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640416768/843BE27BBC497AC58846ED0295BFC661E391BEDF/",
-          "points": 6,
-          "restrictions": {
-            "include": {
-              "type": ["Mandalorian Trooper"]
-            }
-          }
-        },
-        {
-          "name": "Rancor Tamer",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741834052/EE3F163A5E5986958BCE4A45AD91F861EB85459F/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "unit": ["Beast Master"]
-            }
-          }
-        },
-        {
-          "name": "Reputation of the Hutts",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741312392/906B601379C476DB20B6997F64A1B29916A421DB/",
-          "points": 7,
-          "restrictions": {
-            "include": {
-              "unit": ["Jabba The Hutt"]
-            }
-          }
-        },
-        {
-          "name": "Self-Destruct Sequencing",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735318468/FF453A532280D1626623E10338ED5D288FA47B6E/",
-          "points": 5,
-          "restrictions": {
-            "include": {
-              "type": ["Droid Trooper", "Ground Vehicle", "Repulsor Vehicle"]
-            }
-          }
-        },
-        {
-          "name": "Stimpack",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735182732/C3B2C7FA3F05FC71D5C3ED089A8037A92171A103/",
-          "points": 5,
-          "restrictions": {
-            "include": {
-              "type": ["Trooper"]
-            }
-          }
-        },
-        {
-          "name": "Wrist Mounted Disintegrator",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640426484/CAA3EE923F691577E92958B5BAA38AB8221EDF61/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "type": ["Mandalorian Trooper"]
-            }
-          }
-        },
-        {
-          "name": "Wrist Mounted Disruptor",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640427887/A13950D10FE563732533E3C91584E465D47F05F5/",
-          "points": 3,
-          "restrictions": {
-            "include": {
-              "type": ["Mandalorian Trooper"]
-            }
-          }
-        },
-        {
-          "name": "Wrist Mounted Slugthrower",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640413367/65913371690794787832DA2D5D970C42E484A5E0/",
-          "points": 6,
-          "restrictions": {
-            "include": {
-              "type": ["Mandalorian Trooper"]
-            }
-          }
-        },
-        {
-          "name": "Ysalamiri cage",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741834581/FDBF31BD0BD3997D1415E1409F8C4A82744019D9/",
-          "points": 8,
-          "restrictions": {
-            "include": {
-              "unit": ["Beast Master"]
-            }
-          }
-        }
-      ],
-      "Ordnance": [
-        {
-          "name": "Bunker Buster Missiles",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751975579/6613DFBE1168370B4DB2AA3BAC7CCDC8F2B1EEDD/",
-          "points": 5,
-          "restrictions": {
-            "include": {
-              "unit": ["Phase II Darktroopers"]
-            }
-          }
-        },
-        {
-          "name": "Carbonite Missiles",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638969743/EEA573B6F2E054B13E3A220888FFDC03906CA74C/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "unit": ["Missile Attack Launcher"]
-            }
-          }
-        },
-        {
-          "name": "Sabot Missiles",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751975146/7766942C8563D444E253FC2262E6E7DDE1A95F00/",
-          "points": 5,
-          "restrictions": {
-            "include": {
-              "unit": ["Phase II Darktroopers"]
-            }
-          }
-        },
-        {
-          "name": "Shrapnel Missiles",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751975982/EBFAC7D348F41D8A319B15EAF27ADF6F443DD56C/",
-          "points": 5,
-          "restrictions": {
-            "include": {
-              "unit": ["Phase II Darktroopers"]
-            }
-          }
-        }
-      ],
-      "Personnel": [
-        {
-          "name": "Clone Paratrooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747552501/731105BAC6B5011092706B93C5853B6B51317D55/",
-          "points": 16,
-          "restrictions": {
-            "include": {
-              "unit": ["Clone Paratroopers"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693290507042014/A16ED28591E7E27887C7BC119152B6AD889BFF9E/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
-          }
-        },
-        {
-          "name": "Extra Grenadier",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735129141/9805A2223DB725582E8105414121E4505895193F/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365824294/5F43B720E0198A078E25BA472E7DDBCA8F51CBEC/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365824481/27693FC709ADF50440623C6347A11151608D5E2F/"
-          },
-          "points": 11,
-  
-          "restrictions": {
-            "include": {
-              "unit": ["Grenadier Squad"]
-            }
-          }
+    "First Order": {
+      "Commander": [
+        {
+          "name": "Captain Phasma",
+          "title": "Ruthless Leader",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081143260/D95314875641B7FB3C4EF84083544C623CD1A682/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 95,
+          "speed": 2,
+          "upgrades": {
+            "Command": 2,
+            "Training": 1,
+            "Armament": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804925773451/29E9C01AADB63D0F11307AC6DF9FE7F0C29178CD/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804925773688/AA999386C07D280297E4E55F78BE951C22CC4765/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "Traitor!",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081145254/8867B053273BC9DBBB46FDC464881998DF372B1A/",
+              "pip": 1
+            },
+            {
+              "name": "So Good To Have You Back",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081145863/40A8C433BC0D8BBBFBC44BCCF8D9BBBF465CE231/",
+              "pip": 2
+            },
+            {
+              "name": "On My Command...",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081146194/C55577A1151D80D0A283097F5FFE5596258520D0/",
+              "pip": 3
+            }
+          ]
         },
         {
           "name": "First Order Officer",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081395449/B2459EAD6D5B9FCF46951EF77CC2BCBF23370C10/",
-          "points": 22,
-          "leader": true,
-          "restrictions": {
-            "include": {
-              "faction": ["First Order"]
-            }
+          "title": "Cruel Superior",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081388976/28890DF10C50786D86509A5E6E9014EDFB18178A/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 50,
+          "speed": 2,
+          "upgrades": {
+            "Command": 1,
+            "Gear": 1
           },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821664192111404/0E625C7A4614D3BE5DF4DF9D78BA558C2B78803C/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821664192111727/770A7C77419D31361A4E7DF14655D4339B5333BE/"
-          }
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821664192111404/0E625C7A4614D3BE5DF4DF9D78BA558C2B78803C/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821664192111727/770A7C77419D31361A4E7DF14655D4339B5333BE/"
+            }
+          ]
         },
         {
-          "name": "First Order Stormtrooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081340137/E2C8E810E5F4D2F842F4B633A9EF4E633317B5AC/",
-          "points": 12,
-          "restrictions": {
-            "include": {
-              "unit": ["First Order Stormtroopers"]
-            }
+          "name": "General Hux",
+          "title": "First Order High Commander",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081169876/CB65E6B92A868A8379B108FF8AF217970564DECC/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 75,
+          "speed": 2,
+          "upgrades": {
+            "Command": 2,
+            "Flaw": 1
           },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804926507457/5178F7589B3E8647E3FBFDE3C3C0829F284FA23D/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804926496614/9FECECAF48C7046C3714B33C4C16FFB773FCC94C/"
-          }
-        },
-        {
-          "name": "First Order Stormtrooper Officer",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081357391/65AB363DC36732A59EF1CF526B1C236F54F63C87/",
-          "points": 15,
-          "leader": true,
-          "restrictions": {
-            "include": {
-              "unit": ["First Order Stormtroopers"]
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324932753815007/08A3CB2CCDEDD302548596EF866CF64E5E0AFB75/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324932753720403/40A7224F1345DCD440F78BD1669290C07059002E/"
             }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804930715422/16120934F642C553591C4773C4F9E4B21F167A52/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804930715848/CC1157E547C67A4FD8CF56868BFCD9EF3A04075D/"
-          }
-        },
-        {
-          "name": "Forward Observer",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735128538/8947A618AAA4A4A0D92B3C7C12E651A494FDEDA7/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984835690936/3C42012D036A5F420DD9ADD158E66901AB4A5671/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984835691208/1C0C86466F3298E9663CEE3961B7F3F6DBED4DD9/"
-          },
-          "points": 17,
-          "restrictions": {
-            "include": {
-              "unit": ["Grenadier Squad"]
+          ],
+          "commands": [
+            {
+              "name": "Orbital Bombardment ",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081172704/D53673C6656A92D080288EBC0C0F6A7C6760626C/",
+              "pip": 1
+            },
+            {
+              "name": "Tied on the End of a String",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081174703/A647478FFD9A384A559221E190389D2AC56D902D/",
+              "pip": 2
+            },
+            {
+              "name": "Acquiesces to Disorder!",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081176167/0D2A9F919346BEDA9602EF0803ADADEEFB4F9F4C/",
+              "pip": 3
             }
-          }
-        },
-        {
-          "name": "General Caluan Emmat",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1021697756245233178/36866FDE340064CDE02A6C0BB423EA8CAD2B1ABC/",
-          "points": 20,
-          "leader": true,
-          "restrictions": {
-            "include": {
-              "faction": ["Resistance"],
-              "rank": ["Corps"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248463256/9A71FCC63F00BFF1B30323727AE4ECE40A797845/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248457898/6A102129E4F692F04E02D1269F913A4D22B22FBC/"
-          }
-        },
-        {
-          "name": "Geonosian Warrior",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746955018/3E851672C18FC4978BF8E7D82D3BB6E0D4433A9D/",
-          "points": 12,
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893317940526/D1A4E66DAA988ABE66C6D0014DD6D49047AA6697/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893317930470/4A9F58F7B8BC80AF279695655E38DD81A9236057/"
-          },
-          "restrictions": {
-            "include": {
-              "unit": ["Geonosian Warriors"]
-            }
-          }
-        },
-        {
-          "name": "Hired Gun",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742004196/087F0B1F89E7E79E87461EE5D2661B2585C52D4A/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138165871/C51E95633C934897949CFF29D8F9BCE471BF8FFA/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138166035/1BA43B16941621DB32750B2B3CDD35053996ABA9/"
-          },
-          "points": 9,
-          "restrictions": {
-            "include": {
-              "unit": ["Hired Guns"]
-            }
-          }
-        },
-        {
-          "name": "Hutt Cartel Sentry",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738629292/FE183D473B13C247AC36F6DD253B934B09655B34/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436124726/C43B4DBB33AABF8482E19400E53948B5ED032CCB/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436124875/9CB0C0F06DD8F10B227161EE26DD1B55F8F5BDD4/"
-          },
-          "leader": true,
-          "points": 23,
-          "restrictions": {
-            "include": {
-              "unit": ["Weequay Pirates"]
-            }
-          }
-        },
-        {
-          "name": "Hutt Cartel Trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741193921/7F0C6BE42AE860AB77EB6C2BC779788371FE78B7/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132329491/14A83C22F3313876B13BB0A0016C687ED2E77D44/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132233662/46758BE4190670991AEEB84884D2C0926704577E/"
-          },
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "unit": ["Hutt Cartel Troopers"]
-            }
-          }
-        },
-        {
-          "name": "Imperial Supercommando",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751939006/CBC6F2FE8C1DF0F75561DAE45F1F721222BF52FB/",
-          "points": 23,
-          "restrictions": {
-            "include": {
-              "unit": ["Imperial Supercommandos"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982276859/C65AD83F5B3BE7D8787B3F0DC71C3637F257CF58/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982273931/809947D430BEB447CD2FA3E99DD31AF57C3E8F84/"
-          }
-        },
-        {
-          "name": "Paratrooper Medic",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747553122/09BE4CDAF6D1A40AED895C9DAC9B03EECA17E46A/",
-          "points": 29,
-          "restrictions": {
-            "include": {
-              "unit": ["Clone Paratroopers"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693415425401629/49D60D4EE5794A206AF8F604A68F58979CFEBC42/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693415425408778/BD84B4C5CAA84DDA6302739AD749CD29B1C39669/"
-          }
-        },
-        {
-          "name": "Resistance Trench Fighter",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1017194020628451982/E73E545FCA80240A75FBE0988782C8014F891577/",
-          "points": 13,
-          "restrictions": {
-            "include": {
-              "faction": ["Resistance Trench Fighters"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248442551/9D7BC64B0ECFEA79E16E695F4823085745EA8C51/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248440578/125E76600442E01E3AD18725563EA1BE4D63BEFA/"
-          }
-        },
-        {
-          "name": "Resistance Trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752970508/02879490220A6F3BD0B3B501770CE6567C152BD1/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "unit": ["Resistance Troopers"]
-            }
-          },
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324582151467148/595A4E7837AB3D12604D3A2858D08496E4FCBEA5/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324582151467561/892B00728A9164598F3FBE91C0D7C0F8619FCB20/"
-          }
-        },
-        {
-          "name": "Sith Empire Boarding Trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277786308/E222A61B5021B9FC2E56A8A957633B8BD2384CDB/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608884994661/01F7CD51333718A8A814885CF5A93B2A84651652/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
-          },
-          "points": 12,
-          "restrictions": {
-            "include": {
-              "unit": ["Sith Empire Boarding Troopers"]
-            }
-          }
-        },
-        {
-          "name": "Sith Empire Trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277742848/35DD1780CE5A8F446954CC178C0C05089A10B21B/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608878992636/D833E26E44A7763FAEFBE2430390376F9160E931/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608878877171/C209E7E6493A8465F8FD60DE6566AA6BA2C745ED/"
-          },
-          "points": 11,
-          "restrictions": {
-            "include": {
-              "unit": ["Sith Empire Troopers"]
-            }
-          }
-        },
-        {
-          "name": "Sith Sorcerer",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278055781/ED051F07880B0030B6DE21C04E01E640FEAD93C2/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061823163250038/32C72D2D0F766BFD34626E6A8944954C50CC0D77/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061823163250299/7A3E3550E4630C1BF03CF91847C63638AB684434/"
-          },
-          "points": 35,
-          "restrictions": {
-            "include": {
-              "unit": ["Sith Acolytes"]
-            }
-          }
-        },
-        {
-          "name": "Sith Trooper",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281908575/338762E958A0C98B0AB49C47AA6A715893E4548B/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933703057/89125C10F7477148926E221D7D01FC48B49D2502/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
-          },
-          "points": 11,
-          "restrictions": {
-            "include": {
-              "unit": ["Sith Troopers"]
-            }
-          }
-        },
-        {
-          "name": "Sith Warrior",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278056315/1665856EDAB96AF7A8C172511E6599CD901D4E71/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885796271/427E4FBA584A22712C84414761D3EEBB1AE714E7/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608885695776/F5A3AA78554B8F3CB86314E552D94D65C0080F0C/"
-          },
-          "points": 35,
-          "restrictions": {
-            "include": {
-              "unit": ["Sith Acolytes"]
-            }
-          }
-        },
-        {
-          "name": "Veteran Sergeant",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277744958/3610B8D3EB6E459B5BF3C7F97B0E7B2B9AA4CBE1/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608881242939/0D60224C8880F4609ADFC4B901EC92EEA545B235/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608881243790/F0D722D6703135FDF3BB2B7F3105FCAA49DB5284/"
-          },
-          "leader": true,
-          "points": 25,
-          "restrictions": {
-            "include": {
-              "unit": ["Sith Empire Troopers"]
-            }
-          }
-        },
-        {
-          "name": "Weequay Pirate",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738628849/92249CF6F8DC12990B7073346AEF4DE3F3C5BB43/",
-          "mini": {
-            "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436114050/3985CF5B2D5C91AEF263706C20E4C84D7401F1BE/",
-            "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112951/28554A829163EDA67DDE90D1CF137C093FF8A9AC/"
-          },
-          "points": 11,
-          "restrictions": {
-            "include": {
-              "unit": ["Weequay Pirates"]
-            }
-          }
+          ],
+          "required": ["I Don't Care if You Win"]
         }
       ],
-      "Pilot": [
+      "Operative": [
         {
-          "name": "Agent Terex",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081428303/9A5F8BEFCF2B962CAD2849472B5123723578E868/",
-          "points": 15,
-          "restrictions": {
-            "include": {
-              "faction": ["First Order"],
-              "type": ["Repulsor Vehicle"]
+          "name": "Bazine Netal",
+          "title": "Skilled Mercenary and Spy",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081110689/34878CC455F7F58C190A27DEEFAAD326F411F137/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 85,
+          "speed": 2,
+          "upgrades": {
+            "Training": 2,
+            "Gear": 1,
+            "Grenades": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027325137554369094/426567AD530CBB53A36B4DA286606A8028036940/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821664190500251/60F46C12E0D02DE01D36B03BDF1E8ECAFD604F87/"
             }
-          }
+          ],
+          "commands": [
+            {
+              "name": "The Perfect Weapon",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081134318/95DFAC48AF2895CBD541779163F6F58781816CE8/",
+              "pip": 1
+            },
+            {
+              "name": "They Die Or Disappear",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081134688/F073799B09F8A31C076CA224E1B5BD6C8C75106A/",
+              "pip": 2
+            },
+            {
+              "name": "Inform The First Order",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081135367/1425B91FE3B59882B80BB27197F86C066C5DBF46/",
+              "pip": 3
+            }
+          ]
         },
         {
-          "name": "Defoliator Lok Durd",
-          "displayName": "Lok Durd",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743617101/58D618F0C66FFCDC5FEBF39BC32D54D6BA55EB30/",
-          "points": 9,
-          "restrictions": {
-            "include": {
-              "unit": ["Defoliator Deployment Tank"]
+          "name": "Kylo Ren",
+          "title": "Fallen Apprentice",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081182228/D92A0F8C9F86CF7DEA222B23C6172250083EAB29/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 140,
+          "speed": 2,
+          "upgrades": {
+            "Force": 2,
+            "Training": 1,
+            "Flaw": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804925562786/E8A84B89A9397EDE6466F969084F683316C98D64/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804925562981/94795F169138667E0322FE1E28F68E2B8B7F4C37/"
             }
-          }
+          ],
+          "commands": [
+            {
+              "name": "Finish What You Started",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081184101/51986EF40283FA440878CF7C1DD65104FF4A65B9/",
+              "pip": 1
+            },
+            {
+              "name": "I'll Show You the Dark Side",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081186038/6DE22BF4C255C7D6213E01F2B101CB7EA969D68F/",
+              "pip": 2
+            },
+            {
+              "name": "Mind Probe",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081187404/50F791DA2817CC1E8C690138FE028CA17B1B51D5/",
+              "pip": 3
+            }
+          ],
+          "required": ["I'm Being Torn Apart"]
+        }
+      ],
+      "Corps": [
+        {
+          "name": "First Order Stormtroopers",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081335160/5F935176EDBFB5C657AFA3681E67CC2C9F20BC24/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 52,
+          "speed": 2,
+          "upgrades": {
+            "Heavy Weapon": 1,
+            "Personnel": 1,
+            "Training": 1,
+            "Gear": 1,
+            "Grenades": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804926496354/534247FC18865263C1D30BC8C906CB39C93B0394/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804926496614/9FECECAF48C7046C3714B33C4C16FFB773FCC94C/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804926504208/94BA6801EC3D5C7915A803C8DB037D55499DA148/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804926496614/9FECECAF48C7046C3714B33C4C16FFB773FCC94C/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804926505290/B0670893C896898E6BE4CAB01744CE00F1FFE52B/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804926496614/9FECECAF48C7046C3714B33C4C16FFB773FCC94C/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804926506313/1AF44B793BDE12347BA28238D08E48E507CFBD02/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804926496614/9FECECAF48C7046C3714B33C4C16FFB773FCC94C/"
+            }
+          ]
+        }
+      ],
+      "Special Forces": [
+        {
+          "name": "Elite Praetorian Guards",
+          "image": "http://cloud3.steamusercontent.com/ugc/1862817412081432797/70B4BE3AC3FDE23388AFCD4D48844DD102463B12/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 80,
+          "speed": 2,
+          "upgrades": {
+            "Heavy Weapon": 1,
+            "Training": 2,
+            "Gear": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817957003761532/B9A39E219D561F0CFF064BD65083EF2B03FE2408/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817957003761811/4348E66B49C37DBE90E2798DDBCDAC46ADB90020/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817957003762298/2506A4C1DB297710118290CFCEB8FBCE61A371CA/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817957003761811/4348E66B49C37DBE90E2798DDBCDAC46ADB90020/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817957003762782/37B88231894CD5B671EFD926554F8143F593FD86/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817957003761811/4348E66B49C37DBE90E2798DDBCDAC46ADB90020/"
+            }
+          ]
         },
         {
-          "name": "Defoliator T-Series Tactical Droid Pilot",
-          "displayName": "T-Series Tactical Droid Pilot",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743616760/DF7B027C96C111F6170C6DD30E32DC1FBBE08AEE/",
-          "points": 5,
-          "restrictions": {
-            "include": {
-              "unit": ["Defoliator Deployment Tank"]
+          "name": "Jet Troopers",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081228934/0854F9987A9760340D1CFB61EA0360C669DB60A3/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 20,
+          "speed": 3,
+          "heavyWeaponTeam": true,
+          "upgrades": {
+            "Heavy Weapon": 1,
+            "Training": 1,
+            "Comms": 1,
+            "Gear": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698013227866981/5EA3E02AC241512021988DBE0EC44754960D7C1E/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698013227867246/FB14C11D0A31B44E68FDEF0CAF9D3CCE7D140EF7/"
             }
-          }
+          ]
+        }
+      ],
+      "Support": [
+        {
+          "name": "125-Z Treadspeeder Bikes",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081161332/82657FF9895270D7FB5B46FFEC762DE81575BFC3/",
+          "size": "medium",
+          "type": "Repulsor Vehicle",
+          "points": 85,
+          "speed": 2,
+          "upgrades": {
+            "Comms": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770981171565/A72EE65BB1B64233BC73B5A19F8BEEB49B6D25C2/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770981171714/24D19968CC914CDDF4318CD7F4D6A4A8C6453857/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1776099479274350301/4B9837939C2036E21527782F78E06152B3BFD831/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770981179713/F1CAD4EA45F501FA427BFC3194823758D23CAB4C/"
+            }
+          ]
+        }
+      ],
+      "Heavy": [
+        {
+          "name": "AT-ST",
+          "displayName": "First Order AT-ST",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081421585/4B0F0B47465016ACD271DAEFE93F062C79776DDF/",
+          "size": "huge",
+          "type": "Ground Vehicle",
+          "points": 170,
+          "speed": 2,
+          "upgrades": {
+            "Pilot": 1,
+            "Hardpoint": 3,
+            "Comms": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817412080755222/3B92EACA1DE861874A44E0001F4686FB7BA30CA0/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817412080755364/E8C5A3482E6C2FFA2AF18518E3F78823CAD68236/"
+            }
+          ]
         },
         {
-          "name": "Excitable Pirate",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743063563/DECCDDEB113FF6F7E278657E96EB142AEE9690B7/",
-          "points": 15,
-          "restrictions": {
-            "include": {
-              "unit": ["WLO-5 Battle Tank"]
+          "name": "Light Infantry Utility Vehicle",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081200983/383E193D0A6B5D69AB817D4584828A40B0B25C77/",
+          "size": "huge",
+          "type": "Repulsor Vehicle",
+          "points": 75,
+          "speed": 2,
+          "upgrades": {
+            "Pilot": 1,
+            "Crew": 1,
+            "Hardpoint": 1,
+            "Comms": 1,
+            "Generator": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027325137553435779/3A8FDD7CE7E77EA1D206645EEC453C509B3BD6F2/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027325137553435979/8778AF380A0A56B19CD1EA4BC88266803292180E/"
             }
-          }
+          ]
+        }
+      ]
+    },
+    "Rebel": {
+      "Commander": [
+        {
+          "name": "General Rieekan",
+          "title": "Founding Member of the Alliance",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640752085723/9E5DE6BB4E45204DC3A997830A4DC8068C69CABD/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 80,
+          "speed": 2,
+          "upgrades": {
+            "Command": 2,
+            "Gear": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698230624925896/947BD1C75A604FAD92CB77ECAB27AC5109EB7F00/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698230624926095/54D107149A5C01B99334D873DC0D2B172AB71DA7/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "Rapid Response",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640752086080/BC550A52E3D05D8FFB63D4673FD71BCAD35FC13C/",
+              "pip": 1
+            },
+            {
+              "name": "Launch Patrols",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640752086446/2245AED04413455E4469534F5D70B03D02DD184C/",
+              "pip": 2
+            },
+            {
+              "name": "Armored Assault",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640752086781/B8BD73E178BA6F4492F8F9C5110E921BDB1ADA3A/",
+              "pip": 3
+            }
+          ]
+        }
+      ]
+    },
+    "Republic": {
+      "Commander": [
+        {
+          "name": "Mace Windu",
+          "title": "Master Jedi",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747447768/91A80BEC147782188809554C9E3E1C89E38D0A8C/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 200,
+          "speed": 2,
+          "upgrades": {
+            "Force": 3,
+            "Command": 1,
+            "Training": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455187825660/20318CF5820801C8D087056BFFF3B448DD1D24C0/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455187825926/3024C576BF271F52A8E09E226B9CE33A850279B5/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "This Party's Over",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747448183/4C67DCF52EA1A41CE347DFA72F1F249E6D2C990B/",
+              "pip": 1
+            },
+            {
+              "name": "High Jedi General",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747448594/5712552FEBB895EB97EFB122230A64DFC888F30D/",
+              "pip": 2
+            },
+            {
+              "name": "Shatterpoint",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747448920/DE303A6D36A7845AD8B10767827027D50EA8738E/",
+              "pip": 3
+            }
+          ]
         },
         {
-          "name": "Hawkeye",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747619367/B0EFDF7F817DC850C3A28D1CD885213958C2248E/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "unit": ["LA-AT/I Gunship"]
+          "name": "Commander Cody",
+          "title": "Marshal Commander of the 212th",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747469835/A6730D0E28DBDA4AC78F4590BF0C5F1D46083322/",
+          "size": "small",
+          "type": "Clone Trooper",
+          "points": 110,
+          "speed": 2,
+          "upgrades": {
+            "Command": 1,
+            "Training": 1,
+            "Gear": 1,
+            "Armament": 1,
+            "Grenades": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893322692719/36CE1B78678368B94938143D4CEA2773F93F363A/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893322728253/2649AA8D8F66C02A791A73B8AFAD18C25B40A394/"
             }
-          }
+          ],
+          "commands": [
+            {
+              "name": "Blast Him",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747470658/793EFE2139085E54F9F85AAC92274E621C66DC6E/",
+              "pip": 1
+            },
+            {
+              "name": "Good Man That Cody",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747471029/C0DD76F36655C93C8C105652951B3B74FCDC202D/",
+              "pip": 2
+            },
+            {
+              "name": "You Must Realize That You Are Doomed",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747471461/265DF114E68306DF604691C110042DDB00C84DAC/",
+              "pip": 3
+            }
+          ]
+        }
+      ],
+      "Operative": [
+        {
+          "name": "Ahsoka Tano",
+          "title": "Stubborn Padawan",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747500577/DCDE4281DCAD8EC68919759915AB4DF09EAB5546/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 110,
+          "speed": 2,
+          "upgrades": {
+            "Force": 2
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817412091474935/EE39ED83BE15C1003350940C488EAEB4D6E9A96D/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817412091472250/A731A2DF0028A305625B39844340B899A3D97A5A/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "Twin Lightsabers",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747502894/3AE99D7998FF7322CA29DCF7BAE0B72D459F9110/",
+              "pip": 1
+            },
+            {
+              "name": "Anakin's Apprentice",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747503725/0A7361854FBF8757DA002A670DBAA45BDDFD76D4/",
+              "pip": 2
+            },
+            {
+              "name": "Independant Adept",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747504272/935C0A5511D2455D302753EC8DEE0A9AF0326CB6/",
+              "pip": 3
+            }
+          ]
         },
         {
-          "name": "Hutt Cartel Pilot",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743063098/6FA89F40EA19F2FA891BD06D60B6DC06539C1212/",
-          "points": 15,
-          "restrictions": {
-            "include": {
-              "unit": ["WLO-5 Battle Tank"]
+          "name": "Commander Colt",
+          "title": "Rancor Batallion",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747527226/26A8CE439ADC2BDB1C9EE783B4013366CC9F97A8/",
+          "size": "small",
+          "type": "Clone Trooper",
+          "points": 90,
+          "speed": 2,
+          "upgrades": {
+            "Training": 1,
+            "Comms": 1,
+            "Gear": 2,
+            "Grenades": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693415431516051/4EAB6085C2D2D6C176B3C9847E2F1F228CEFE7BB/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693415431516248/89D5E03C721391A7CBC7930180396F3B14E5273F/"
             }
-          }
+          ],
+          "commands": [
+            {
+              "name": "Legacy Of A Legend",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747528124/18B118F66C532CAF69CC82877EC177C68A9A5278/",
+              "pip": 1
+            },
+            {
+              "name": "Shock Traps",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747528435/A7754C5F989DC2C48860EA1F8DDFC671FCD90338/",
+              "pip": 2
+            },
+            {
+              "name": "Shoulder to Shoulder",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747528812/CFDDAA0DDD1CB89C937F8B47D672B78CF44D19D5/",
+              "pip": 3
+            }
+          ]
+        }
+      ],
+      "Special Forces": [
+        {
+          "name": "Clone Paratroopers",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747550450/AB6335C9C96E10F6D70F161BCDFC89FDB2934C57/",
+          "size": "small",
+          "type": "Clone Trooper",
+          "points": 68,
+          "speed": 2,
+          "upgrades": {
+            "Heavy Weapon": 1,
+            "Personnel": 1,
+            "Training": 1,
+            "Comms": 1,
+            "Gear": 1,
+            "Grenades": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693290507071203/040CF6A943C83588994E5BD8C0DDB793F6DE9875/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693415425506623/121AA3B4552A900E92161C97E55443D4040D7886/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693290507016826/760576DD3D314CB88313B54E105FB561009F8502/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693290506836632/AE0366ABB62BED44CC56CB5F25D5C6478592EBBF/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
+            }
+          ]
         },
         {
-          "name": "Commander Malarus",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081428804/85C88660A6344BDA309990BD1BCA5254EB26D6FE/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "faction": ["First Order"],
-              "rank": ["Heavy"]
+          "name": "Republic Commandos",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747569673/F45852AF875FCB41E9BB5B23FFACC1029A8E548C/",
+          "size": "small",
+          "type": "Clone Trooper",
+          "points": 100,
+          "speed": 2,
+          "upgrades": {
+            "Training": 1,
+            "Comms": 1,
+            "Gear": 1,
+            "Armament": 2,
+            "Grenades": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455182355861/149A0196C96C1D78830C56F479A27BF825E9C6AB/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455182206940/096195C231ECC170C0963163315EFADABC01D5D7/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455182228456/B086CF963F81B78DCBE9E0893013169CF6454817/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455182206940/096195C231ECC170C0963163315EFADABC01D5D7/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455182280894/C546CADEC6AD3A41EFFC07CCD86AAE1EFB325BC7/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455182206940/096195C231ECC170C0963163315EFADABC01D5D7/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1005935455182431253/81E98F267170F435E05AA7ED621A04F6476DC3B0/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1005935455182206940/096195C231ECC170C0963163315EFADABC01D5D7/"
             }
-          }
+          ]
+        }
+      ],
+      "Heavy": [
+        {
+          "name": "AT-AP",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747585288/91E17B9FFBE325EE7E46C3F18DF4E613EF60E6A3/",
+          "size": "epic",
+          "type": "Ground Vehicle",
+          "points": 165,
+          "speed": 1,
+          "upgrades": {
+            "Pilot": 1,
+            "Hardpoint": 2,
+            "Comms": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756243525814/22DBD5FF8C4A887FF7DBFD977F190A7192C1D4B7/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756243525957/D334BA41B51D1DD235E2A5ED14F1EEACC9CD9EEF/"
+            }
+          ]
         },
         {
-          "name": "Nightsister Rider",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742458550/DA4B94232A6C585F9052738F990C70095E579256/",
+          "name": "LA-AT/I Gunship",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747615420/DD22D969B4D59595325925BD059DBF83F295F406/",
+          "size": "epic",
+          "type": "Repulsor Vehicle",
+          "points": 190,
+          "speed": 2,
+          "upgrades": {
+            "Pilot": 1,
+            "Hardpoint": 2,
+            "Ordnance": 1,
+            "Comms": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028454854943442054/64C9040DF30E7980A9E9F22FD7A56D5C84052167/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028454854943501740/E509E21CEB3321071E6F56B006F24C1D919B6F3B/"
+            }
+          ]
+        }
+      ]
+    },
+    "Resistance": {
+      "Commander": [
+        {
+          "name": "Finn",
+          "title": "First Order Defector",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752987105/4E0911D06D60474448E5EF5CFB340A7CA015C62D/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 110,
+          "speed": 2,
+          "upgrades": {
+            "Command": 1,
+            "Comms": 1,
+            "Gear": 1,
+            "Armament": 1,
+            "Counterpart": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770985763040/56F6F436F140391F26FB16960E2D6CD57FB14B71/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770985763307/FB7EDB7C8D248BF873C1405012C99CC32C9FEBAA/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "Big Deal",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752986056/CDC39A7E6D1022EC938F8F8A599EE7513650A574/",
+              "pip": 1
+            },
+            {
+              "name": "Come Get It",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752985107/DEB9D333DCC6E48F6855736D9E28A806719CE0E0/",
+              "pip": 2
+            },
+            {
+              "name": "I am with the Resistance",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752983093/53828D3EB704897C38DD09ECE6E0083DEB51146F/",
+              "pip": 3
+            }
+          ]
+        },
+        {
+          "name": "Poe Dameron",
+          "title": "Reckless Flyboy",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1022821770975464596/6EDA2DD86069BD1A0B3B2690B5397BC3FC01C228/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 100,
+          "speed": 2,
+          "upgrades": {
+            "Command": 1,
+            "Training": 1,
+            "Comms": 1,
+            "Gear": 1,
+            "Counterpart": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770984969371/73F6B8B3D8D4C55321CBCE3D8B75E5A7E5B25A94/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770984969603/8925F3262BB3FE97EC31D45DAE964400AE8A528F/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "We are the Spark",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1022821770975465215/89BB4AAD301785869E3A3C44CFB2745F511C8FE8/",
+              "pip": 1
+            },
+            {
+              "name": "Dead Heros",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1022821770975470651/B99A6006460BC0A2B198BBE3CE6BA403E3B1AB7A/",
+              "pip": 2
+            },
+            {
+              "name": "I Need a Pilot",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1022821770975471416/4ED3DFBB9E55FC22BA5F9A7E2B1D5B5229CE9C79/",
+              "pip": 3
+            }
+          ]
+        }
+      ],
+      "Operative": [
+        {
+          "name": "Rey",
+          "title": "Force Prodigy",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1022821770981203693/E3069DE71ED495326B84393B00F82E021420E753/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 125,
+          "speed": 2,
+          "upgrades": {
+            "Force": 1,
+            "Training": 1,
+            "Gear": 1,
+            "Armament": 1,
+            "Counterpart": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804925013057/F62D7D1921B435B28DDB56BD129BB39D1FB2C2FD/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324712401180346/5DD131A4135CF4C90A2D42D264F3FAB332155AB3/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "The Force Awakens",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1027324582151432669/7A2F43C29C19033B13852F63165D64A18D766544/",
+              "pip": 1
+            },
+            {
+              "name": "You Came back For Me",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1027324582151438024/BC43E151F85D06C17D0602947648984AA604E08F/",
+              "pip": 2
+            },
+            {
+              "name": "I Think I Can Handle Myself",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752998047/158965EE8DD63D9BD1A1F43BC7E51993538FC7E3/",
+              "pip": 3
+            }
+          ]
+        },
+        {
+          "name": "BB-8",
+          "title": "A Clever Little Droid",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1022824296871784130/E6058352DDF98D626EC56C53D97FBD31675E6898/",
+          "size": "small",
+          "type": "Droid Trooper",
+          "points": 45,
+          "speed": 2,
+          "upgrades": {
+            "Comms": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068157620585/9E7930221D8CD87F6338B9D4B58F4D3F824D08C0/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068157620780/493748852320ED988465533F8BC49FEA2672A9E8/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "Happy Beeps",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157653789/55772CA9D24676C0367BBAC6F831F03E0340F4EB/",
+              "pip": 1
+            },
+            {
+              "name": "Keep an eye on this kid",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157657298/77DAA5AFFEDD096EC568637DC3777E4696DE7D9D/",
+              "pip": 1
+            },
+            {
+              "name": "Engineering Expertise",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157658855/8B72242F4B9650FC1DBE591F7FE32D574808DAA1/",
+              "pip": 2
+            },
+            {
+              "name": "Never Underestimate a Droid",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157658236/1E07FA41D1449A2991220D2733B1F51D2565C4F7/",
+              "pip": 2
+            },
+            {
+              "name": "A Mutual Understanding",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1022824296871786871/AF5D00FAB14B8C70B843DFB4BD18D6EFC9F8ADD1/",
+              "pip": 2
+            },
+            {
+              "name": "Impromptu Imposter",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157655413/18B1636E2055305E94F285684921B2FDAA773450/",
+              "pip": 2
+            },
+            {
+              "name": "Good Things Come Back",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1022824296871785786/4EA05DE445200A52D753CD1A023028FE0B5F0A0D/",
+              "pip": 3
+            },
+            {
+              "name": "Deus Ex Machina",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157655832/49730DEF4AAD9BF0481CA578387F21D074A104D8/",
+              "pip": 3
+            }
+          ]
+        },
+        {
+          "name": "R2-D2",
+          "title": "Hero Of A Thousand Devices",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1022821770981205050/4D72685715DF8671198FA4BC591397371BC96665/",
+          "size": "small",
+          "type": "Droid Trooper",
+          "points": 45,
+          "speed": 1,
+          "upgrades": {
+            "Counterpart": 1,
+            "Comms": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/776232727456806966/EFBA4A71BFE748A2868C14B82DA3A7B0D559874A/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/777357228032306302/F5CA6FC54A8625E261F123D73792DE36D74E1686/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "Blast Off!",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564037063/A7AE3401CB3A51A58A8682BBCD8D6F6C104804AF/",
+              "pip": 1
+            },
+            {
+              "name": "Impromptu Immolation",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564035209/4C4829AE9D1B01B14F2D4FDE2C6D3935D8055954/",
+              "pip": 2
+            },
+            {
+              "name": "Smoke Screen",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564033033/7FC32081CE8646476E7B0C475F452AA629BA7713/",
+              "pip": 3
+            }
+          ]
+        }
+      ],
+      "Corps": [
+        {
+          "name": "Resistance Troopers",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1027324582151747849/0DC6B237D0C8CC16BE47236FF1B5268D403945C1/",
+          "size": "small",
+          "type": "Trooper",
           "points": 30,
-          "restrictions": {
-            "include": {
-              "unit": ["Rancor"]
+          "speed": 2,
+          "upgrades": {
+            "Heavy Weapon": 1,
+            "Personnel": 1,
+            "Gear": 1,
+            "Grenades": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804924627970/AE0B4993C8FA598D93829CF55F0E0A6415ACBBFB/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324582151454188/1EC7453DFA3870ADCA468AD5A9257330B58CF8F4/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324582151456311/376D681EDE4D18D355A359F47C49551B6AC5EBAA/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324582151456617/9EBFAB9697DE7A1435FF501C6F39BBCC3B244BCB/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324582151464621/CEB3271C1C9E43C30C41206E919ACA9AFFB45247/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324582151464893/EF78574A7DFC9EBC7EC9FB76B27BA5F846B8F97D/"
             }
-          }
+          ]
         },
         {
-          "name": "Oddball",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747618963/6FE86EFBC23C8FDFDB87FBE066C60CBD32FF1DFE/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "unit": ["LA-AT/I Gunship"]
+          "name": "Resistance Trench Fighters",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1017194020628449858/1DC8646D5B2D0F5ABF7828732E6DE923F301DE46/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 39,
+          "speed": 2,
+          "upgrades": {
+            "Heavy Weapon": 1,
+            "Personnel": 1,
+            "Training": 1,
+            "Gear": 1,
+            "Grenades": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248440350/60BC7FB4B3F6B327003DAB9B924C5EC98FA67C4B/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248444916/D62AC2DD70775BA5025900AC76975C4AB45A54CC/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248441473/F330E21469E4FF560B9E8892E784C14373697F16/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248440578/125E76600442E01E3AD18725563EA1BE4D63BEFA/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248442051/472D72BABB02CCA9F99639F83E21A9D3AF83BB14/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248440578/125E76600442E01E3AD18725563EA1BE4D63BEFA/"
             }
-          }
-        },
+          ]
+        }
+      ],
+      "Special Forces": [
         {
-          "name": "Pirate Hotshot",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556639096066/A06D6ABDA4E9B1B1F2A63187D6B24F13D5D283A5/",
-          "points": 15,
-          "restrictions": {
-            "include": {
-              "unit": ["Canderous Class Assault Tank"]
+          "name": "Salvaged B2 Battle droids",
+          "title": "Defenders of the Colossus",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1021698068155819425/F5A156E66B986DA76D65B649D689496C6A4BB79A/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 64,
+          "speed": 2,
+          "upgrades": {
+            "Heavy Weapon": 1,
+            "Comms": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/775105953849586118/94F967F21EA7E390A200C4BDA5581D07DBB37AC2/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/775105953849585789/91A639AB9F57BE393683DA53212E395886307C52/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/775105953849586430/E5941CF7A3631E6D4A28832AE489A4340C96B0B9/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/775105953849585789/91A639AB9F57BE393683DA53212E395886307C52/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/775105953849586226/9326AD8D3EC80CC53F4BF2D156014978DCD715D9/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/775105953849585789/91A639AB9F57BE393683DA53212E395886307C52/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/775105953849586324/B5D59E535AFA2BF99FCA3C584E28FA500ADB89BD/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/775105953849585789/91A639AB9F57BE393683DA53212E395886307C52/"
             }
-          }
-        },
+          ]
+        }
+      ],
+      "Support": [
         {
-          "name": "Pirate Speed Freak",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556639095451/373D5F83FB4E8F4D3223A3CAD3E6A8E661FAAC2F/",
-          "points": 8,
-          "restrictions": {
-            "include": {
-              "unit": ["Canderous Class Assault Tank"]
+          "name": "Orbak Riders",
+          "heavyWeaponTeam": true,
+          "image": "http://cloud-3.steamusercontent.com/ugc/1022821770986742661/33B78DBDC2B4A466B810D5299DB14745FAFB1E68/",
+          "size": "medium",
+          "type": "Creature Trooper",
+          "points": 45,
+          "speed": 2,
+          "upgrades": {
+            "Heavy Weapon": 1,
+            "Comms": 1,
+            "Gear": 2
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770976478153/4E00BD588837F87DDA2828DC092CEEE3BEDCC7A3/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770976472996/354C4EE85A60585BD0FB817AFEE21D00E93799BA/"
             }
-          }
+          ]
         },
         {
           "name": "Rose Tico",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1021697620252778721/621B535E20B29F253B38AD3548C986EE0DB42CCF/",
-          "points": 8,
-          "restrictions": {
-            "include": {
-              "faction": ["Resistance"]
+          "title": "Skilled Technician",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1021697620253184171/055BD7F8C30E5D043104316A572B1846227F6DC5/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 50,
+          "speed": 2,
+          "upgrades": {
+            "Comms": 1,
+            "Gear": 2,
+            "Counterpart": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697601906861807/C7CB31D9AFAFF6C7B2633663A2A33D939F4E8205/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697601906862116/99E8BDA93C81AD3875DFC214AA5E39DC4F5477A5/"
             }
-          }
-        },
-        {
-          "name": "Veteran Gunner",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747586823/256792792FFE8D876759E9A894F76F489BFDE968/",
-          "points": 6,
-          "restrictions": {
-            "include": {
-              "unit": ["AT-AP"]
+          ],
+          "commands": [
+            {
+              "name": "Saving What We Love",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1021697620253191671/458068FD2D398FA6C7540EEFF383BD8E39509350/",
+              "pip": 3
             }
-          }
-        },
-        {
-          "name": "Veteran Mechanic",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638970650/AE724920A75FF2F1D840AC3DE707166D67EA0323/",
-          "points": 8,
-          "restrictions": {
-            "include": {
-              "unit": ["Missile Attack Launcher"]
-            }
-          }
-        },
-        {
-          "name": "Veteran Tank Pilot",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556639094597/6678DD776757AAFAFA216FB7538DA7BC35147757/",
-          "points": 5,
-          "restrictions": {
-            "include": {
-              "unit": ["Canderous Class Assault Tank"]
-            }
-          }
-        },
-        {
-          "name": "Warthog",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747618630/E00C8B7A4F81CCD6F2A12747031B7D62D05857E3/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "unit": ["LA-AT/I Gunship"]
-            }
-          }
+          ]
         }
       ],
-      "Relic": [
+      "Heavy": [
         {
-          "name": "Sith Holocron",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747372001/0447B19DFCA692F5AC2D176A7C6C7A1CB53A156B/",
-          "points": 15
-        }
-      ],
-      "Programming": [
-        {
-          "name": "Blitz Programming",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412069009833/BCC52828E3F19620E57D60244623D8A3E5C94135/",
-          "points": 12,
-          "restrictions": {
-            "include": {
-              "unit": ["SD-4K Assassin Droid"]
+          "name": "V-4X-D Ski Speeder",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1021697620252781965/A29532E1391479BD4424DEE3CD7130CC5927AB08/",
+          "size": "epic",
+          "type": "Repulsor Vehicle",
+          "points": 140,
+          "speed": 3,
+          "upgrades": {
+            "Pilot": 1,
+            "Hardpoint": 1,
+            "Comms": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804931072163/80F5B756EF0C02455B5C31CD1A608DD51B9108BD/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804925084213/855D3C37D204F44B1840665B50CCCB73A7CD62D2/"
             }
-          }
+          ]
         },
         {
-          "name": "Stealth Programming",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412069009272/8CD2CDD81193F051285BF5B44FD7B45AE80FC4B6/",
-          "points": 18,
-          "restrictions": {
-            "include": {
-              "unit": ["SD-4K Assassin Droid"]
+          "name": "V-232 Turret",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157670378/DB2D6E46CD982AE3C38EA63F93939CDC2EECA984/",
+          "size": "huge",
+          "type": "Ground Vehicle",
+          "points": 100,
+          "speed": 0,
+          "upgrades": {
+            "Comms": 1,
+            "Generator": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068157631207/B54652720E993614D7AD481BD4A1B8236561DCAA/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756247150301/5C9F0E6F01394012B925C60CC4D8548E66B05427/"
             }
-          }
-        }
-      ],
-      "Training": [
-        {
-          "name": "Advanced Assault Training",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640415256/3E0DA25CB2B44F7093E46DADA1965C0DBD3C703A/",
-          "points": 5,
-          "restrictions": {
-            "include": {
-              "type": ["Mandalorian Trooper"]
-            }
-          }
-        },
-        {
-          "name": "Blend In",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735182379/DD072454059CA2BB5CB206848D0BCBF656F494F9/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "faction": ["Scum"],
-              "rank": ["Commander", "Operative", "Special Forces"]
-            }
-          }
-        },
-        {
-          "name": "Brutality",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741408425/6FED2B70FD2FCEFC6A1A8249888003F3C9798118/",
-          "points": 10
-        },
-        {
-          "name": "Conditioning",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081410188/2D437F005CAE9C5E11B19E2A59D5CB24D58CDB28/",
-          "points": 5,
-          "restrictions": {
-            "include": {
-              "faction": ["First Order"],
-              "rank": ["Corps", "Special Forces"]
-            }
-          }
-        },
-        {
-          "name": "Conditioning ",
-          "displayName": "Conditioning",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081410188/2D437F005CAE9C5E11B19E2A59D5CB24D58CDB28/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "faction": ["First Order"],
-              "rank": ["Commander", "Operative", "Support", "Heavy"]
-            }
-          }
-        },
-        {
-          "name": "Disarming Slash",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747373016/011CE3497BCC2229C114CDBF69464D3FB6E16B26/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "slot": ["Force"]
-            }
-          }
-        },
-        {
-          "name": "Hasty Exit",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747373759/AF9520B70176F54DCB2B098735D1D3F468E9F442/",
-          "points": 3
-        },
-        {
-          "name": "Faithful Companion",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735164302/4C5E96A3397E6BD2F8C07A61AA9B25FDC0D8C031/",
-          "points": 8,
-          "restrictions": {
-            "include": {
-              "unit": ["Beast Master", "Silri"]
-            }
-          }
-        },
-        {
-          "name": "Geonosian Brain Worms",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746957609/4564866DD4465ADC1224AC20C8A82A2895D19FE9/",
-          "points": 0,
-          "restrictions": {
-            "include": {
-              "unit": ["Geonosian Warriors"]
-            }
-          }
-        },
-        {
-          "name": "Rising Phoenix Training",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640409422/F8AF40A8E8F4C87CA364A0ADADA7281F20F8F0D7/",
-          "points": 10,
-          "restrictions": {
-            "include": {
-              "type": ["Mandalorian Trooper"]
-            }
-          }
+          ]
         }
       ]
     },
-    "commands": {
-      "Sith Empire": [
+    "Revans Sith Empire": {
+      "Commander": [
         {
-          "name": "Oppressive Tactics",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278110637/7EF1FEF7DCEB65C84A89E72110F107932A7CE783/",
-          "pip": 1
+          "name": "Darth Revan",
+          "title": "Fallen Lord",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281811934/A5A06CC61DE1B518F307931E848ED0F2F84DBE3C/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 220,
+          "speed": 2,
+          "upgrades": {
+            "Force": 3
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933832570/34E443C62233F9BFAB5A1A56848C92AF12D16DB0/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933823285/EE9DA185779FAC54191A9DC0353E57D542CF6EE9/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "Slayer of Mandalore",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281812320/441136636E20A3C920D22041163506AC74BD9E34/",
+              "pip": 1
+            },
+            {
+              "name": "I am the Dark Lord of the Sith",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281812673/A864BC3FB16C88EF914102FA82EBE360D05B7016/",
+              "pip": 2
+            },
+            {
+              "name": "The Fallen Lords",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281813019/D00A57B0F11280E97F8A27269F9F39A031001D38/",
+              "pip": 3
+            }
+          ]
         },
         {
-          "name": "Legacy of Vaiken",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278110292/436DDD7EE789790446C0C4DB7F79A24843F7273A/",
-          "pip": 3
+          "name": "Darth Malak",
+          "title": "Treacherous Apprentice",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281873194/CE73E7B8BE4C4C155231F3BBEE4F857395F1C174/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 195,
+          "speed": 2,
+          "upgrades": {
+            "Force": 2
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933880695/1D163F620C1BF4639F889CE39C1DCB6E8ED159E9/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933876696/ED5A556257FEA5E3EA9AD18215604CB599E132C2/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "This is but a Taste of the Dark Side",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281873643/108B3E63FB5AAE3E70915C74CB0CEADB660F1899/",
+              "pip": 1
+            },
+            {
+              "name": "You Will Forever Stand Alone",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281874073/CC8FEB5E5D0934D8C0FA1A3E8752A656D6EE849E/",
+              "pip": 2
+            },
+            {
+              "name": "Wipe this planet from the face of the galaxy",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281874384/99D8B33D2B2422AFD4D24953C07B352DD585F493/",
+              "pip": 3
+            }
+          ]
+        }
+      ],
+      "Operative": [
+        {
+          "name": "Calo Nord",
+          "title": "Nefarious Bounty Hunter",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412068777865/AD645A6CA22119B08159D249FF1FAA79A9ABF568/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 90,
+          "speed": 2,
+          "upgrades": {
+            "Training": 2,
+            "Gear": 1,
+            "Grenades": 1,
+            "Armament": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817412068837885/8382AD2EDA22D520AF2FFAF89E3D4CF044EB2E71/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817412068838066/B01C1691D062FFBDAF364DFA926330D8F0C107C5/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "Updated Contract",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1862817412068780726/450A5AD57585FD96262A630B2C7CC574CA293F41/",
+              "pip": 1
+            },
+            {
+              "name": "I am hard to kill",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1862817412068781019/5958B05B2457B2A3F1BFDA10269F84EDBA1DC7B4/",
+              "pip": 2
+            },
+            {
+              "name": "One. Two. Three.",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1862817412068781429/29B9885FB2E1E129E6F684472C7281B09617EB46/",
+              "pip": 3
+            }
+          ]
+        }
+      ],
+      "Corps": [
+        {
+          "name": "Sith Troopers",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281907874/694CCAFD2FB6C6ADA01DAB52DCEFB6CE4DBAB1D0/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 44,
+          "speed": 2,
+          "upgrades": {
+            "Heavy Weapon": 1,
+            "Personnel": 1,
+            "Gear": 1,
+            "Grenades": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933591216/236BEBCCFA8E4701879F66DE28E7E61EB71696DA/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933675175/1561AB6D3E5FCD7952FC0B2A76BEF1B14D75D00D/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933538068/07579EBF0F9C9A7BD0DBC30EFE30BEEF1FB31D33/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933630508/AF5621F9AAF5556EADD9373D4C8F7DE5C3A6D95D/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
+            }
+          ]
         }
       ]
     },
-    "battlefield": {},
-    "objects": {}
-  }
+    "Scum": {
+      "Commander": [
+        {
+          "name": "Tyber Zann",
+          "title": "Cold, Methodical, and Ruthless",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735070640/74612E44D0AF4F505937EE2E0DAF21C08EB4E15B/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 140,
+          "speed": 2,
+          "upgrades": {
+            "Command": 1,
+            "Training": 1,
+            "Illicit": 1,
+            "Gear": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365775807/337D2A5009DD4A91F0A469B418D4C77867FDF52D/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365776115/8606DE28865E723D2343D17F890A99959E25AC8F/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "Orbital Bombardment",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735071380/B7CEA3F14638418D63BEFF3F7A611F5078D31667/",
+              "pip": 1
+            },
+            {
+              "name": "Corruption is My Weapon",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735071871/7524B10AD4DB25DAA1E5F5F0275A58DE9C3EC666/",
+              "pip": 2
+            },
+            {
+              "name": "Everyone Has a Price",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735072378/3A407CC85B615E03763D5F22E7116CA3FB217F0B/",
+              "pip": 3
+            }
+          ]
+        },
+        {
+          "name": "Urai Fen",
+          "title": "Loyal Lieutenant",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735039360/1B0C02842ADDAA687687E529BE8B33983CAD933F/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 90,
+          "speed": 2,
+          "upgrades": {
+            "Training": 2,
+            "Illicit": 1,
+            "Gear": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984835649865/8FC3F2E4E22555D72BDF283AD0E686537F33A043/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984835650100/057E08B03AAE7CA89B585D8916BB25023B63341A/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "Strike and Fade",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735040340/32D15FA78098AB05AD6D98B51631935EC6DEC3C3/",
+              "pip": 1
+            },
+            {
+              "name": "The Consortium Commands It",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735041426/F309B5F10C9F44B3E9FE50A42FAD541185DEE9A5/",
+              "pip": 2
+            },
+            {
+              "name": "No Mission is too Dangerous",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735047596/1516182BE8ED3D0635F56F830C4FB85F869C477C/",
+              "pip": 3
+            }
+          ]
+        },
+        {
+          "name": "Defiler",
+          "title": "Under Cover Agent",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735208736/794BBDD282201AA4D82C0B728D90073E6CAF423C/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 90,
+          "speed": 2,
+          "upgrades": {
+            "Training": 1,
+            "Gear": 1,
+            "Armament": 1,
+            "Illicit": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515362210843/CDD5E72C8CE5B42739060E6ADC81DC64751294F0/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515362211007/246011C13B53F2A881968B8996802F50B33D075F/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "I Like Explosions",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735209433/1B7DC25C849E9B7D2657E40E71FF198B8588381F/",
+              "pip": 1
+            },
+            {
+              "name": "Nothing Stops Me",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735210006/8EAEC185C0C43B5D6099ED763E9B3D4FC5C493A5/",
+              "pip": 2
+            },
+            {
+              "name": "I Stand In the Shadows",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735210753/1BF727CB55BFAB8151A9F9A368C91C6B76248636/",
+              "pip": 3
+            }
+          ]
+        },
+        {
+          "name": "Pre Vizsla",
+          "title": "Defender of Tradition",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640671157/50ED9FE9885FBF3530E3BF5D7E2ECA85E331972F/",
+          "size": "small",
+          "type": "Mandalorian Trooper",
+          "points": 165,
+          "speed": 3,
+          "upgrades": {
+            "Command": 1,
+            "Training": 2,
+            "Illicit": 1,
+            "Gear": 1,
+            "Armament": 2
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886396178/07FB37CA0A11552BEF96C3DCA10AF232C65AF7B6/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886396372/35E5047903DC30F882B40719809ECF90DBC65A5A/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "Blade Launcher",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640671650/36CC81AF419D113B28FC5AB7CF6B3210085DFB45/",
+              "pip": 1
+            },
+            {
+              "name": "Warlord of Mandalore",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640672041/2F91858F91AB3648DDEF429A5C1C584D129634C1/",
+              "pip": 2
+            },
+            {
+              "name": "Rise of the Death Watch",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640672498/BED2FE1183721CCB1A1B623A6C4DED69383DA739/",
+              "pip": 3
+            }
+          ]
+        },
+        {
+          "name": "Jabba The Hutt",
+          "title": "Vile Gangster",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741311873/1C5E99B44B0F2BAB89FF0F00315D88DCAC991BBE/",
+          "size": "large",
+          "type": "Trooper",
+          "points": 180,
+          "speed": 1,
+          "upgrades": {
+            "Command": 2,
+            "Counterpart": 1,
+            "Illicit": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984838965716/328A3D3A0AFDA83FC55E8DDCAF62845FFF80CF64/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984838965864/2C27448D99B31E0730B60E10427A6009A6AEF1C7/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "Appetite for Violence",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741312832/9DD7CEC7F0A4BBEC81E368726BA5A07E4F81AD9D/",
+              "pip": 1
+            },
+            {
+              "name": "Sinister Belly Laugh",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741313391/27122DF6EB3315976464D7B481537EE5E1E58D94/",
+              "pip": 2
+            },
+            {
+              "name": "Big Shot Gangster",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741313883/86E8818123FD0C01DA7890E271BE897212D4733D/",
+              "pip": 3
+            }
+          ]
+        },
+        {
+          "name": "Hondo Ohnaka",
+          "title": "Self-Serving Pirate",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738473397/8A62072BB1AFA3D4BF14CC3BA56EB1C2F1614F46/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 90,
+          "speed": 2,
+          "upgrades": {
+            "Command": 1,
+            "Illicit": 3,
+            "Armament": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697601906780896/650CF3405CD4106C46B9CB7F0B8C3884B62CD278/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697601906781011/E61558EE4DCDF12D33E98940751D940381181C93/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "No Longer Profitable!",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738477182/571BC50F3C1ABB05DAF75F3BE004DCEBD4C27DD7/",
+              "pip": 1
+            },
+            {
+              "name": "Drive a Big Tank",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738476702/E723D8E97412E2B9E422741F4E2225D5B8A146C8/",
+              "pip": 2
+            },
+            {
+              "name": "Insolence! We are Pirates!",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738475852/69D3EE2DF1CDA15E4BDC49F143CE2DD621B8553F/",
+              "pip": 3
+            }
+          ]
+        }
+      ],
+      "Operative": [
+        {
+          "name": "Silri",
+          "title": "Dark Witch",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735151492/82278C71E894B0710E02376909241ECAAD41F8C7/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 150,
+          "speed": 2,
+          "upgrades": {
+            "Force": 1,
+            "Training": 2,
+            "Illicit": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984835654759/B33E7C3B1D34E7DDAC7B617DC466F12FF66774E1/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984835654931/3ACEDEC6F99A311A245C7492883DAB9720D05348/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "I Shall Rip Out Their Souls",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735165967/E52C14F2A96A0DDA785B12C9400F47E9E5E2F4A7/",
+              "pip": 1
+            },
+            {
+              "name": "Come Closer",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735165400/6E97DF5AC3BF3172E316DD409240AA04BD4C6DE4/",
+              "pip": 2
+            },
+            {
+              "name": "They Will Know Fear",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735164916/B6CDD990B416AE4B7897AB3A27E35ACD4A46DE07/",
+              "pip": 3
+            }
+          ]
+        },
+        {
+          "name": "Bo-Katan Kryze",
+          "title": "Death Watch Lieutenant",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640560685/8771A2D7895F003917A4CD9D170E7D5FBAA81D65/",
+          "size": "small",
+          "type": "Mandalorian Trooper",
+          "points": 120,
+          "speed": 3,
+          "upgrades": {
+            "Training": 2,
+            "Gear": 1,
+            "Armament": 2
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886421665/441B37D17213CA1B82174A8988ED23AA2D59336E/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886421832/BBE3592A7496E444E116271913178A8ED41F5323/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "Poison Dart",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640561281/E6C9BE0EB9F4357B31FB1459E8615D85BBE6F660/",
+              "pip": 1
+            },
+            {
+              "name": "Fierce and Deadly",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640561707/6E91E487B7F9AD4225A336081B4AB58F4AAB3CD2/",
+              "pip": 2
+            },
+            {
+              "name": "Memorable and Funny Quote",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640562097/E3FFDCB0E1AC2EB8E690C90C0599AA093788759C/",
+              "pip": 3
+            }
+          ]
+        },
+        {
+          "name": "Dengar",
+          "title": "Payback",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743206950/10A169A5029EDFC4ACA82E73B8BA7D4777BB499D/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 105,
+          "speed": 2,
+          "upgrades": {
+            "Training": 1,
+            "Illicit": 1,
+            "Gear": 2
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982050300/7F58F09A4EBE2B1D4036CA35ECD771FAC087027F/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982050497/14DBD099731E973681F538C811E89F52971C6258/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "Ello Darlin",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743207736/AC879456E5C89349EDE04DC810B7437A49F9017B/",
+              "pip": 1
+            },
+            {
+              "name": "Thats Not a Knife",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743208077/F604A72BAD8ADED41170B6134687C8792E272C0B/",
+              "pip": 2
+            },
+            {
+              "name": "Credits are Calling my Name",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743208459/015271D4636D4659598040A7A33AABA2A7373863/",
+              "pip": 3
+            }
+          ]
+        },
+        {
+          "name": "Greedo",
+          "title": "Mercenary of Misfortune",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741745161/DE21A067535ADD00F083F96CE00AEF706CDBC1B3/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 60,
+          "speed": 2,
+          "upgrades": {
+            "Training": 2,
+            "Gear": 1,
+            "Grenades": 1,
+            "Flaw": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697128192156760/0799D47F8ABA442104B92441C2EE558246DD447B/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697128192156907/44D809B717035663BCC53BBF8B6C34E47F27D953/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "Maclunky!",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741745870/4D9A87A50635EFDD25A2E01B381D20FC3B23D0E7/",
+              "pip": 1
+            },
+            {
+              "name": "Oonta Goota?",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741746363/52B7999E4C27DFA029632DF034C633BD94B6ECE3/",
+              "pip": 2
+            },
+            {
+              "name": "E Chu Ta",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741747117/E0DD4D0E9489424A42EF020B57AFCB2E34CC3935/",
+              "pip": 3
+            }
+          ],
+          "required": ["I'll Bet You Have"]
+        },
+        {
+          "name": "IG-88",
+          "title": "Calculating Assassin",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743156483/4AB94765581EEA7C01F1C931649279C0820A18D6/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 130,
+          "speed": 1,
+          "upgrades": {
+            "Training": 1,
+            "Illicit": 1,
+            "Gear": 2,
+            "Grenades": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982048942/6855349E653C6F4E0433AF56E1554F75F307CBF3/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982049139/F1EB5D96934D784828CAD32E88CFD581446B6041/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "Toxic Dioxis Despenser",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743157480/AC5FF98814A9D017737A5C5FEDE3FD7E401A7D4D/",
+              "pip": 1
+            },
+            {
+              "name": "Defensive Programming",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743157867/DBE4FB014B259FD7B2E4C6774D766C557735F320/",
+              "pip": 2
+            },
+            {
+              "name": "I Destroy, Therefore I Endure",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743158259/1693B7E0EECA04393914E8566B892A1E0052039F/",
+              "pip": 3
+            }
+          ]
+        }
+      ],
+      "Corps": [
+        {
+          "name": "Grenadier Squad",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735128053/8071373F43B26B004A85BB1423AE10D8BA9FA2D9/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 33,
+          "speed": 2,
+          "upgrades": {
+            "Personnel": 1,
+            "Illicit": 1,
+            "Comms": 1,
+            "Gear": 1,
+            "Grenades": 2
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365822891/9245AC0020E31C369AE4129B35D0BA467A01F2B4/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365823446/E94BC334A0B2F95CFB75FEDC3A0FEDF2FFD5A970/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365824294/5F43B720E0198A078E25BA472E7DDBCA8F51CBEC/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365824481/27693FC709ADF50440623C6347A11151608D5E2F/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365824294/5F43B720E0198A078E25BA472E7DDBCA8F51CBEC/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365824481/27693FC709ADF50440623C6347A11151608D5E2F/"
+            }
+          ]
+        },
+        {
+          "name": "Hutt Cartel Troopers",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741193364/B2A9024FE737F3E6CAC757C062FAE63B180020F4/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 40,
+          "speed": 2,
+          "upgrades": {
+            "Heavy Weapon": 1,
+            "Personnel": 1,
+            "Illicit": 1,
+            "Grenades": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132327065/C97ECB0137975A84387D1450B76E656DD3A34CC6/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132327244/97AF50B5FA4E76262E8F7A6BBCBF465FD8D13210/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132328895/00FFC141D583FDE6EB27DCEF374C6EA79E4BC8DC/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132233662/46758BE4190670991AEEB84884D2C0926704577E/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132328408/9323E551FA703709CF34056F60EB7B9808DBBC6F/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132233662/46758BE4190670991AEEB84884D2C0926704577E/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132327863/05220805319D5F586AF2C45288D1880BBCF5B1D4/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132233662/46758BE4190670991AEEB84884D2C0926704577E/"
+            }
+          ]
+        },
+        {
+          "name": "Weequay Pirates",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738627390/5CC1A1E67FA0FB421324802CFFF43AEBF54CC512/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 44,
+          "speed": 2,
+          "upgrades": {
+            "Heavy Weapon": 1,
+            "Personnel": 1,
+            "Illicit": 2,
+            "Grenades": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436112170/7B9627FA526DBD9262F7B82066DF7F5BDF1E5B76/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112951/28554A829163EDA67DDE90D1CF137C093FF8A9AC/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436113638/F31ACA002873CE6039E4A0438F29423E59383C71/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112951/28554A829163EDA67DDE90D1CF137C093FF8A9AC/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436114564/440659EBF9A36F6A6E2C7E4C7AE6B2C6A6DBFABD/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112951/28554A829163EDA67DDE90D1CF137C093FF8A9AC/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436115021/ECE24BA2DD41BC0C0EA4638CF553ABDE1969DC4C/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112951/28554A829163EDA67DDE90D1CF137C093FF8A9AC/"
+            }
+          ]
+        },
+        {
+          "name": "Hired Guns",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741999970/AEA964040C9423D7CB3BBFE8E6127BFF6D9B4B16/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 36,
+          "speed": 2,
+          "upgrades": {
+            "Heavy Weapon": 1,
+            "Personnel": 1,
+            "Illicit": 1,
+            "Armament": 1,
+            "Grenades": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138162716/6618383926180465FB60EC9786E27A680C85BFC9/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138162922/C28DD0F623633DABFC9748FFE85A4AFA8D6010DE/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138162195/FB52D7D4C013778E22F5FB391B8506E10F7C8126/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138163807/FF1D50425F0F472D96EA277636EC08E98F969A4F/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138164240/210C9B6E98EBF1F2648A855CDFFEA405E75AFB82/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138164385/1460EF2F670C31A209FB8FD428800D727F310A9F/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138164936/04CD0F0BF910DC7E078F67D680411F0B948714C2/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138165334/AEF9F43EDE77B3E981B4EE3CFA26869D27B45CE0/"
+            }
+          ]
+        }
+      ],
+      "Special Forces": [
+        {
+          "name": "Mercenary Assault Squad",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735112958/CA567516B908134719A9891C1855E81C88E39E7E/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 72,
+          "speed": 1,
+          "upgrades": {
+            "Heavy Weapon": 1,
+            "Training": 1,
+            "Illicit": 1,
+            "Gear": 1,
+            "Armament": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365876771/3C9BD90A0E8E6BA277A1133D1AF61B2D44C2DEB0/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365877132/5DEAE7FFFF586E0ACBFD5BB29AF4869E6D675044/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365880281/45B6B327A692DBFDE6D5E5F642EB7FEBBC2A0A4F/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365878394/8AD2A611C51D78184D8E4204A720C59EEC2C7755/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365879761/026D7FD22C9074A12068AE05CE293EBB833FC70E/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365878394/8AD2A611C51D78184D8E4204A720C59EEC2C7755/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365879295/EC66EBB1550D6D61DAC1AC96CAE92A0273B06A45/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365878394/8AD2A611C51D78184D8E4204A720C59EEC2C7755/"
+            }
+          ]
+        },
+        {
+          "name": "Infiltrators",
+          "title": "Strike Team",
+          "heavyWeaponTeam": true,
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638837280/E9F99045D6B7FA98055D860B700FB5402373070B/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 22,
+          "speed": 2,
+          "upgrades": {
+            "Heavy Weapon": 1,
+            "Training": 1,
+            "Illicit": 1,
+            "Comms": 1,
+            "Gear": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068156464007/651A73813208989A1D36777648388ABBF2F11376/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068156464181/1FABB24F11BA883FEB5A7CB16CB7EAE86CB50402/"
+            }
+          ]
+        },
+        {
+          "name": "Death Watch Fireteam",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736281138/4153C964147552CEAC2E3E23A51ED5358BC5C424/",
+          "size": "small",
+          "type": "Mandalorian Trooper",
+          "points": 54,
+          "speed": 3,
+          "upgrades": {
+            "Heavy Weapon": 1,
+            "Training": 1,
+            "Illicit": 1,
+            "Comms": 1,
+            "Gear": 1,
+            "Armament": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886427483/34A3605CA2B2D8280D40991583D41D7D1B3F0E31/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886427771/60D6CA1D97D822A2222E4FAF614931265B7B0AF2/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886435784/9A83A99579A78DF53A23E3FFB79C07798E4F3C5C/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886427771/60D6CA1D97D822A2222E4FAF614931265B7B0AF2/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886429750/5D62ADB1200B1AD16A0349AF87E757F40E720115/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886427771/60D6CA1D97D822A2222E4FAF614931265B7B0AF2/"
+            }
+          ]
+        },
+        {
+          "name": "Nite Owls",
+          "title": "Bo-Katan's Elite",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736216918/59B584E476FCEAE304E4E3152B4BF12843AE9214/",
+          "size": "small",
+          "type": "Mandalorian Trooper",
+          "points": 60,
+          "speed": 3,
+          "upgrades": {
+            "Training": 1,
+            "Illicit": 1,
+            "Comms": 1,
+            "Gear": 1,
+            "Armament": 1,
+            "Grenades": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357880094/FFFBDA79DE3B6192926EFCDFC257708C2A360562/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515357880292/78883B5B08CCDC0B7BC4EF36D45DAB06E9057FEB/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357881561/B365369415AE0FB6A96E69817D76D9BAD1366038/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515357880292/78883B5B08CCDC0B7BC4EF36D45DAB06E9057FEB/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357880886/06542D3BD6F03DC43D9E675680F86F2964B210F9/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515357880292/78883B5B08CCDC0B7BC4EF36D45DAB06E9057FEB/"
+            }
+          ]
+        },
+        {
+          "name": "Gamorrean Gaurds",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741407333/B5A53DE0F8D6ECC08CCD913669E3AB7D846F9320/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 75,
+          "speed": 2,
+          "upgrades": {
+            "Heavy Weapon": 1,
+            "Training": 1,
+            "Illicit": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407431269414/974FE237CC3CE17AEC2C321DBB69DE340A0D962F/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407431269590/C7A08ECB6A962EC390A208C771B6A8AF513AE685/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407431271048/84FBE9C70610660263F4FE0424E1C02C401A945B/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407431270422/909F25E16D76BF99AE8122963CEE8BAD7ECFD15A/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407431270243/80653030A9E58BF9637ED105E4F63598082B2D9E/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407431270422/909F25E16D76BF99AE8122963CEE8BAD7ECFD15A/"
+            }
+          ]
+        },
+        {
+          "name": "Beast Master",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741833198/7B472992DE2786ABF9B11852AC28F1BBE3EFF7BF/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 20,
+          "speed": 1,
+          "upgrades": {
+            "Training": 1,
+            "Comms": 1,
+            "Illicit": 1,
+            "Gear": 1,
+            "Counterpart": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696827920718216/511748ACB39B86DB07F412D61B8BC0706C09A5C5/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696827920718383/E67A519C2234A19CB159E833352376586A237A07/"
+            }
+          ]
+        },
+        {
+          "name": "IG-86 Sentinel Droids",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742381727/F1DAD4DF93EE4BE12C4E2E2BC1D7BADF29BAD32A/",
+          "size": "small",
+          "type": "Droid Trooper",
+          "points": 80,
+          "speed": 2,
+          "upgrades": {
+            "Heavy Weapon": 1,
+            "Training": 1,
+            "Illicit": 1,
+            "Gear": 1,
+            "Grenades": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407432785617/C21E190F258AC17A01C5D096C890DFA3B988759D/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432785832/186A72B65075EEA56ED2C3D1DC80718E987884B5/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407433051929/749E23C3D0FD9CE738CEA98802F52CA8B64ADABE/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432785832/186A72B65075EEA56ED2C3D1DC80718E987884B5/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407433051436/F1EA8C6D3CCB8278F7775C7AB78AD996DFC24291/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432785832/186A72B65075EEA56ED2C3D1DC80718E987884B5/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407433050963/ED218EC8188C166AFEE1E1DE86351BE786E764D7/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432785832/186A72B65075EEA56ED2C3D1DC80718E987884B5/"
+            }
+          ]
+        },
+        {
+          "name": "IG-86 Sentinel Droids",
+          "title": "Strike Team",
+          "displayName": "Sentinel Droids (Strike Team)",
+          "heavyWeaponTeam": true,
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742381186/83833409E9638CCAE4D3E135DD7DE7C3F50BF6B2/",
+          "size": "small",
+          "type": "Droid Trooper",
+          "points": 25,
+          "speed": 2,
+          "upgrades": {
+            "Heavy Weapon": 1,
+            "Training": 1,
+            "Illicit": 1,
+            "Comms": 1,
+            "Gear": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407432785617/C21E190F258AC17A01C5D096C890DFA3B988759D/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432785832/186A72B65075EEA56ED2C3D1DC80718E987884B5/"
+            }
+          ]
+        }
+      ],
+      "Support": [
+        {
+          "name": "Droideka MKII",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638672297/9A21A780F96BA78A849FD5FFF320FF4D0581259A/",
+          "size": "medium",
+          "type": "Ground Vehicle",
+          "points": 110,
+          "speed": 1,
+          "upgrades": {
+            "Comms": 1,
+            "Hardpoint": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365798378/BE8A6530AC8273FFE4549147A2F83C7A77BA5597/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365798566/72991BC6227C745C3157A2328EEFDF4F1671924D/"
+            }
+          ]
+        },
+        {
+          "name": "EWHB-12 Heavy Blaster team",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742525705/7188974BC1594CD7D0B2D6775629F3933FE40E62/",
+          "displayName": "EWHB-12 Team",
+          "size": "medium",
+          "type": "Emplacement Trooper",
+          "points": 60,
+          "speed": 1,
+          "upgrades": {
+            "Comms": 1,
+            "Illicit": 1,
+            "Generator": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756243818494/7211F52034FC36725841F968E5F2B991F8C10274/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756243792095/065CF347E346B773F8F93F81B0048E6A6A67A2C1/"
+            }
+          ]
+        }
+      ],
+      "Heavy": [
+        {
+          "name": "Cuddles",
+          "title": "Ferocious One",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735162413/20647BC13446FAA4A0951E6E9D5003D9904557E9/",
+          "size": "huge",
+          "type": "Creature Trooper",
+          "points": 135,
+          "speed": 1,
+          "upgrades": {
+            "Creature": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984835661685/1668BEEE179A260B9988D3C60872160FF93CEE51/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984835661821/7B52CEEC4169ACB4A32C0489D4A878BC72030DE2/"
+            }
+          ]
+        },
+        {
+          "name": "Canderous Class Assault Tank",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556639132725/E48531757B6B7D582D3D3AD313D790E21FAD2655/",
+          "size": "epic",
+          "type": "Repulsor Vehicle",
+          "points": 180,
+          "speed": 1,
+          "upgrades": {
+            "Pilot": 1,
+            "Comms": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231133144508/4BB9CD650D4795CEB6C81CBB95AB31DA7365F7EF/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231133144655/86527E20BE4B11B688A7F14894775EBE347C475B/"
+            }
+          ]
+        },
+        {
+          "name": "Missile Attack Launcher",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738556639035496/5F41C143C5ADE4631FFDC497CD8053BF7F0F9E43/",
+          "size": "epic",
+          "type": "Repulsor Vehicle",
+          "points": 140,
+          "speed": 1,
+          "upgrades": {
+            "Pilot": 1,
+            "Ordnance": 2,
+            "Comms": 1,
+            "Hardpoint": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698013227951332/BDA59EEE85EBD5AE628E38AC9B0C539D59DC9525/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698013227951474/8641BEED6BF44F70975F6F27093477327361567C/"
+            }
+          ]
+        },
+        {
+          "name": "Rancor",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742458068/53A90269FBB599680D91DA51225BE59738A8C049/",
+          "size": "huge",
+          "type": "Creature Trooper",
+          "points": 155,
+          "speed": 1,
+          "upgrades": {
+            "Pilot": 1,
+            "Creature": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696827920773360/FA78C7E63C77DD4A9CDF435A2DCE83BEE4235B82/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696827920773489/CCC8F655681A6962AA133E4DB9D4EBD8B3D487AD/"
+            }
+          ]
+        },
+        {
+          "name": "WLO-5 Battle Tank",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743059742/E6358D1656688B41E351113B72177D770264FB6B/",
+          "size": "epic",
+          "type": "Repulsor Vehicle",
+          "points": 125,
+          "speed": 2,
+          "upgrades": {
+            "Pilot": 1,
+            "Hardpoint": 1,
+            "Illicit": 1,
+            "Comms": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436416564/7E56BA386FDC26CB14047F335B62C19995B4AA5E/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436416842/1C5A975045A289BF43FBDC29DC3F2BD0ED7E1E0C/"
+            }
+          ]
+        }
+      ]
+    },
+    "Separatist": {
+      "Commander": [
+        {
+          "name": "Darth Sidious",
+          "title": "Master of Manipulation",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743518519/E404C02C62D579D5E0385EEDCB318DC45FFF7D13/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 240,
+          "speed": 2,
+          "upgrades": {
+            "Force": 3,
+            "Command": 1,
+            "Training": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824153235918382/C6629B635DB0B3D04D345B83AE6A0DA0EF4CDDBC/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824153235918510/4CE73F1347AA53974D94CADE1B77D9875694299C/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "Power! Unlimited Power!",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743519427/23500514817BCDB46436B493396E941FD5FFE6E7/",
+              "pip": 1
+            },
+            {
+              "name": "Execute Order 66",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743519790/0A304E9ECB85D8BCC65B1FA93658FC87D98DC96D/",
+              "pip": 2
+            },
+            {
+              "name": "A Surprise, To Be Sure",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743520163/A584E2B66E09368C6E89485F7C44DBA8CEA2A0D5/",
+              "pip": 3
+            }
+          ]
+        }
+      ],
+      "Operative": [
+        {
+          "name": "Sun Fac",
+          "title": "Archduke's Chief Lieutenant",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746952332/B95C799020F79D219FFDF62FF12C7EFB302E3920/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 105,
+          "speed": 3,
+          "upgrades": {
+            "Command": 1,
+            "Training": 2
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318234636/1ECC7AF43F26DDE2A82E90A54DCE2956F02A27F0/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893318234765/77E9C34FC82B00D2C3E96A60AF29948CBEC88784/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "Enforcer of the Swarm",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746960145/1E5AA4E032A934D62D4DBA0FB0C892E07603F8D7/",
+              "pip": 1
+            }
+          ]
+        }
+      ],
+      "Corps": [
+        {
+          "name": "Geonosian Warriors",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746956460/10EC43D13EC18AB52E30175D8E015E2C233EC310/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 48,
+          "speed": 3,
+          "upgrades": {
+            "Heavy Weapon": 1,
+            "Personnel": 1,
+            "Training": 1,
+            "Armament": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318078184/8B5466E18846FE7CF66B17BC0A657A0208855F03/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893318078962/DEB31D473979E7DE679F9564781A76B0E8E522FD/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318071468/13869F37C5ED6881ED97E16D300ED50175E1C007/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893317930470/4A9F58F7B8BC80AF279695655E38DD81A9236057/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318070141/E59D21FBF0E1DCE0AA6CF1B9574AB6BDF26438FC/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893317930470/4A9F58F7B8BC80AF279695655E38DD81A9236057/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318076612/BCD33D7FAFC2C324271FB92894740CACEFF7ED9D/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893317930470/4A9F58F7B8BC80AF279695655E38DD81A9236057/"
+            }
+          ]
+        }
+      ],
+      "Support": [
+        {
+          "name": "LM-432 Crabdroid",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743527286/34BE0F9B234F769983BE410CB8D2D94B695D5840/",
+          "size": "medium",
+          "type": "Ground Vehicle",
+          "points": 90,
+          "speed": 2,
+          "upgrades": {
+            "Comms": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455020027815604/10F9822A314D818E81C27CE272E1F52E50B6EBF3/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455020027816841/367B15AD633665E238815516DF8E82AC4EFAA34B/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455020027819432/1A96D256F849409A6F2157F0A896967146B7A13C/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455020027816841/367B15AD633665E238815516DF8E82AC4EFAA34B/"
+            }
+          ]
+        },
+        {
+          "name": "LR1K Sonic Cannon",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746955793/8D7F4A2BA75689F096F5D44BC4AB28B6BBDBC062/",
+          "size": "large",
+          "type": "Emplacement Trooper",
+          "points": 75,
+          "speed": 0,
+          "upgrades": {
+            "Comms": 1,
+            "Generator": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318385775/0D78686C63C10B04D2BA172B26F125D007034C0C/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893318369456/484B53AD87428BCF7E190DB1A763640373914353/"
+            }
+          ]
+        },
+        {
+          "name": "Octuptarra Tri-Droid",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743539441/5709DCD601EB0694A3CA0DA71D1BCC1D3C2A0F87/",
+          "size": "large",
+          "type": "Ground Vehicle",
+          "points": 60,
+          "speed": 2,
+          "upgrades": {
+            "Hardpoint": 1,
+            "Comms": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455403164598593/5A7C010653DBCE628FE44C40B0915C460164945A/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455403164542430/B2F1D02EDF736CAE38008DD4CEF11F2394AB18B4/"
+            }
+          ]
+        },
+        {
+          "name": "SD-4K Assassin Droid",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412069008204/589A89C815CF960153728A928496992538741916/",
+          "size": "large",
+          "type": "Ground Vehicle",
+          "points": 70,
+          "speed": 2,
+          "upgrades": {
+            "Programming": 1,
+            "Comms": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1055478180707369319/5222F20E44E450F944F7C39E59C16359C9743A60/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1055478180707368539/DDBADF81B279336EBE157E67F2ECAB3B6C8A037A/"
+            }
+          ]
+        },
+        {
+          "name": "Sharpshooter Droideka",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743586301/1CCF100C94512AE1CB7D788234024FDC86B16A29/",
+          "size": "medium",
+          "type": "Ground Vehicle",
+          "points": 110,
+          "speed": 1,
+          "upgrades": {
+            "Comms": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455553732191897/63312F1C4D01590EDA8153640DDF31260E7A27E2/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455553732192021/2D0E1C0D65555EF7A52443E3000E0979A287E077/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455553732192630/7B686F1D43905244043848E1240DA5B112F92A09/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455553732192021/2D0E1C0D65555EF7A52443E3000E0979A287E077/"
+            }
+          ]
+        }
+      ],
+      "Heavy": [
+        {
+          "name": "Defoliator Deployment Tank",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743614358/8A82032A999FD9F81E83CA8925B0C8AC301D07FD/",
+          "size": "epic",
+          "type": "Repulsor Vehicle",
+          "points": 155,
+          "speed": 1,
+          "upgrades": {
+            "Pilot": 1,
+            "Hardpoint": 1,
+            "Ordnance": 1,
+            "Comms": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893327245472/0E4E57241F7F12B74598D3D83A5D501E5586315F/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893327220558/8D3108FC26DE5361995CDDB2CE24CE004F69F1C9/"
+            }
+          ]
+        },
+        {
+          "name": "HMP Droid Gunship",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743692190/E87C41BC6C6F5797FA124D17C0F5C0FCB15769B0/",
+          "size": "epic",
+          "type": "Repulsor Vehicle",
+          "points": 155,
+          "speed": 2,
+          "upgrades": {
+            "Hardpoint": 1,
+            "Ordnance": 2,
+            "Comms": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028454854943605642/C9B582DDD3BD0DD6A4C0C3AB35E91064DFF77C42/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028454854943586665/C0F6961CFFA9F8E15FB5F6B6538AE5C404DD40B4/"
+            }
+          ]
+        },
+        {
+          "name": "IG-227 Hailfire-Class Droid Tank",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743648691/D8401535639FA435BD7D89A4DC8A9CEF8E077529/",
+          "size": "huge",
+          "type": "Ground Vehicle",
+          "points": 110,
+          "speed": 3,
+          "upgrades": {
+            "Hardpoint": 1,
+            "Comms": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455516900984588/FD6A321B7F88D5680A3AF647417BA4BB5E74EAEF/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455516901771593/595DBAC62796FE3C66973A218C72DDCEC3B4B05B/"
+            }
+          ]
+        },
+        {
+          "name": "Octuptarra Magna Tri-Droid",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743670386/A2A33692DAFB2F4BE77EE01ABEAB89F7B7CA1228/",
+          "size": "epic",
+          "type": "Ground Vehicle",
+          "points": 180,
+          "speed": 2,
+          "upgrades": {
+            "Hardpoint": 1,
+            "Comms": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455403164753290/F8E53798804F16BA75E428DF4DE94D930DB0F20A/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455403164542430/B2F1D02EDF736CAE38008DD4CEF11F2394AB18B4/"
+            }
+          ]
+        },
+        {
+          "name": "OG-9 Homing Spider Droid",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743679867/D32CA64107D6C9D10B086FE2335D8CC6A545F90C/",
+          "size": "epic",
+          "type": "Ground Vehicle",
+          "points": 140,
+          "speed": 1,
+          "upgrades": {
+            "Comms": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455403167048357/2192FD561FA2D05EB86CC3AE445499640E570E21/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455403164322367/DB9DC63C0285A43C8547D724F882063227910D89/"
+            }
+          ]
+        }
+      ]
+    },
+    "Sith Empire": {
+      "Commander": [
+        {
+          "name": "Darth Malgus",
+          "title": "Prodigy of Battle",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277562476/E42383A66E46621D98A52DA5D0BD1C7FBAD02AB9/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 190,
+          "speed": 2,
+          "upgrades": {
+            "Force": 3,
+            "Training": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824296871909914/CC551973C1E900C1153BB015BED7EE408646DF78/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231133343207/A24CBD9CC466137A560F72A00359E34DF0083071/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "Furious Charge",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277563415/5A0861160BA5F979A8F0C216F494C9925D5538BB/",
+              "pip": 1
+            },
+            {
+              "name": "Visions of Doubt",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277563761/ECD4F9155C9E74C1B70403FD0F547B55070F205C/",
+              "pip": 2
+            },
+            {
+              "name": "Force Maelstrom",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277564474/A1645474FAA791583F23BC7FFE299704AA112FCF/",
+              "pip": 3
+            }
+          ]
+        },
+        {
+          "name": "Lord Adraas",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277602848/B56DEFFD7CC8988D8568476DE4E0C7E59908A6E1/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 120,
+          "speed": 2,
+          "upgrades": {
+            "Force": 2
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885833891/AE635515661DD84861ADF0CF4FC48052FD3DEF87/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608885695776/F5A3AA78554B8F3CB86314E552D94D65C0080F0C/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "Counting Corpses",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277603245/63BC127864462C645D997822348332C2053CD8C8/",
+              "pip": 1
+            },
+            {
+              "name": "Spearheading the Assault",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277603553/067F6633690E6A14497AA7AA0164F0B93F773C2D/",
+              "pip": 2
+            },
+            {
+              "name": "Claiming Victory",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277603895/1237D55EFD6265C9922C8B7DEC76F46AD20608C4/",
+              "pip": 3
+            }
+          ]
+        },
+        {
+          "name": "Shae Vizla",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277698530/3A31084E01120F5B0F53A17C0B6F3ECBD2FD6DA6/",
+          "size": "small",
+          "type": "Mandalorian Trooper",
+          "points": 135,
+          "speed": 3,
+          "upgrades": {
+            "Training": 2,
+            "Gear": 1,
+            "Armament": 2
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642366438145/53BAD2A0BECE84168DD54692576AFFD8D43A9962/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642366438391/C107A0534E3BC5211416290AD53F4EB4482E021B/"
+            }
+          ],
+          "commands": [
+            {
+              "name": "Flame Burst",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277699041/E5D63FF435C115846E9863192F7A61EBABCD0DE4/",
+              "pip": 1
+            },
+            {
+              "name": "Mandalore The Avenger",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277699427/213D174E2B02C59A9774F14990693D661012BA30/",
+              "pip": 2
+            },
+            {
+              "name": "Whatever...",
+              "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277699707/C145698341E7B15563A59265F2D6D63A1F16E340/",
+              "pip": 3
+            }
+          ]
+        }
+      ],
+      "Corps": [
+        {
+          "name": "Sith Empire Troopers",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277742096/C1DC5A839A9F754B2EECA3F022F05A30C182F003/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 44,
+          "speed": 2,
+          "upgrades": {
+            "Heavy Weapon": 1,
+            "Personnel": 1,
+            "Training": 1,
+            "Grenades": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608878956135/77C5F51565475CEB63D9A0A0E97F3616EC17992E/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608878877171/C209E7E6493A8465F8FD60DE6566AA6BA2C745ED/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608878992636/D833E26E44A7763FAEFBE2430390376F9160E931/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608878877171/C209E7E6493A8465F8FD60DE6566AA6BA2C745ED/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608879652119/A6E9D1CC7FCF34BF844B1847503E21E60C007A21/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608878877171/C209E7E6493A8465F8FD60DE6566AA6BA2C745ED/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608878917211/A6984255B6241D8A292F4785C28A87E134354C9A/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608878877171/C209E7E6493A8465F8FD60DE6566AA6BA2C745ED/"
+            }
+          ]
+        },
+        {
+          "name": "Sith Empire Boarding Troopers",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277785197/971E0418CD2A7CE414F629E2AFEE3B684B99BA46/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 48,
+          "speed": 2,
+          "upgrades": {
+            "Personnel": 1,
+            "Heavy Weapon": 1,
+            "Training": 1,
+            "Comms": 1,
+            "Grenades": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885319465/2474308EBBDD92BDF8D331691E4F47EB4E1D9D7B/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885051525/BE73F7CADC7D35B297FE86A2C7C13532B33BED20/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885219099/28222F723E524C776ADFD8BF4072B274D5DD6513/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885271840/AEB99C8ABF425086732389D43FA67625C6E6C4CB/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
+            }
+          ]
+        },
+        {
+          "name": "Sith Empire Support Troopers",
+          "heavyWeaponTeam": true,
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277927003/D6339601058975760755CFB0F0FEE8ED3B6A4372/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 30,
+          "speed": 2,
+          "upgrades": {
+            "Heavy Weapon": 1,
+            "Training": 1,
+            "Comms": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824477681546677/855DD1F57D897B360CCA3F12DDB4449E0D116255/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824477681548557/DB63AB0044B89CB25D50A204A061D535CA20F495/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824477681548370/AFD42783EB041326C035DDB002BF34928A1AE002/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824477681548557/DB63AB0044B89CB25D50A204A061D535CA20F495/"
+            }
+          ]
+        }
+      ],
+      "Special Forces": [
+        {
+          "name": "Imperial Commandos",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277957842/94E04A758D860C9A7FCFE6D6356AA07DBFD811FD/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 72,
+          "speed": 2,
+          "upgrades": {
+            "Heavy Weapon": 1,
+            "Gear": 1,
+            "Training": 1,
+            "Comms": 1,
+            "Grenades": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024260308213/15A8FC12EB8192B2272D639557ED336BAF9718BE/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260606126/9430D9F19B59E68648F5261C8162A66C253EDDC0/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024261188154/B23F2669D0C619618D89D2BCF50E701363CDB26B/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260988667/8B8E27DFEDD6DEBA4EFABD6E738D3B6AC3E925AB/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024260446504/E46DFA85E16AF894A710D4F6714BA84BC9C6BBB3/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260606126/9430D9F19B59E68648F5261C8162A66C253EDDC0/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024260532062/6D98D9E28283E02F34B203849A11F420D1A1C99E/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260606126/9430D9F19B59E68648F5261C8162A66C253EDDC0/"
+            }
+          ]
+        },
+        {
+          "name": "Sith Acolytes",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278054907/1EA779D6C64F1883A9EF450C1424A0459EF087F9/",
+          "size": "small",
+          "type": "Trooper",
+          "points": 78,
+          "speed": 2,
+          "upgrades": {
+            "Personnel": 1,
+            "Training": 1,
+            "Force": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1012691837448680455/252DCD7E06B5083BBE6CABCA4F8349D6DCE46498/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608885695776/F5A3AA78554B8F3CB86314E552D94D65C0080F0C/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885701810/42CE6863B9D31E7EDDA1C4DEEC0C52F6DFEBB0D1/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608885695776/F5A3AA78554B8F3CB86314E552D94D65C0080F0C/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885733918/43DD4CBAEAD756429F47BAF24133A3D97CEA9DA6/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608885695776/F5A3AA78554B8F3CB86314E552D94D65C0080F0C/"
+            }
+          ]
+        }
+      ],
+      "Support": [
+        {
+          "name": "War Droid MK I",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278072181/D3BB57A041FA5490F372A792EEF35A344BD68FCD/",
+          "size": "medium",
+          "type": "Ground Vehicle",
+          "points": 110,
+          "speed": 1,
+          "upgrades": {
+            "Comms": 1
+          },
+          "minis": [
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697620253289667/85745104AA0C94936FA804B87EA1A61938161B79/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697620253289816/7245F236A07C662A6AA471AA89E323417AB7D604/"
+            },
+            {
+              "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697620253290925/09820A879BC9DB027D438A7F0051F90D558A3D97/",
+              "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697620253289816/7245F236A07C662A6AA471AA89E323417AB7D604/"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "upgrades": {
+    "Armament": [
+      {
+        "name": "Amped up A-280's",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742002345/F99AB12D9FC7810EC0868DEA0DD3EEFBB15D686E/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "unit": ["Hired Guns"]
+          }
+        }
+      },
+      {
+        "name": "Anakin's Lightsaber",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1027324932753002794/C0A0C19E79DAF7B4B11E6DCEE218AB2F4C385966/",
+        "points": 25,
+        "restrictions": {
+          "include": {
+            "unit": ["Finn"]
+          }
+        }
+      },
+      {
+        "name": "Anakin's Lightsaber Rey",
+        "displayName": "Anakin's Lightsaber",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1027324932753002794/C0A0C19E79DAF7B4B11E6DCEE218AB2F4C385966/",
+        "points": 20,
+        "restrictions": {
+          "include": {
+            "unit": ["Rey"]
+          }
+        }
+      },
+      {
+        "name": "BB-8 Grappling cord",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1021698068157660515/A2C7648C32E4AF4B631D2C498E6C76CC97B25925/",
+        "points": 0,
+        "restrictions": {
+          "include": {
+            "unit": ["BB-8"]
+          }
+        }
+      },
+      {
+        "name": "Cody's DC-15a",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747470278/1615C1C3D7C36AA201B25F52D99215DC4D12195C/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "unit": ["Commander Cody"]
+          }
+        }
+      },
+      {
+        "name": "Defilers Blaster",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735211533/50044D04BF35EAE0926C6A86936DC5A2DA95B0FD/",
+        "points": 15,
+        "restrictions": {
+          "include": {
+            "unit": ["Defiler"]
+          }
+        }
+      },
+      {
+        "name": "DC-17m Anti-Armor Config",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747570525/CACD6285B8098528A1E23C5AA68F3EB68076B4DF/",
+        "points": 18,
+        "restrictions": {
+          "include": {
+            "unit": ["Republic Commandos"]
+          }
+        }
+      },
+      {
+        "name": "DC-17m Sniper Rifle Config",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747571113/0AA95599A43D23EDBDA63F1835698A1CBAC6D746/",
+        "points": 20,
+        "restrictions": {
+          "include": {
+            "unit": ["Republic Commandos"]
+          }
+        }
+      },
+      {
+        "name": "Defilers Slug Thrower",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735211196/02C8A1B676C2CFC2A17BFB8819B8C6981DAD74D7/",
+        "points": 15,
+        "restrictions": {
+          "include": {
+            "unit": ["Defiler"]
+          }
+        }
+      },
+      {
+        "name": "DXR-6 Focused Fire Config",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735115917/9E0BA5F8013B1491D5EF74BED3C484BA0F3052AB/",
+        "flip": {
+          "name": "DXR-6 Power Shot Config",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735116297/419AF3D6925D7004CA92BE249969A1BFB42B9742/"
+        },
+        "points": 8,
+        "restrictions": {
+          "include": {
+            "unit": ["Mercenary Assault Squad"]
+          }
+        }
+      },
+      {
+        "name": "Elite Wrist Mounted Flamethrower",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640412575/1F3B56925DC71E5FAFDD405CF117B72CC0DB3B42/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "type": ["Mandalorian Trooper"],
+            "rank": ["Commander", "Operative"]
+          }
+        }
+      },
+      {
+        "name": "Gauntlet Blades",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640410174/FF136859D9C64EFC2B33CEDF111204596228A4B0/",
+        "points": 6,
+        "restrictions": {
+          "include": {
+            "unit": ["Bo-Katan Kryze"]
+          }
+        }
+      },
+      {
+        "name": "Hondo's Electrostaff",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738475192/6004D55A77E10329CE6EABD01DE46D1BB2DF1572/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "unit": ["Hondo Ohnaka"]
+          }
+        }
+      },
+      {
+        "name": "Illegally Modified E-11's",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742002948/59F017866F7B7293C00FED3BA937D371B7E71C0A/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "unit": ["Hired Guns"]
+          }
+        }
+      },
+      {
+        "name": "Quicksilver Baton",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081144482/1AA3BE94F83F1BE4DE2D135E655B5C1D811B327F/",
+        "flip": {
+          "name": "Chromium SE-44 Blaster",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081144665/EE6A1C8395737CB64EA6529ECFC1D00146A350FC/"
+        },
+        "points": 15,
+        "restrictions": {
+          "include": {
+            "unit": ["Captain Phasma"]
+          }
+        }
+      },
+      {
+        "name": "Static Pikes",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746953521/48A9A9BFC5662EA0496E1533D16AAE84DB4CCE48/",
+        "points": 6,
+        "restrictions": {
+          "include": {
+            "unit": ["Geonosian Warriors"]
+          }
+        }
+      },
+      {
+        "name": "Vibroblade",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412068779530/6BC0F180AB6278302B59DFDC3C381F048CFA28D7/",
+        "points": 12,
+        "restrictions": {
+          "include": {
+            "unit": ["Calo Nord"]
+          }
+        }
+      },
+      {
+        "name": "Wrist Rocket",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640428446/AE6DB75F1A3643AF7DCB7CA1BA8DAFF87E7A5C8A/",
+        "points": 6,
+        "restrictions": {
+          "include": {
+            "type": ["Mandalorian Trooper"]
+          }
+        }
+      },
+      {
+        "name": "Whistling Birds",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640411728/A3BCBA7C1B49EE5B996A55A8FC6CB581A9EAA96C/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "type": ["Mandalorian Trooper"],
+            "rank": ["Commander", "Operative"]
+          }
+        }
+      },
+      {
+        "name": "Wrist Mounted Blasters",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640413937/745B5BEAD23640A8222A54287029ACF70F9A81EE/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "type": ["Mandalorian Trooper"]
+          }
+        }
+      },
+      {
+        "name": "Wrist Mounted Flamethrower",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640416270/08971192288A83DD208F4D91D02703E094090133/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "type": ["Mandalorian Trooper"]
+          }
+        }
+      },
+      {
+        "name": "Z-6 Riot Control baton",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752981376/8F2F3430452BDBD8DD78E48243BCECEA994DF1AC/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "unit": ["Finn"]
+          }
+        }
+      }
+    ],
+    "Command": [
+      {
+        "name": "Racketeering",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735072829/84C080C8B919D06884AF3BC12ADDB58B524C5271/",
+        "points": 5,
+        "restrictions": {
+          "include": {
+            "unit": ["Tyber Zann"]
+          }
+        }
+      }
+    ],
+    "Comms": [
+      {
+        "name": "B1's Datapad",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1021698068155822603/B74DFBDE71FC462A482C92AF02C57AD2C6373E0F/",
+        "points": 6,
+        "restrictions": {
+          "include": {
+            "unit": ["Salvaged B2 Battle Droids"]
+          }
+        }
+      },
+      {
+        "name": "Proximity Signal",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743573243/8687C5FADEF63558D5088A664E51ACF3C9D3D172/",
+        "points": 6,
+        "restrictions": {
+          "include": {
+            "unit": ["SD-4K Assassin Droid"]
+          }
+        }
+      }
+    ],
+    "Counterpart": [
+      {
+        "name": "BB-8",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1022824296871784739/BA69ED4E4B2926D1C9E5FB255791569EB5AA7A05/",
+        "points": 25,
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068157620585/9E7930221D8CD87F6338B9D4B58F4D3F824D08C0/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068157620780/493748852320ED988465533F8BC49FEA2672A9E8/"
+        },
+        "restrictions": {
+          "include": {
+            "faction": ["Resistance"],
+            "unit": ["Rose Tico", "Rey", "Poe Dameron", "Finn", "R2-D2"]
+          }
+        }
+      },
+      {
+        "name": "C-3PO",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1616219505080628828/F6A01DB4DFDB1A518FC4E373D72237AB1B31300B/",
+        "points": 15,
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/776232727456807069/DE7E32B39455DB5111769436FD0C5BFDA3841268/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/777357228032306506/D60CB8A1159723917EF1831D4042318A67458A7A/"
+        },
+        "restrictions": {
+          "include": {
+            "unit": ["R2-D2"]
+          }
+        }
+      },
+      {
+        "name": "Salacious B. Crumb",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741310541/C8ADFE085EC634C8766C303BD1F89D230BEADEBE/",
+        "points": 10,
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984838966754/DCEED639BB3AA1D36A2AF82B26708EF4007A3583/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984838966978/51C97B6161C17AE3229372F0C26331EAD0D44200/"
+        },
+        "restrictions": {
+          "include": {
+            "unit": ["Jabba The Hutt"]
+          }
+        }
+      },
+      {
+        "name": "Vornskr's",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741832560/CFA25E88275C65CC80ACE518A3DBDB2C4235E061/",
+        "points": 15,
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697620252875766/48FF7F717DEA00FCE1E830FD4FA888494433370A/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697620252875970/2006E4E0DA5EA0DEEEB1B3982D975944B8F9DC7B/"
+        },
+        "restrictions": {
+          "include": {
+            "unit": ["Beast Master"]
+          }
+        }
+      }
+    ],
+    "Crew": [
+      {
+        "name": "F-11D Blaster Rifle Gunner",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081208241/F230A7C4DE9FBF543B9DD9F4CB370A7D59B44BAA/",
+        "points": 7,
+        "restrictions": {
+          "include": {
+            "unit": ["Light Infantry Utility Vehicle"]
+          }
+        }
+      },
+      {
+        "name": "First Order Officer ",
+        "displayName": "First Order Officer",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081214064/11B6F493E9AFB18F34739932FD21874F50EA6E7E/",
+        "points": 8,
+        "restrictions": {
+          "include": {
+            "unit": ["Light Infantry Utility Vehicle"]
+          }
+        }
+      }
+    ],
+    "Flaw": [
+      {
+        "name": "I Don't Care if You Win",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081176926/A624D3D4A4BF45129F3D140BA5FFEFEF471065B9/",
+        "points": 0
+      },
+      {
+        "name": "I'll Bet You Have",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741747564/7E279CBA3100D1D5A3E4B5D9EBD362D57373ABE8/",
+        "points": 0
+      },
+      {
+        "name": "I'm Being Torn Apart",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081188353/E86EB5CB8B87C8CE341CD77CD32CD8A6A5FA3B67/",
+        "points": 0
+      }
+    ],
+    "Force": [
+      {
+        "name": "Acolyte Force Lightning",
+        "displayName": "Force Lightning",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278090576/86604BC87F9AB158776F63811C23AB3AE058722A/",
+        "points": 5,
+        "restrictions": {
+          "include": {
+            "faction": ["Sith Empire"]
+          }
+        }
+      },
+      {
+        "name": "Chain Lightning",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278091219/1C7C89C5537F9B248294B44DADC5F24D181892C2/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "faction": ["Sith Empire"]
+          }
+        }
+      },
+      {
+        "name": "Force Dash",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747371109/7290AD045A9201DA40F367CAD1FF04C1615B9851/",
+        "points": 9
+      },
+      {
+        "name": "Force Lightning",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747371606/231C69EF773D74B95CCC5EB34F1EB96C1119FA98/",
+        "points": 12,
+        "restrictions": {
+          "include": {
+            "alignment": ["Dark"]
+          }
+        }
+      },
+      {
+        "name": "Force Rend",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747370532/B97ADF8AC0302E13A315C68402376409B45A5FFE/",
+        "points": 17,
+        "restrictions": {
+          "include": {
+            "alignment": ["Dark"]
+          }
+        }
+      },
+      {
+        "name": "Force Statis",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747369898/5CC327BAEB59E3B817B71AFF6EC21D3E14ADB4A2/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "alignment": ["Dark"]
+          }
+        }
+      },
+      {
+        "name": "Maglus Force Lightning",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277562964/22A352A0E0EF8FE27B1DF1F19C08A80CE1564B3C/",
+        "points": 5,
+        "restrictions": {
+          "include": {
+            "unit": ["Darth Malgus"]
+          }
+        }
+      }
+    ],
+    "Gear": [
+      {
+        "name": "Bacta Auto-Dispenser",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747571812/21DA4C0C9811D5252F4FAB4E7F10B358FC74C2BA/",
+        "points": 20,
+        "restrictions": {
+          "include": {
+            "unit": ["Republic Commandos"]
+          }
+        }
+      },
+      {
+        "name": "Calo Nord's Battle Armor",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412068780383/4FE70939384B8CD88DC852C8CAED0D21BAF3C367/",
+        "points": 35,
+        "restrictions": {
+          "include": {
+            "unit": ["Calo Nord"]
+          }
+        }
+      },
+      {
+        "name": "Electro Grappling Line",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640414601/68D77CCDC40F2F1F103F1AF7568727FA6F9E8CE9/",
+        "points": 3,
+        "restrictions": {
+          "include": {
+            "type": ["Mandalorian Trooper"]
+          }
+        }
+      },
+      {
+        "name": "JT-12 Jetpack",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747527633/AF0E4FAA5C2D92BD45DC40252B9ADAB003A5FC5F/",
+        "points": 5,
+        "restrictions": {
+          "include": {
+            "unit": ["Commander Colt"]
+          }
+        }
+      },
+      {
+        "name": "Jump pack",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751974753/5AF713EB09F4AFDF88B76C8CB9F54CE4D0BEB7D8/",
+        "points": 0,
+        "restrictions": {
+          "include": {
+            "unit": ["Phase II Darktroopers"]
+          }
+        }
+      },
+      {
+        "name": "Personal Combat Shield",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640410953/DEF506B2DB3747BF1DD5ABBECEB36764450D0B7C/",
+        "points": 15,
+        "restrictions": {
+          "include": {
+            "type": ["Mandalorian Trooper"]
+          }
+        }
+      },
+      {
+        "name": "Target Designator",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638971560/0F6F9FB93CD712E0D2B5916DE3392EF98BDAB3DC/",
+        "points": 6,
+        "restrictions": {
+          "include": {
+            "faction": ["Scum"]
+          }
+        }
+      },
+      {
+        "name": "Vambrace Reloader",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640415774/E6C7E28AAA6C1EC3CB460AE5947F2AAE2960EF15/",
+        "points": 3,
+        "restrictions": {
+          "include": {
+            "type": ["Mandalorian Trooper"]
+          }
+        }
+      }
+    ],
+    "Generator": [
+      {
+        "name": "Class-5B1 Duplex Generator",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747375028/7DEFD098875FF94FD712C2FB42C37218AE5F95D9/",
+        "points": 10
+      },
+      {
+        "name": "GNK-series Power Droid",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747374218/EBE238DB2CCD3F06AC1CC96325D04FEE2B5ECD1C/",
+        "points": 5
+      },
+      {
+        "name": "Ion Generator",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747374603/462C32A767195B287E9FFCFC73BD0FA798F982DF/",
+        "points": 10
+      },
+      {
+        "name": "Scavenged Generator",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1022824296871788518/1BB5B0A6D3E8BDA3F3E66F6ED7B4E30BC24C4C3E/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "faction": ["Resistance", "Rebel"]
+          }
+        }
+      },
+      {
+        "name": "Targeted Generator",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742526797/6A85F0CB99FE4DB7DCFD7DA3EDF1E04B4D1A56DC/",
+        "points": 7,
+        "restrictions": {
+          "include": {
+            "unit": ["EWHB-12 Heavy Blaster team"]
+          }
+        }
+      }
+    ],
+    "Grenades": [
+      {
+        "name": "Cluster Grenades",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640427155/BAB17778B9558A117B7672B361169E1429B8FFBD/",
+        "points": 5,
+        "restrictions": {
+          "include": {
+            "type": ["Mandalorian Trooper"]
+          }
+        }
+      },
+      {
+        "name": "Cryoban Grenade",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747372562/020D8C7E51888C66929A5C68BC64CF2A0751AB96/",
+        "points": 10
+      },
+      {
+        "name": "Concussive Discs",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743157047/93145CADA2644E48715594A16814C0B588B09264/",
+        "points": 7,
+        "restrictions": {
+          "include": {
+            "unit": ["IG-88"]
+          }
+        }
+      }
+    ],
+    "Hardpoint": [
+      {
+        "name": "Auto Loader",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638973875/12A8A6DAC58F8AD954452CFC4B0DC38ED932407B/",
+        "points": 5,
+        "restrictions": {
+          "include": {
+            "unit": ["Missile Attack Launcher"]
+          }
+        }
+      },
+      {
+        "name": "Chain-Fed Missile Launcher",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743540463/2FDD9391217B4D3C83489ACFC70B5D4D70D828AF/",
+        "points": 8,
+        "restrictions": {
+          "include": {
+            "unit": ["Octuptarra Tri-Droid"]
+          }
+        }
+      },
+      {
+        "name": "D-93 Incinerator",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081207055/8CE886D73E5632DFB6B71F21AEE082B90DB862B2/",
+        "points": 24,
+        "restrictions": {
+          "include": {
+            "unit": ["Light Infantry Utility Vehicle"]
+          }
+        }
+      },
+      {
+        "name": "Ball Turrets",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747617309/E7A1C86302FE190A75A859B3405353D24B56AA93/",
+        "points": 20,
+        "restrictions": {
+          "include": {
+            "unit": ["LA-AT/I Gunship"]
+          }
+        }
+      },
+      {
+        "name": "Defoliator Missile Launcher",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743618077/FD3FF4AAAA791E2B578007273E93859B7FA12E6E/",
+        "points": 28,
+        "restrictions": {
+          "include": {
+            "unit": ["Defoliator Deployment Tank"]
+          }
+        }
+      },
+      {
+        "name": "Dorsal Laser Cannon",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747586054/E0CA1658DB7AB53E43598B3506A980E595D78AA8/",
+        "points": 16,
+        "restrictions": {
+          "include": {
+            "unit": ["AT-AP"]
+          }
+        }
+      },
+      {
+        "name": "Enhanced Stabilizers",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747587543/837CEB0047D91D5ADEB112F08F19C456609042D9/",
+        "points": 14,
+        "restrictions": {
+          "include": {
+            "unit": ["AT-AP"]
+          }
+        }
+      },
+      {
+        "name": "Enhanced Targeting Computer",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743649603/CC9BB61488A9EDD358521E3E62D73A316BC07F23/",
+        "points": 8,
+        "restrictions": {
+          "include": {
+            "unit": ["IG-227 Hailfire-Class Droid Tank"]
+          }
+        }
+      },
+      {
+        "name": "EWHB-12 Blaster Turret",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743064886/381FF3A3AED8050E5BDF1E3A4EC6B6DC2608B4EE/",
+        "points": 28,
+        "restrictions": {
+          "include": {
+            "unit": ["WLO-5 Battle Tank"]
+          }
+        }
+      },
+      {
+        "name": "Expanded Launch Tubes",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638975154/0F3C24800735B4BB8E0B156258FF032116C503F0/",
+        "points": 4,
+        "restrictions": {
+          "include": {
+            "unit": ["Missile Attack Launcher"]
+          }
+        }
+      },
+      {
+        "name": "Fire Direction Center",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638972654/A3E6D0BCB701B2DEFB788DA9CEB3F163F4025EEF/",
+        "points": 8,
+        "restrictions": {
+          "include": {
+            "unit": ["Missile Attack Launcher"]
+          }
+        }
+      },
+      {
+        "name": "FWMB-10 Megablaster",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081201870/567FD6D4762C52C8EA448858D8E030A5D9846683/",
+        "points": 35,
+        "restrictions": {
+          "include": {
+            "unit": ["Light Infantry Utility Vehicle"]
+          }
+        }
+      },
+      {
+        "name": "Ion Cannon",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638673967/DCE9270CEAD120F4DD068CDF23C326E2371DC75C/",
+        "points": 15,
+        "restrictions": {
+          "include": {
+            "unit": ["Droideka MKII"]
+          }
+        }
+      },
+      {
+        "name": "Magna Chain-Fed Missile Launcher",
+        "displayName": "Chain-Fed Missile Launcher",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743671604/F03AE6E7CE4E84CDA2D22BBD7B6A2BE97F45437B/",
+        "points": 20,
+        "restrictions": {
+          "include": {
+            "unit": ["Octuptarra Magna Tri-Droid"]
+          }
+        }
+      },
+      {
+        "name": "Magna Plague Carrier",
+        "displayName": "Plague Carrier",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743671273/2C55E19F1F47BABA103DCA4ECA92471CEA8D503A/",
+        "points": 5,
+        "restrictions": {
+          "include": {
+            "unit": ["Octuptarra Magna Tri-Droid"]
+          }
+        }
+      },
+      {
+        "name": "MS-1 Medium Laser Turret",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743066443/2CF2905266AA4BDE3F40F755F800CB0E0A3392A6/",
+        "points": 20,
+        "restrictions": {
+          "include": {
+            "unit": ["WLO-5 Battle Tank"]
+          }
+        }
+      },
+      {
+        "name": "Plague Carrier",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743540072/7D3F2EBDCE33584ED931379EFF49B8A3E26789C7/",
+        "points": 15,
+        "restrictions": {
+          "include": {
+            "unit": ["Octuptarra Tri-Droid"]
+          }
+        }
+      },
+      {
+        "name": "Proton Missile Launcher",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743617683/7B7D562698834D3ACEC51A5BC5BC6B148F4C55A4/",
+        "points": 20,
+        "restrictions": {
+          "include": {
+            "unit": ["Defoliator Deployment Tank"]
+          }
+        }
+      },
+      {
+        "name": "Raised Mono-Ski",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1021697620252782821/C642C07229E6BDCA7AA79F99D34328383622F962/",
+        "flip": {
+          "name": "Lowered Mono-Ski",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1021697620252782950/AE54FB7E97854E2621BC3F9EB314F432DBE1EC75/"
+        },
+        "points": 0,
+        "restrictions": {
+          "include": {
+            "unit": ["V-4X-D Ski Speeder"]
+          }
+        }
+      },
+      {
+        "name": "Rapid Fire Launchers",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743649159/0BAF4A7EC12DAC1AEB13A22120D2D3B1FA1BC0B6/",
+        "points": 14,
+        "restrictions": {
+          "include": {
+            "unit": ["IG-227 Hailfire-Class Droid Tank"]
+          }
+        }
+      },
+      {
+        "name": "Sealed Blast Shields",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747617819/F41341A8EA3FDEBA78238EC8298691A0E2C5248C/",
+        "points": 0,
+        "restrictions": {
+          "include": {
+            "unit": ["LA-AT/I Gunship"]
+          }
+        }
+      },
+      {
+        "name": "Transport Rack",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743692647/47DDE4B573774D76E0DD110994DEEF3C2F0406BB/",
+        "points": 20,
+        "restrictions": {
+          "include": {
+            "unit": ["HMP Droid Gunship"]
+          }
+        }
+      },
+      {
+        "name": "Tri Laser Cannons",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638674750/6057A2DACA2F104F889921E46FF3AC717DE4B962/",
+        "points": 25,
+        "restrictions": {
+          "include": {
+            "unit": ["Droideka MKII"]
+          }
+        }
+      },
+      {
+        "name": "Wing Ball Turrets",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747616297/2753260BCF4BD591144C4D74769F5E982D4E9D10/",
+        "points": 14,
+        "restrictions": {
+          "include": {
+            "unit": ["LA-AT/I Gunship"]
+          }
+        }
+      }
+    ],
+    "Heavy Weapon": [
+      {
+        "name": "ACP Trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735115264/1D92758AC20C28AA48019DCD564E31D271B20A2C/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068156270983/519A43ACE1F5461D51AA1BA81ADF4A5C37BEF9E4/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068156271135/318D90BCDE4E3E362797A38823A21FF17FAF651E/"
+        },
+        "points": 30,
+        "restrictions": {
+          "include": {
+            "unit": ["Mercenary Assault Squad"]
+          }
+        }
+      },
+      {
+        "name": "B1",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1021698068155818428/717521A597961079FBE4E4121DECAF4F0ED00471/",
+        "points": 16,
+        "restrictions": {
+          "include": {
+            "unit": ["Salvaged B2 Battle droids"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/785234780869166347/AA861F86A0B74CF335533E425A6CBACB99395A09/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/785234780869166529/263C2AB95B1743539EC2CBDE40B0A14B1F5E5693/"
+        }
+      },
+      {
+        "name": "BD-1 Vibroaxe Guard",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741407943/466AB5745404A77F5156D5AF55160CCB52545A50/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407431287477/62E1591E99BD747C7C130C3D4B5F70CA6FFA34B2/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407431272263/BBD5D7D12BC2B61E0C88AA50721BDD40AF766FF7/"
+        },
+        "points": 25,
+        "restrictions": {
+          "include": {
+            "unit": ["Gamorrean Gaurds"]
+          }
+        }
+      },
+      {
+        "name": "Beam Blaster Elite",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746958937/58D737AAB1676A6450C545CEE6299DBC19AF6E59/",
+        "points": 38,
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318091926/A474DAED7A90C67374FC60462D9A34FA7A29261F/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893318085783/83580E45A97E753127E6E4D5E221E5227B35E6A4/"
+        },
+        "restrictions": {
+          "include": {
+            "unit": ["Geonosian Warriors"]
+          }
+        }
+      },
+      {
+        "name": "Blaster Lance Droid",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742382205/FD43E6FF2AEF649B5A4A59B02630F602BEAE2C42/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407432789217/7FA6CC4082ED2BA4F96DB4A6A32DC268B55A924A/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432781824/644CE23A0B74C79BF20698A408FCF00D319EA7BE/"
+        },
+        "points": 30,
+        "restrictions": {
+          "include": {
+            "unit": ["IG-86 Sentinel Droids"]
+          }
+        }
+      },
+      {
+        "name": "Boarding Shotgun Trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277786673/D0232B6BBE5FA4816C85DF20383B0892B8151979/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692419888092880/788628E64550196C6371C2B129FEB590CC2691DE/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
+        },
+        "points": 24,
+        "restrictions": {
+          "include": {
+            "unit": ["Sith Empire Boarding Troopers"]
+          }
+        }
+      },
+      {
+        "name": "Commander Pyre",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081379697/2F3B002E5BB2D13118DF5330C9BE7BA27B84D749/",
+        "points": 30,
+        "leader": true,
+        "restrictions": {
+          "include": {
+            "faction": ["First Order"],
+            "rank": ["Corps"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027325137553590946/9E9D1E1798483BDDE43862B03D2424FB7B68EBB0/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027325137553591247/46CE15787E0615D89B2D6931B1BCDE53F1D2B954/"
+        }
+      },
+      {
+        "name": "Concussion Rifle Trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735114688/7F06A4AA27BBEFE8D08FF392CB8E7E8FC4083F6B/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068156271785/233649FA9B56D451B97E71E706C777AD529B0810/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068156271944/671F0E7483F7DA3D92D551E5042698EE06E510EB/"
+        },
+        "points": 30,
+        "restrictions": {
+          "include": {
+            "unit": ["Mercenary Assault Squad"]
+          }
+        }
+      },
+      {
+        "name": "Cycler Rifle Sniper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638840781/F5E96AC72E6D27DDA4AAC1467261D01B33AAD476/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068156464799/C000C8B3CF81A11687F6B39574ACE73A8FEF1A28/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068156464974/774C639F2300D7816E654D8276585556DEAD6432/"
+        },
+        "points": 30,
+        "restrictions": {
+          "include": {
+            "unit": ["Infiltrators"]
+          }
+        }
+      },
+      {
+        "name": "CY-M Carbine Geonosian",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746958335/3F471B7803B243D2ED9C1A3E69C86655874E3AAE/",
+        "points": 25,
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893318084126/7B0D406E30E73FC005FA1AB1258738A91908E9D0/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893318095905/A0476F5F976ACE1C0BCE6F1D5C12085DBF6628B7/"
+        },
+        "restrictions": {
+          "include": {
+            "unit": ["Geonosian Warriors"]
+          }
+        }
+      },
+      {
+        "name": "DC-15 Paratrooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747551847/74C7612A3CD055BEF6F7ED101DCC13AC2EF96D2F/",
+        "points": 34,
+        "restrictions": {
+          "include": {
+            "unit": ["Clone Paratroopers"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693290506984196/E1DADD867AD088A500B4D44B6966A1BDA6F1A62A/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
+        }
+      },
+      {
+        "name": "Death Watch Duelist",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736282375/F5A9EF30A976727C91F3C880E7B603D827086B6F/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357841451/50164A1C84E6D119BC45BDD31C8209ED7D9A0F29/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515357841757/1DC29C81D9DFCB2FB7D8A3B2EA2F2ABD3F416396/"
+        },
+        "points": 25,
+        "restrictions": {
+          "include": {
+            "unit": ["Death Watch Fireteam"]
+          }
+        }
+      },
+      {
+        "name": "Death Watch Fireteam Trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736282915/B810832E8ACDF94B56D90DE60C159FE0A5FF77D2/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357844380/B08FE1606E634293EBE16FFD9541B5F7C801E2CF/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886427771/60D6CA1D97D822A2222E4FAF614931265B7B0AF2/"
+        },
+        "points": 18,
+        "restrictions": {
+          "include": {
+            "unit": ["Death Watch Fireteam"]
+          }
+        }
+      },
+      {
+        "name": "Death Watch Marksman",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736284088/EF0FB8D721EE6297963990219E9FC01B1A0AB940/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696350886436522/D0CBBE1EB66E7A3FEECA1A6DF0FEF6F352287404/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696350886436834/E27641C0A96264724D710A4B3F912F543CF9413E/"
+        },
+        "points": 34,
+        "restrictions": {
+          "include": {
+            "unit": ["Death Watch Fireteam"]
+          }
+        }
+      },
+      {
+        "name": "Detonite Charge Saboteur",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638839094/D0D81BD4107CD9647D5C041676865BAA1CFF027D/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698068156470652/C2D7BF3AADDECA01B8C5442DF6419D2F1FF2389B/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698068156470835/5E87EEBFF97975FF1A8985808C26B645EC53CAAC/"
+        },
+        "points": 28,
+        "restrictions": {
+          "include": {
+            "unit": ["Infiltrators"]
+          }
+        },
+        "additionalObjects": ["Proton Charge Token"]
+      },
+      {
+        "name": "Disruptor Rifle Trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277743519/060D5A5B2B512DF5E41BD6923EF07C064EEC1E7C/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608881149656/B3DDF1010726FDC59F24ACC4375251D7919F6135/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608881150442/1B5AD6129AC8D180D97CFE93ACE1DC7E49119F04/"
+        },
+        "points": 22,
+        "restrictions": {
+          "include": {
+            "unit": ["Sith Empire Troopers"]
+          }
+        }
+      },
+      {
+        "name": "DLA-13 Trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277745430/15ED754DCBAE03022CE8D08671C057280FE90B7F/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608879755028/53718ACF3D389983D1CF2630D761DF90121CDA5A/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608879744395/158047D5CFC30AFE6A2A50F64A2DA8F7BD4073B4/"
+        },
+        "points": 20,
+        "restrictions": {
+          "include": {
+            "unit": ["Sith Empire Troopers"]
+          }
+        }
+      },
+      {
+        "name": "EL-16HFE Fighter",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1021697756245234129/D1D2CFCCD4C29B15FEBC3BB12EE0E66292729C1F/",
+        "points": 25,
+        "restrictions": {
+          "include": {
+            "unit": ["Resistance Trench Fighters"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248448323/8992031636B30867375FF6724079096F6F95F5B0/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248448499/974E02AC778A5EFD4EF7F33F393B06B71ADF20A6/"
+        }
+      },
+      {
+        "name": "Electro-chain Whip Guard",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081435049/EE1C47B91E05240A23E58D4E5A905843DC1AECD6/",
+        "points": 30,
+        "restrictions": {
+          "include": {
+            "unit": ["Elite Praetorian Guards"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817957003764515/0FDC98B926F47CE64FE6407AACBCD29E5F1A8C78/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817957003763776/D3F6005987B0D827683E0B7EB3E482E8D5213424/"
+        }
+      },
+      {
+        "name": "F-11ABA Sith Trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081229621/9B54F3E6AD5E11523D82D0152FE273FA459E7FDD/",
+        "points": 28,
+        "restrictions": {
+          "include": {
+            "unit": ["Jet Troopers"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698013227868656/38A393B4932FF16ABF01AAB99C280BA4C224FE25/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698013227868793/0A4C85E66B3E68C4DDCF3D191D1E9E8B809C0727/"
+        }
+      },
+      {
+        "name": "F-11D Assault Cannon Trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277928461/7263E2C1EF01981353B16786CB01441C92A7D941/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824477681555675/1E4C571546078FEFFD4E753CBBC08EF18CBD0342/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824477681548557/DB63AB0044B89CB25D50A204A061D535CA20F495/"
+        },
+        "points": 30,
+        "restrictions": {
+          "include": {
+            "unit": ["Sith Empire Support Troopers"]
+          }
+        }
+      },
+      {
+        "name": "FN-2199",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081374822/8CF5DD30B49BCDA674B5A2E7343C421C7D367A1E/",
+        "points": 28,
+        "restrictions": {
+          "include": {
+            "unit": ["First Order Stormtroopers"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821972716827731/5B0D97A839084D07EA0B8A1F6C925732D300D681/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821972716828171/0331B4B577F867C2D647DDC63E4F201D400D679E/"
+        }
+      },
+      {
+        "name": "FWMB-10K Heavy Trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081336883/0386F13822F48C2CE6086861FAF8FA18C862645C/",
+        "points": 24,
+        "restrictions": {
+          "include": {
+            "unit": ["First Order Stormtroopers"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804930752354/251CAAD6FBAED5982A2DE07F97E73DAC15AA9B0F/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804930752683/A8A5605318AA4D5D0E86706390784598DFE8E1D9/"
+        }
+      },
+      {
+        "name": "First Order Executioner",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081370859/0CC06F999D1152E6D2591DC70C58F75D70310DAC/",
+        "points": 24,
+        "restrictions": {
+          "include": {
+            "unit": ["First Order Stormtroopers"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804931312746/A2A7E0ED462A3CC61067CD54DD75FE3EDB6FBB96/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804931312990/768DB3CC7A9A7C481E90874F6D0EBA7B76830145/"
+        }
+      },
+      {
+        "name": "First Order Flametrooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081363087/EACBFEE7B2FAB08DAA79F044AA8933BB6B2C7000/",
+        "points": 22,
+        "restrictions": {
+          "include": {
+            "unit": ["First Order Stormtroopers"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804930743225/47AC918E4F8214D21DFA7F41A1BFDC7DDC03AEC0/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804930743458/9AE62864563BECCC50045802E4B9F010B9C34098/"
+        }
+      },
+      {
+        "name": "G125 Projectile Trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081230342/5DB2636553D599B55D5642F3235445BC77C6BFEA/",
+        "points": 34,
+        "restrictions": {
+          "include": {
+            "unit": ["Jet Troopers"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021698013227867905/C5D8EACB94ED7499B8B9396A430BE3E3B0074D3D/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021698013227868129/0C5AB5D1F2332F71B7DFCD4F74272056F8D4A82A/"
+        }
+      },
+      {
+        "name": "Gi/9 Cannon Hired Gun",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742003564/A822E18141D6C082B017F73378B458F77F1685EF/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138166568/ED8EA2877D68277418CD413C22E7298490A0E88A/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138166740/961EBEFD298B956494AD8C52FAE4089A66129240/"
+        },
+        "points": 22,
+        "restrictions": {
+          "include": {
+            "unit": ["Hired Guns"]
+          }
+        }
+      },
+      {
+        "name": "Heavy Blaster Cannon Gunner",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640736281792/283829A6193016BD5AF9264D1E90D59D07D7125A/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696515357847983/815BAE46D59A5AE4EE98449FF47A9F4E1F5FF4F7/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696515357848221/4A5E3289B5C619501C33A169426DCEEE5F31C670/"
+        },
+        "points": 34,
+        "restrictions": {
+          "include": {
+            "unit": ["Death Watch Fireteam"]
+          }
+        }
+      },
+      {
+        "name": "Hutt Cartel lieutenant",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741194306/575F31C4867CAD2378D7FC8C57B97BE1BC7168C2/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132349796/F0D00662C6C5F6DC99EA86808B428D1A13E5F062/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132349987/DE29CB1DE563DCFE69E72C45F89F7BA994DA9599/"
+        },
+        "leader": true,
+        "points": 26,
+        "restrictions": {
+          "include": {
+            "unit": ["Hutt Cartel Troopers"]
+          }
+        }
+      },
+      {
+        "name": "Hyperstorm Heavy Cannon Gunner",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277928814/8CB3DD46BE7B2AFC9558DF5180F6FD6DAB46EFAE/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824477681557142/6A6BB38909200F986FCC00C6ED6D09B055D780BE/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824477681557325/B9CACA9DF2EB9B7AAC473686F3E8597B000E1387/"
+        },
+        "points": 32,
+        "restrictions": {
+          "include": {
+            "unit": ["Sith Empire Support Troopers"]
+          }
+        }
+      },
+      {
+        "name": "IQA-11 Sniper Droid",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742382638/9E6E5FD638CB2D2304CD6621F66CA7E1529785FC/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407432785196/AFC423350DB19E06E25D2B7B67DF95CA3323FBEF/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432781824/644CE23A0B74C79BF20698A408FCF00D319EA7BE/"
+        },
+        "points": 32,
+        "restrictions": {
+          "include": {
+            "unit": ["IG-86 Sentinel Droids"]
+          }
+        }
+      },
+      {
+        "name": "Jannah",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1022821770986743715/2D901A3B93E61AA15B16922B7C314BFE18FE079B/",
+        "points": 65,
+        "restrictions": {
+          "include": {
+            "unit": ["Orbak Riders"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770976479474/71199B4B530A5D511E21B37E7AAE4D28AEF8F799/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770976479691/41E9EEF26B5B57FE44F5ED0C4B2912F09827F465/"
+        }
+      },
+      {
+        "name": "Kronos-327",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742383051/E35635E0213C5BF6D3DECFF3DEBAEB53385737AE/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407432807943/6854E55A0F61C5DE97189B6CAC90202E6BC1F622/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407432805568/E1F93A35700D25A3C33BA87AD4D64514795D6FDE/"
+        },
+        "leader": true,
+        "points": 34,
+        "restrictions": {
+          "include": {
+            "unit": ["IG-86 Sentinel Droids"]
+          }
+        }
+      },
+      {
+        "name": "M-45 Ion Fighter",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1017194020628455620/5C9E4D9872161408669629A2BD9455804F3BFBB7/",
+        "points": 27,
+        "restrictions": {
+          "include": {
+            "unit": ["Resistance Trench Fighters"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248443153/7D7FF98B537193A399A5974FF7CA73941E6D80AD/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248443360/6BD1A35DC4787C5086210BA1A0436B983B39B4CE/"
+        }
+      },
+      {
+        "name": "Mantellan Frontline Cannon Trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277928133/6CF94D4B6DA81B997D2E3BC9438CB8254F39BC0D/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1022824477681558249/5B7DA9706523B65997C0F39E0E3BCF6FA82F7628/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022824477681547387/758CB297CD1211353CBBC992035532A98F53893E/"
+        },
+        "points": 30,
+        "restrictions": {
+          "include": {
+            "unit": ["Sith Empire Support Troopers"]
+          }
+        }
+      },
+      {
+        "name": "Mercenary Assault Trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735114176/44B42375B5C11B5BADA3029FC1BF45BBCE56575C/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365878231/A04BECDA5804E0A38FF974528C70AB5AAAE4B715/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365878394/8AD2A611C51D78184D8E4204A720C59EEC2C7755/"
+        },
+        "points": 18,
+        "restrictions": {
+          "include": {
+            "unit": ["Mercenary Assault Squad"]
+          }
+        }
+      },
+      {
+        "name": "Modified E-5C Trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741194755/20A0EFE3551FB3F616037ECA2A6B085B32437E09/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132330046/E57A960285EF5FF9C8519B41BAF73C3AFE2E9910/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132330505/2C66A444F87C08CCD808F9EC32307C893552204A/"
+        },
+        "points": 24,
+        "restrictions": {
+          "include": {
+            "unit": ["Hutt Cartel Troopers"]
+          }
+        }
+      },
+      {
+        "name": "MPL-57 Ion Stormtrooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081352987/219CD748E9D94C081BC63179004FEAF74A821088/",
+        "points": 24,
+        "restrictions": {
+          "include": {
+            "unit": ["First Order Stormtroopers"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804930745597/D46A49EBCC75A7E442CE5B9B393880CAA55411EC/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804930745893/C3D0240348A1F44EB8D086D4AC626DCCFA1DB209/"
+        }
+      },
+      {
+        "name": "Orback Rider",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1022821770986745583/D188E40D6063DA1246C0DD94216E458C45B6FDE6/",
+        "points": 45,
+        "restrictions": {
+          "include": {
+            "unit": ["Orbak Riders"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770976472837/B6A4F9FAEAF8F6DC50A4EB8CE30D1D9D62CE1477/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770976472996/354C4EE85A60585BD0FB817AFEE21D00E93799BA/"
+        }
+      },
+      {
+        "name": "Ordnance launcher trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742001131/D2429556F4177E933131B739E7E038AA5546B250/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138167432/E485629FA5F7F44891F3DE6ECF6C0F8726AD1AE3/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138184470/30F29A14D05E0FF6A5153C51E7DFC770706D0119/"
+        },
+        "points": 27,
+        "restrictions": {
+          "include": {
+            "unit": ["Hired Guns"]
+          }
+        }
+      },
+      {
+        "name": "Proton Charge Commando",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277967164/198C348A7F75677615C77AC57C0229F6B0934D03/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024261154211/0A0578275AD73052B08D31C272B3AD066484EFEB/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260988667/8B8E27DFEDD6DEBA4EFABD6E738D3B6AC3E925AB/"
+        },
+        "points": 30,
+        "restrictions": {
+          "include": {
+            "unit": ["Sith Empire Boarding Troopers", "Imperial Commandos"]
+          }
+        },
+        "additionalObjects": ["Proton Charge Token"]
+      },
+      {
+        "name": "Rose Tico",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1021697620252778506/96583F29F6DDE41276C77D92C892C2DE8965A086/",
+        "leader": true,
+        "points": 28,
+        "restrictions": {
+          "include": {
+            "faction": ["Resistance"],
+            "rank": ["Corps"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697601906861807/C7CB31D9AFAFF6C7B2633663A2A33D939F4E8205/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697601906862116/99E8BDA93C81AD3875DFC214AA5E39DC4F5477A5/"
+        }
+      },
+      {
+        "name": "RSP-6 Paratrooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747551248/7EB35E562D1685283C46BCC74678C8B0573F68FE/",
+        "points": 29,
+        "restrictions": {
+          "include": {
+            "unit": ["Clone Paratroopers"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693415425547360/64A0DE5FC04770CADAEFA3F202A83EF0ACA1AABB/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
+        }
+      },
+      {
+        "name": "Salvaged T-21 Rider",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1022821770986744919/D39D941758BD3209F2D9F72B075DE5752FC2AD80/",
+        "points": 55,
+        "restrictions": {
+          "include": {
+            "unit": ["Orbak Riders"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821770976478775/74F36986A6C7597A92FB07CBD80D29430F2ADC0C/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821770976478988/8EA7C3063101B4163C223C1AA9D3FFD5196EED24/"
+        }
+      },
+      {
+        "name": "Sith Rifleman",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281908934/40B735C56C1C6EFF536F72A96FCB2E86EBA4D7B5/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933721582/A454C20F4D869C5BDCBB07E7DF297D3A97C518F1/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
+        },
+        "points": 20,
+        "restrictions": {
+          "include": {
+            "unit": ["Sith Troopers"]
+          }
+        }
+      },
+      {
+        "name": "Smart Rocket Trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081347253/3C29E016BF3A1401C14EE4B73127663E916A14F2/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817412080915363/ECDC62217B6E15167C6E1CCFD38F0FDA4E424C7A/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817412080915548/72D86514E3B30EBE60DFEF4D7E5EBE63FCFCD01B/"
+        },
+        "points": 28,
+        "restrictions": {
+          "include": {
+            "unit": ["First Order Stormtroopers"]
+          }
+        }
+      },
+      {
+        "name": "Stolen RPS-6 Trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738627942/4B5C5C7EE5C0A917920BC1ACD6D9BDC884C3F66F/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436116594/297A8181876F9899A0116189C171CB6DCF8F7E91/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436116780/2EDB6D1F02708B64292E99D8A6C1C2BA9772D6CD/"
+        },
+        "points": 25,
+        "restrictions": {
+          "include": {
+            "unit": ["Weequay Pirates"]
+          }
+        }
+      },
+      {
+        "name": "Tactial Shotgun Commando",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277958661/B7303152FFBCFF29BFD241865245D297469E6F17/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1007062024261155036/D5997D5F703F00DB00BB6C2CB1C92B0BB3E4B972/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007062024260988667/8B8E27DFEDD6DEBA4EFABD6E738D3B6AC3E925AB/"
+        },
+        "points": 30,
+        "restrictions": {
+          "include": {
+            "unit": ["Imperial Commandos"]
+          }
+        }
+      },
+      {
+        "name": "TL-50 Resistance Trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752980632/3AC1DF926A9DF195B85993DE03C1BA837FF12038/",
+        "points": 26,
+        "restrictions": {
+          "include": {
+            "unit": ["Resistance Troopers"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324582151739582/7B71E9B3E009D0CE72542DCE4EE88F80A15975F1/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324582151739873/59E17839EF9DE940D822E980A6B8D17EAF323009/"
+        }
+      },
+      {
+        "name": "TL-50 Stormtrooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751871157/BC6D8D82C13ED515680AE0748BCBF8BBA1967D52/",
+        "points": 28,
+        "restrictions": {
+          "include": {
+            "unit": ["Stormtroopers"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324932748013140/6A82D4809AA884C3F5786210898CE813BC9789F9/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324932748013349/A449441B895CE926D13CE9D1501BFC9B12A08A9D/"
+        }
+      },
+      {
+        "name": "Trandoshan Blaster Trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738629805/EEDC0DDF8D9737D6CFFDBAAEDDF73C2BC39DC9AF/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436115961/DBF66375F8D2143292D9BBDC3F6FF6AB46D7AB16/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112372/F530C8FD39C7DAC7766DF00F0087A82E8044DE0D/"
+        },
+        "points": 27,
+        "restrictions": {
+          "include": {
+            "unit": ["Weequay Pirates"]
+          }
+        }
+      },
+      {
+        "name": "Vibro-arbir Blade Guard",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081435867/C1A0F6BB89AB4B4C2C2857491FFD840AA82AFFA6/",
+        "points": 25,
+        "restrictions": {
+          "include": {
+            "unit": ["Elite Praetorian Guards"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1862817957003763616/5D2007C0F4115E9406A2A83D98E4D4D3275E168F/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1862817957003763776/D3F6005987B0D827683E0B7EB3E482E8D5213424/"
+        }
+      },
+      {
+        "name": "Riot Control Trooper (Offensive)",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081343404/198C195A7C6538264754E6ED65810E699941909B/",
+        "flip": {
+          "name": "Riot Control Trooper (Defensive)",
+          "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081343586/AFEAA0E712AC4720D360E2A44E8DD5DCC5AD2F3E/"
+        },
+        "points": 22,
+        "restrictions": {
+          "include": {
+            "unit": ["First Order Stormtroopers"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324932747749076/BC0B7C898A646CCDFC518280A48B7C82EECB54B1/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324932747749244/7BD30A42AAF722FC4D005E08EC5EB2BCBD938E22/"
+        }
+      },
+      {
+        "name": "Z-6B Resistance Trooper ",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752971387/1606CD1A3BD10A2FAF39558C7B36597840920010/",
+        "points": 22,
+        "restrictions": {
+          "include": {
+            "unit": ["Resistance Troopers"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324932752944952/1207D0D12B5971CC86CDAC845AB9487AFB0913E2/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324932752945165/7BFD62143549CA0DC0C9FDF7A251A8546AFB50DD/"
+        }
+      },
+      {
+        "name": "Z-6 StormTrooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751870825/96353DB410957633EF3D108F2BC58D4F84EBEC7E/",
+        "points": 25,
+        "restrictions": {
+          "include": {
+            "unit": ["Stormtroopers"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324932748082014/050A615D4A688CAF04806338E172186E1BEE93F5/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324932748082306/B60EBE5BB730F9B03EC541DDF15993BADBE2820F/"
+        }
+      }
+    ],
+    "Illicit": [
+      {
+        "name": "Black Market Weapon Modifications",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735317485/24DDC0FD309F0F75C04559832E888C0ED6E52CB1/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "type": ["Trooper"]
+          }
+        }
+      },
+      {
+        "name": "Black sun Assault mod",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742527952/354B544F4AB6ED4EA8FE90895DA7E62CC6D9DED9/",
+        "points": 5,
+        "restrictions": {
+          "include": {
+            "unit": ["EWHB-12 Heavy Blaster team"]
+          }
+        }
+      },
+      {
+        "name": "Ewok Bomb",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741833695/4345404F4A2F9E97DC140024285F113A8DDEAAE9/",
+        "points": 22,
+        "restrictions": {
+          "include": {
+            "unit": ["Beast Master"]
+          }
+        },
+        "additionalObjects": ["Proton Charge Token"]
+      },
+      {
+        "name": "Glitterstim",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735317047/31F1D322D5E1C986DFB20E582590653A0B0CAF7F/",
+        "points": 5,
+        "restrictions": {
+          "include": {
+            "type": ["Trooper"]
+          }
+        }
+      },
+      {
+        "name": "Inspiring Monologue",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738474691/8D852B6879C8FF5C5F0A2883FC9A204FB8937979/",
+        "points": 5,
+        "restrictions": {
+          "include": {
+            "unit": ["Hondo Ohnaka"]
+          }
+        }
+      },
+      {
+        "name": "Lord of Pirates",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738474167/126CF97710D8C7F9BDFBB16BF051B1F8660C7263/",
+        "points": 15,
+        "restrictions": {
+          "include": {
+            "unit": ["Hondo Ohnaka"]
+          }
+        }
+      },
+      {
+        "name": "Outer Rim Modifications",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735317893/3A2F6E60B2980B2608C4DA9B029E1C4B2F257560/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "type": ["Droid Trooper", "Ground Vehicle", "Repulsor Vehicle"]
+          }
+        }
+      },
+      {
+        "name": "Personal Shield",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735181899/208D960208099BDF4461E2E09204169FF959FC52/",
+        "points": 8,
+        "restrictions": {
+          "include": {
+            "type": ["Trooper"]
+          }
+        }
+      },
+      {
+        "name": "Piercing Dart",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640417521/8FE5D7BA77D3E25ED3FB812B261AD3E3DD88EF10/",
+        "points": 6,
+        "restrictions": {
+          "include": {
+            "type": ["Mandalorian Trooper"]
+          }
+        }
+      },
+      {
+        "name": "Pirate Retrofit",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742527540/AA9771542B3B0F58F1D813AE833F6E230163C361/",
+        "points": 5,
+        "restrictions": {
+          "include": {
+            "unit": ["EWHB-12 Heavy Blaster team"]
+          }
+        }
+      },
+      {
+        "name": "Poison Dart",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640416768/843BE27BBC497AC58846ED0295BFC661E391BEDF/",
+        "points": 6,
+        "restrictions": {
+          "include": {
+            "type": ["Mandalorian Trooper"]
+          }
+        }
+      },
+      {
+        "name": "Rancor Tamer",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741834052/EE3F163A5E5986958BCE4A45AD91F861EB85459F/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "unit": ["Beast Master"]
+          }
+        }
+      },
+      {
+        "name": "Reputation of the Hutts",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741312392/906B601379C476DB20B6997F64A1B29916A421DB/",
+        "points": 7,
+        "restrictions": {
+          "include": {
+            "unit": ["Jabba The Hutt"]
+          }
+        }
+      },
+      {
+        "name": "Self-Destruct Sequencing",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735318468/FF453A532280D1626623E10338ED5D288FA47B6E/",
+        "points": 5,
+        "restrictions": {
+          "include": {
+            "type": ["Droid Trooper", "Ground Vehicle", "Repulsor Vehicle"]
+          }
+        }
+      },
+      {
+        "name": "Stimpack",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735182732/C3B2C7FA3F05FC71D5C3ED089A8037A92171A103/",
+        "points": 5,
+        "restrictions": {
+          "include": {
+            "type": ["Trooper"]
+          }
+        }
+      },
+      {
+        "name": "Wrist Mounted Disintegrator",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640426484/CAA3EE923F691577E92958B5BAA38AB8221EDF61/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "type": ["Mandalorian Trooper"]
+          }
+        }
+      },
+      {
+        "name": "Wrist Mounted Disruptor",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640427887/A13950D10FE563732533E3C91584E465D47F05F5/",
+        "points": 3,
+        "restrictions": {
+          "include": {
+            "type": ["Mandalorian Trooper"]
+          }
+        }
+      },
+      {
+        "name": "Wrist Mounted Slugthrower",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640413367/65913371690794787832DA2D5D970C42E484A5E0/",
+        "points": 6,
+        "restrictions": {
+          "include": {
+            "type": ["Mandalorian Trooper"]
+          }
+        }
+      },
+      {
+        "name": "Ysalamiri cage",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741834581/FDBF31BD0BD3997D1415E1409F8C4A82744019D9/",
+        "points": 8,
+        "restrictions": {
+          "include": {
+            "unit": ["Beast Master"]
+          }
+        }
+      }
+    ],
+    "Ordnance": [
+      {
+        "name": "Bunker Buster Missiles",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751975579/6613DFBE1168370B4DB2AA3BAC7CCDC8F2B1EEDD/",
+        "points": 5,
+        "restrictions": {
+          "include": {
+            "unit": ["Phase II Darktroopers"]
+          }
+        }
+      },
+      {
+        "name": "Carbonite Missiles",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638969743/EEA573B6F2E054B13E3A220888FFDC03906CA74C/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "unit": ["Missile Attack Launcher"]
+          }
+        }
+      },
+      {
+        "name": "Sabot Missiles",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751975146/7766942C8563D444E253FC2262E6E7DDE1A95F00/",
+        "points": 5,
+        "restrictions": {
+          "include": {
+            "unit": ["Phase II Darktroopers"]
+          }
+        }
+      },
+      {
+        "name": "Shrapnel Missiles",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751975982/EBFAC7D348F41D8A319B15EAF27ADF6F443DD56C/",
+        "points": 5,
+        "restrictions": {
+          "include": {
+            "unit": ["Phase II Darktroopers"]
+          }
+        }
+      }
+    ],
+    "Personnel": [
+      {
+        "name": "Clone Paratrooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747552501/731105BAC6B5011092706B93C5853B6B51317D55/",
+        "points": 16,
+        "restrictions": {
+          "include": {
+            "unit": ["Clone Paratroopers"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693290507042014/A16ED28591E7E27887C7BC119152B6AD889BFF9E/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693290506789283/9EBB8D09E13819F8402026EC807781965A37310A/"
+        }
+      },
+      {
+        "name": "Extra Grenadier",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735129141/9805A2223DB725582E8105414121E4505895193F/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696642365824294/5F43B720E0198A078E25BA472E7DDBCA8F51CBEC/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696642365824481/27693FC709ADF50440623C6347A11151608D5E2F/"
+        },
+        "points": 11,
+
+        "restrictions": {
+          "include": {
+            "unit": ["Grenadier Squad"]
+          }
+        }
+      },
+      {
+        "name": "First Order Officer",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081395449/B2459EAD6D5B9FCF46951EF77CC2BCBF23370C10/",
+        "points": 22,
+        "leader": true,
+        "restrictions": {
+          "include": {
+            "faction": ["First Order"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1022821664192111404/0E625C7A4614D3BE5DF4DF9D78BA558C2B78803C/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1022821664192111727/770A7C77419D31361A4E7DF14655D4339B5333BE/"
+        }
+      },
+      {
+        "name": "First Order Stormtrooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081340137/E2C8E810E5F4D2F842F4B633A9EF4E633317B5AC/",
+        "points": 12,
+        "restrictions": {
+          "include": {
+            "unit": ["First Order Stormtroopers"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804926507457/5178F7589B3E8647E3FBFDE3C3C0829F284FA23D/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804926496614/9FECECAF48C7046C3714B33C4C16FFB773FCC94C/"
+        }
+      },
+      {
+        "name": "First Order Stormtrooper Officer",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081357391/65AB363DC36732A59EF1CF526B1C236F54F63C87/",
+        "points": 15,
+        "leader": true,
+        "restrictions": {
+          "include": {
+            "unit": ["First Order Stormtroopers"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324804930715422/16120934F642C553591C4773C4F9E4B21F167A52/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324804930715848/CC1157E547C67A4FD8CF56868BFCD9EF3A04075D/"
+        }
+      },
+      {
+        "name": "Forward Observer",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735128538/8947A618AAA4A4A0D92B3C7C12E651A494FDEDA7/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696984835690936/3C42012D036A5F420DD9ADD158E66901AB4A5671/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696984835691208/1C0C86466F3298E9663CEE3961B7F3F6DBED4DD9/"
+        },
+        "points": 17,
+        "restrictions": {
+          "include": {
+            "unit": ["Grenadier Squad"]
+          }
+        }
+      },
+      {
+        "name": "General Caluan Emmat",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1021697756245233178/36866FDE340064CDE02A6C0BB423EA8CAD2B1ABC/",
+        "points": 20,
+        "leader": true,
+        "restrictions": {
+          "include": {
+            "faction": ["Resistance"],
+            "rank": ["Corps"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248463256/9A71FCC63F00BFF1B30323727AE4ECE40A797845/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248457898/6A102129E4F692F04E02D1269F913A4D22B22FBC/"
+        }
+      },
+      {
+        "name": "Geonosian Warrior",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746955018/3E851672C18FC4978BF8E7D82D3BB6E0D4433A9D/",
+        "points": 12,
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1028455893317940526/D1A4E66DAA988ABE66C6D0014DD6D49047AA6697/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1028455893317930470/4A9F58F7B8BC80AF279695655E38DD81A9236057/"
+        },
+        "restrictions": {
+          "include": {
+            "unit": ["Geonosian Warriors"]
+          }
+        }
+      },
+      {
+        "name": "Hired Gun",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742004196/087F0B1F89E7E79E87461EE5D2661B2585C52D4A/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231138165871/C51E95633C934897949CFF29D8F9BCE471BF8FFA/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231138166035/1BA43B16941621DB32750B2B3CDD35053996ABA9/"
+        },
+        "points": 9,
+        "restrictions": {
+          "include": {
+            "unit": ["Hired Guns"]
+          }
+        }
+      },
+      {
+        "name": "Hutt Cartel Sentry",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738629292/FE183D473B13C247AC36F6DD253B934B09655B34/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436124726/C43B4DBB33AABF8482E19400E53948B5ED032CCB/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436124875/9CB0C0F06DD8F10B227161EE26DD1B55F8F5BDD4/"
+        },
+        "leader": true,
+        "points": 23,
+        "restrictions": {
+          "include": {
+            "unit": ["Weequay Pirates"]
+          }
+        }
+      },
+      {
+        "name": "Hutt Cartel Trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741193921/7F0C6BE42AE860AB77EB6C2BC779788371FE78B7/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697231132329491/14A83C22F3313876B13BB0A0016C687ED2E77D44/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697231132233662/46758BE4190670991AEEB84884D2C0926704577E/"
+        },
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "unit": ["Hutt Cartel Troopers"]
+          }
+        }
+      },
+      {
+        "name": "Imperial Supercommando",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640751939006/CBC6F2FE8C1DF0F75561DAE45F1F721222BF52FB/",
+        "points": 23,
+        "restrictions": {
+          "include": {
+            "unit": ["Imperial Supercommandos"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021696737982276859/C65AD83F5B3BE7D8787B3F0DC71C3637F257CF58/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021696737982273931/809947D430BEB447CD2FA3E99DD31AF57C3E8F84/"
+        }
+      },
+      {
+        "name": "Paratrooper Medic",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747553122/09BE4CDAF6D1A40AED895C9DAC9B03EECA17E46A/",
+        "points": 29,
+        "restrictions": {
+          "include": {
+            "unit": ["Clone Paratroopers"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1012693415425401629/49D60D4EE5794A206AF8F604A68F58979CFEBC42/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012693415425408778/BD84B4C5CAA84DDA6302739AD749CD29B1C39669/"
+        }
+      },
+      {
+        "name": "Resistance Trench Fighter",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1017194020628451982/E73E545FCA80240A75FBE0988782C8014F891577/",
+        "points": 13,
+        "restrictions": {
+          "include": {
+            "faction": ["Resistance Trench Fighters"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697756248442551/9D7BC64B0ECFEA79E16E695F4823085745EA8C51/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697756248440578/125E76600442E01E3AD18725563EA1BE4D63BEFA/"
+        }
+      },
+      {
+        "name": "Resistance Trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1027324932752970508/02879490220A6F3BD0B3B501770CE6567C152BD1/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "unit": ["Resistance Troopers"]
+          }
+        },
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1027324582151467148/595A4E7837AB3D12604D3A2858D08496E4FCBEA5/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1027324582151467561/892B00728A9164598F3FBE91C0D7C0F8619FCB20/"
+        }
+      },
+      {
+        "name": "Sith Empire Boarding Trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277786308/E222A61B5021B9FC2E56A8A957633B8BD2384CDB/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608884994661/01F7CD51333718A8A814885CF5A93B2A84651652/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608884994960/C45BA65336571270F7ABFDB147D8696B7D93138D/"
+        },
+        "points": 12,
+        "restrictions": {
+          "include": {
+            "unit": ["Sith Empire Boarding Troopers"]
+          }
+        }
+      },
+      {
+        "name": "Sith Empire Trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277742848/35DD1780CE5A8F446954CC178C0C05089A10B21B/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608878992636/D833E26E44A7763FAEFBE2430390376F9160E931/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608878877171/C209E7E6493A8465F8FD60DE6566AA6BA2C745ED/"
+        },
+        "points": 11,
+        "restrictions": {
+          "include": {
+            "unit": ["Sith Empire Troopers"]
+          }
+        }
+      },
+      {
+        "name": "Sith Sorcerer",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278055781/ED051F07880B0030B6DE21C04E01E640FEAD93C2/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061823163250038/32C72D2D0F766BFD34626E6A8944954C50CC0D77/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061823163250299/7A3E3550E4630C1BF03CF91847C63638AB684434/"
+        },
+        "points": 35,
+        "restrictions": {
+          "include": {
+            "unit": ["Sith Acolytes"]
+          }
+        }
+      },
+      {
+        "name": "Sith Trooper",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479281908575/338762E958A0C98B0AB49C47AA6A715893E4548B/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1012692039933703057/89125C10F7477148926E221D7D01FC48B49D2502/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1012692039933490257/46C7CB2E2B2537203D15FFD1EE0924E16455E4FA/"
+        },
+        "points": 11,
+        "restrictions": {
+          "include": {
+            "unit": ["Sith Troopers"]
+          }
+        }
+      },
+      {
+        "name": "Sith Warrior",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278056315/1665856EDAB96AF7A8C172511E6599CD901D4E71/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608885796271/427E4FBA584A22712C84414761D3EEBB1AE714E7/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608885695776/F5A3AA78554B8F3CB86314E552D94D65C0080F0C/"
+        },
+        "points": 35,
+        "restrictions": {
+          "include": {
+            "unit": ["Sith Acolytes"]
+          }
+        }
+      },
+      {
+        "name": "Veteran Sergeant",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479277744958/3610B8D3EB6E459B5BF3C7F97B0E7B2B9AA4CBE1/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1007061608881242939/0D60224C8880F4609ADFC4B901EC92EEA545B235/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1007061608881243790/F0D722D6703135FDF3BB2B7F3105FCAA49DB5284/"
+        },
+        "leader": true,
+        "points": 25,
+        "restrictions": {
+          "include": {
+            "unit": ["Sith Empire Troopers"]
+          }
+        }
+      },
+      {
+        "name": "Weequay Pirate",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640738628849/92249CF6F8DC12990B7073346AEF4DE3F3C5BB43/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/1021697407436114050/3985CF5B2D5C91AEF263706C20E4C84D7401F1BE/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/1021697407436112951/28554A829163EDA67DDE90D1CF137C093FF8A9AC/"
+        },
+        "points": 11,
+        "restrictions": {
+          "include": {
+            "unit": ["Weequay Pirates"]
+          }
+        }
+      }
+    ],
+    "Pilot": [
+      {
+        "name": "Agent Terex",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081428303/9A5F8BEFCF2B962CAD2849472B5123723578E868/",
+        "points": 15,
+        "restrictions": {
+          "include": {
+            "faction": ["First Order"],
+            "type": ["Repulsor Vehicle"]
+          }
+        }
+      },
+      {
+        "name": "Defoliator Lok Durd",
+        "displayName": "Lok Durd",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743617101/58D618F0C66FFCDC5FEBF39BC32D54D6BA55EB30/",
+        "points": 9,
+        "restrictions": {
+          "include": {
+            "unit": ["Defoliator Deployment Tank"]
+          }
+        }
+      },
+      {
+        "name": "Defoliator T-Series Tactical Droid Pilot",
+        "displayName": "T-Series Tactical Droid Pilot",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743616760/DF7B027C96C111F6170C6DD30E32DC1FBBE08AEE/",
+        "points": 5,
+        "restrictions": {
+          "include": {
+            "unit": ["Defoliator Deployment Tank"]
+          }
+        }
+      },
+      {
+        "name": "Excitable Pirate",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743063563/DECCDDEB113FF6F7E278657E96EB142AEE9690B7/",
+        "points": 15,
+        "restrictions": {
+          "include": {
+            "unit": ["WLO-5 Battle Tank"]
+          }
+        }
+      },
+      {
+        "name": "Hawkeye",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747619367/B0EFDF7F817DC850C3A28D1CD885213958C2248E/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "unit": ["LA-AT/I Gunship"]
+          }
+        }
+      },
+      {
+        "name": "Hutt Cartel Pilot",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640743063098/6FA89F40EA19F2FA891BD06D60B6DC06539C1212/",
+        "points": 15,
+        "restrictions": {
+          "include": {
+            "unit": ["WLO-5 Battle Tank"]
+          }
+        }
+      },
+      {
+        "name": "Commander Malarus",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081428804/85C88660A6344BDA309990BD1BCA5254EB26D6FE/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "faction": ["First Order"],
+            "rank": ["Heavy"]
+          }
+        }
+      },
+      {
+        "name": "Nightsister Rider",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640742458550/DA4B94232A6C585F9052738F990C70095E579256/",
+        "points": 30,
+        "restrictions": {
+          "include": {
+            "unit": ["Rancor"]
+          }
+        }
+      },
+      {
+        "name": "Oddball",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747618963/6FE86EFBC23C8FDFDB87FBE066C60CBD32FF1DFE/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "unit": ["LA-AT/I Gunship"]
+          }
+        }
+      },
+      {
+        "name": "Pirate Hotshot",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556639096066/A06D6ABDA4E9B1B1F2A63187D6B24F13D5D283A5/",
+        "points": 15,
+        "restrictions": {
+          "include": {
+            "unit": ["Canderous Class Assault Tank"]
+          }
+        }
+      },
+      {
+        "name": "Pirate Speed Freak",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556639095451/373D5F83FB4E8F4D3223A3CAD3E6A8E661FAAC2F/",
+        "points": 8,
+        "restrictions": {
+          "include": {
+            "unit": ["Canderous Class Assault Tank"]
+          }
+        }
+      },
+      {
+        "name": "Rose Tico",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1021697620252778721/621B535E20B29F253B38AD3548C986EE0DB42CCF/",
+        "points": 8,
+        "restrictions": {
+          "include": {
+            "faction": ["Resistance"]
+          }
+        }
+      },
+      {
+        "name": "Veteran Gunner",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747586823/256792792FFE8D876759E9A894F76F489BFDE968/",
+        "points": 6,
+        "restrictions": {
+          "include": {
+            "unit": ["AT-AP"]
+          }
+        }
+      },
+      {
+        "name": "Veteran Mechanic",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556638970650/AE724920A75FF2F1D840AC3DE707166D67EA0323/",
+        "points": 8,
+        "restrictions": {
+          "include": {
+            "unit": ["Missile Attack Launcher"]
+          }
+        }
+      },
+      {
+        "name": "Veteran Tank Pilot",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556639094597/6678DD776757AAFAFA216FB7538DA7BC35147757/",
+        "points": 5,
+        "restrictions": {
+          "include": {
+            "unit": ["Canderous Class Assault Tank"]
+          }
+        }
+      },
+      {
+        "name": "Warthog",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747618630/E00C8B7A4F81CCD6F2A12747031B7D62D05857E3/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "unit": ["LA-AT/I Gunship"]
+          }
+        }
+      }
+    ],
+    "Relic": [
+      {
+        "name": "Sith Holocron",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747372001/0447B19DFCA692F5AC2D176A7C6C7A1CB53A156B/",
+        "points": 15
+      }
+    ],
+    "Programming": [
+      {
+        "name": "Blitz Programming",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412069009833/BCC52828E3F19620E57D60244623D8A3E5C94135/",
+        "points": 12,
+        "restrictions": {
+          "include": {
+            "unit": ["SD-4K Assassin Droid"]
+          }
+        }
+      },
+      {
+        "name": "Stealth Programming",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412069009272/8CD2CDD81193F051285BF5B44FD7B45AE80FC4B6/",
+        "points": 18,
+        "restrictions": {
+          "include": {
+            "unit": ["SD-4K Assassin Droid"]
+          }
+        }
+      }
+    ],
+    "Training": [
+      {
+        "name": "Advanced Assault Training",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640415256/3E0DA25CB2B44F7093E46DADA1965C0DBD3C703A/",
+        "points": 5,
+        "restrictions": {
+          "include": {
+            "type": ["Mandalorian Trooper"]
+          }
+        }
+      },
+      {
+        "name": "Blend In",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735182379/DD072454059CA2BB5CB206848D0BCBF656F494F9/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "faction": ["Scum"],
+            "rank": ["Commander", "Operative", "Special Forces"]
+          }
+        }
+      },
+      {
+        "name": "Brutality",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640741408425/6FED2B70FD2FCEFC6A1A8249888003F3C9798118/",
+        "points": 10
+      },
+      {
+        "name": "Conditioning",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081410188/2D437F005CAE9C5E11B19E2A59D5CB24D58CDB28/",
+        "points": 5,
+        "restrictions": {
+          "include": {
+            "faction": ["First Order"],
+            "rank": ["Corps", "Special Forces"]
+          }
+        }
+      },
+      {
+        "name": "Conditioning ",
+        "displayName": "Conditioning",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1862817412081410188/2D437F005CAE9C5E11B19E2A59D5CB24D58CDB28/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "faction": ["First Order"],
+            "rank": ["Commander", "Operative", "Support", "Heavy"]
+          }
+        }
+      },
+      {
+        "name": "Disarming Slash",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747373016/011CE3497BCC2229C114CDBF69464D3FB6E16B26/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "slot": ["Force"]
+          }
+        }
+      },
+      {
+        "name": "Hasty Exit",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640747373759/AF9520B70176F54DCB2B098735D1D3F468E9F442/",
+        "points": 3
+      },
+      {
+        "name": "Faithful Companion",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738505735164302/4C5E96A3397E6BD2F8C07A61AA9B25FDC0D8C031/",
+        "points": 8,
+        "restrictions": {
+          "include": {
+            "unit": ["Beast Master", "Silri"]
+          }
+        }
+      },
+      {
+        "name": "Geonosian Brain Worms",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738640746957609/4564866DD4465ADC1224AC20C8A82A2895D19FE9/",
+        "points": 0,
+        "restrictions": {
+          "include": {
+            "unit": ["Geonosian Warriors"]
+          }
+        }
+      },
+      {
+        "name": "Rising Phoenix Training",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1638738556640409422/F8AF40A8E8F4C87CA364A0ADADA7281F20F8F0D7/",
+        "points": 10,
+        "restrictions": {
+          "include": {
+            "type": ["Mandalorian Trooper"]
+          }
+        }
+      }
+    ]
+  },
+  "commands": {
+    "Sith Empire": [
+      {
+        "name": "Oppressive Tactics",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278110637/7EF1FEF7DCEB65C84A89E72110F107932A7CE783/",
+        "pip": 1
+      },
+      {
+        "name": "Legacy of Vaiken",
+        "image": "http://cloud-3.steamusercontent.com/ugc/1776099479278110292/436DDD7EE789790446C0C4DB7F79A24843F7273A/",
+        "pip": 3
+      }
+    ]
+  },
+  "battlefield": {},
+  "objects": {}
+}


### PR DESCRIPTION
Added Operative unit "Calo Nord" to Revans Sith Empire
Added Armament upgrade "Vibroblade"
Added Gear upgrade "Calo Nord's Battle Armor"
Removed Hardpoint upgrade "Probe Killer Swarm"
Removed Pilot upgrade "Blitz Programming"
Removed Pilot upgrade "Stealth Programming"
Added Programming upgrade "Blitz Programming"
Added Programming upgrade "Stealth Programming"
Changed Support unit "SD-4K Assassin Droid" in Separatist
Added proton charge token spawning for "Proton Charge Commando", "Ewok Bomb", and "Detonite Charge Saboteur" upgrades
Updated card image for "125-Z Treadspeeder Bikers" unit card, adjusted point value to 85
Updated card images for "Bazine Natel" unit card and command cards, adjusted point value to 85
Updated card images for "Captain Phasma" unit card and command cards, adjusted point value to 95
Updated card image for "Quicksilver Baton"/"Chromium SE-44 Blaster", adjusted point value to 15
Added "Elite Praetorian Guards" unit to First Order Special Forces
Added "Electro-chain Whip Guard" and "Vibro-arbir Blade Guard" upgrades to Heavy Weapons
Added "First Order AT-ST" unit to First Order Heavy
Updated card images for "First Order Stormtroopers" unit cards and upgrade cards
Added "Smart Rocket Trooper" upgrade to Heavy Weapons
Added "Agent Terex" and "Commander Malarus" upgrades to Pilot
Updated "General Hux" unit and command cards, added flaw card
Updated "Jet Troopers" unit and upgrade cards
Updated "Kylo Ren" unit and command cards, added flaw card, adjusted point wavlue to 140
Updated "Light Infantry Utility Vehicle" unit and upgrade cards
Removed duplicate "D-93 Incinerator" and "FWMB-10 Megablaster" upgrades from crew
Updated "Disarming Slash" to include force slot restriction
Updated various card image links