### PR TITLE
Fix 'A Beautiful Friendship' typo

### DIFF
--- a/contrib/cards/Rebel/RebelUnits.json
+++ b/contrib/cards/Rebel/RebelUnits.json
@@ -84,7 +84,7 @@
           "pip": 2
         },
         {
-          "name": "A Beautiful Friendsdhip",
+          "name": "A Beautiful Friendship",
           "image": "http://cloud-3.steamusercontent.com/ugc/2023850162090082691/D81307AA7C4530A264B8CBAA2012FCA9134EA9B4/",
           "pip": 2
         },


### PR DESCRIPTION
This will let current LHQ and TTA properly export the CC