### PR TITLE
Print position and rotation of unit leaders

### DIFF
--- a/mod/src/StarWarsLegion/Order_Token.a57c41.lua
+++ b/mod/src/StarWarsLegion/Order_Token.a57c41.lua
@@ -673,6 +673,7 @@ end
 
 function moveStart()
     local endPos = initPos
+    endPos.y = initPos.y + 2
     selectedUnitObj.setPositionSmooth(endPos, false, false)
     selectedUnitObj.setRotationSmooth(initRot, false, false)
     Wait.frames(function()

--- a/mod/src/StarWarsLegion/Order_Token.a57c41.lua
+++ b/mod/src/StarWarsLegion/Order_Token.a57c41.lua
@@ -1153,7 +1153,6 @@ function endActivation()
 end
 
 function resetActivation()
-    selectedUnitObj.call("printMovement")
     stopUnit()
     stopAttack()
     standby()

--- a/mod/src/StarWarsLegion/Order_Token.a57c41.lua
+++ b/mod/src/StarWarsLegion/Order_Token.a57c41.lua
@@ -36,6 +36,8 @@ function setTemplateVariables()
     unitData.buttonColor = templateInfo.buttonColor[unitData.selectedSpeed]
     unitData.fontColor = templateInfo.fontColor[unitData.selectedSpeed]
 end
+
+
 ------------------------------------------------- MATH FIND PROXIMITY------------------------------------------------------------
 function findProximity(targetObj, object)
     local objectPos = object.getPosition()
@@ -198,6 +200,8 @@ function activate()
     getSelectedUnitObjVariables()
     setTemplateVariables()
 
+    selectedUnitObj.call("setStartPos")
+
     highlightUnit(selectedUnitObj.getTable("miniGUIDs"),{0,1,0})
     highlightCard(getObjectFromGUID(selectedUnitObj.getVar("cardGUID")))
 
@@ -351,7 +355,6 @@ end
 
 ------------------------------------------------- NEXTUNIT ------------------------------------------------------------
 function nextUnit()
-
     local out = false
     local originalUnitNumber = selectedUnitNumber
     while out == false do
@@ -375,6 +378,7 @@ function nextUnit()
                 stopAttack()
                 selectedUnitObj = eligibleUnits[selectedUnitNumber]
 
+                selectedUnitObj.call("setStartPos")
                 highlightUnit(selectedUnitObj.getTable("miniGUIDs"),{0,1,0})
                 highlightCard(getObjectFromGUID(selectedUnitObj.getVar("cardGUID")))
                 getSelectedUnitObjVariables()
@@ -400,6 +404,7 @@ end
 function initMove()
     initPos = selectedUnitObj.getPosition()
     initRot = selectedUnitObj.getRotation()
+    selectedUnitObj.call("setStartPos")
     moveUnit()
 end
 
@@ -668,7 +673,6 @@ end
 
 function moveStart()
     local endPos = initPos
-    endPos.y = initPos.y + 2
     selectedUnitObj.setPositionSmooth(endPos, false, false)
     selectedUnitObj.setRotationSmooth(initRot, false, false)
     Wait.frames(function()
@@ -711,7 +715,8 @@ end
 ------------------------------------------------- stop UNIT ------------------------------------------------------------
 function stopUnit()
     -- destroy templates
-
+    selectedUnitObj.call("printMovement")
+    selectedUnitObj.call("setStartPos")
     self.clearButtons()
     clearTemplates()
     resetButtons()
@@ -1143,12 +1148,12 @@ end
 ------------------------------------------------- end UNIT ------------------------------------------------------------
 
 function endActivation()
-
     resetActivation()
     self.flip()
 end
 
 function resetActivation()
+    selectedUnitObj.call("printMovement")
     stopUnit()
     stopAttack()
     standby()

--- a/mod/src/StarWarsLegion/Order_Token.a57c41.lua
+++ b/mod/src/StarWarsLegion/Order_Token.a57c41.lua
@@ -36,8 +36,6 @@ function setTemplateVariables()
     unitData.buttonColor = templateInfo.buttonColor[unitData.selectedSpeed]
     unitData.fontColor = templateInfo.fontColor[unitData.selectedSpeed]
 end
-
-
 ------------------------------------------------- MATH FIND PROXIMITY------------------------------------------------------------
 function findProximity(targetObj, object)
     local objectPos = object.getPosition()

--- a/mod/src/StarWarsLegion/Unit_Leader.99f1c8.lua
+++ b/mod/src/StarWarsLegion/Unit_Leader.99f1c8.lua
@@ -15,6 +15,8 @@ function setUp()
     silhouetteState = false
     locks = {}
     lockState = false
+    startPosition = nil
+    startRotation = nil
 
     lockBtnGreen = {0.2, 0.9, 0.05, 0.7}
     lockBtnRed = {0.9, 0.1, 0.05, 0.7}
@@ -261,4 +263,29 @@ function dropCoroutine()
     return 1
 end
 
+
+function setStartPos()
+  startPosition = self.getPosition()
+  startRotation = self.getRotation()
+end
+
+function printMovement()
+  if startPosition == self.getPosition() and startRotation == self.getRotation() then
+    return
+  end
+  if startPosition ~= nil then
+    print(colorSide .. " " .. unitName .. " Moved From")
+    print("Position " .. coordToString(startPosition) .. " to " .. coordToString(self.getPosition()))
+    print("Rotation " .. coordToString(startRotation) .. " to " .. coordToString(self.getRotation()))
+  end
+end
+
+function coordToString(coord, rotation)
+  return "(X:" .. round(coord[1], 2) .. ", Y:" .. round(coord[2], 2) .. ", Z:" .. round(coord[3], 2) .. ")"
+end
+
+function round(num, numDecimalPlaces)
+  local mult = 10^(numDecimalPlaces or 0)
+  return math.floor(num * mult + 0.5) / mult
+end
 


### PR DESCRIPTION
Addresses issue #559 

If a unit leader is moved while active by an order token, when it 'stops' its movement through either stopping its activation or clicking 'Done' after moving, a print out will show the original position and its new position.

Example print out.
![image](https://user-images.githubusercontent.com/39471681/221402830-0e56d0bc-8b47-4ead-8dd7-54d9cc5d928d.png)

Notes
- values are rounded to 2 decimal places. There is a lot more precision available, but I thought this was a good compremise for readability. 
- I am not aware of a nicer format for unit names in the print out and I have yet looked for a way to include a number indicating which number unit it's for as shown in the issue