### PR TITLE
Update GAR Commander and Operative Unit and Command Cards

### DIFF
--- a/contrib/cards/Empire/EmpireUnits.json
+++ b/contrib/cards/Empire/EmpireUnits.json
@@ -372,7 +372,7 @@
       },
       "minis": [
         {
-          "bundle": "http://cloud-3.steamusercontent.com/ugc/2058763770174720883/27A48880934C3B35AE42D5E62C73EA3A0ECA240B/"
+          "bundle": "https://steamusercontent-a.akamaihd.net/ugc/2456221571853672166/B86F663B609267644D837B4F18C59614C6785229/"
         }
       ],
       "commands": [
@@ -402,7 +402,7 @@
       },
       "minis": [
         {
-          "bundle": "http://cloud-3.steamusercontent.com/ugc/2058763770174720951/C4FC16B1ACE927ECF9F59C726DC59B8C6561FED8/"
+          "bundle": "https://steamusercontent-a.akamaihd.net/ugc/2446090001278329724/E8E229E0E3FB6230D9F5A1823C71032A0FC9F2D0/"
         }
       ],
       "commands": [
@@ -479,8 +479,7 @@
       },
       "minis": [
         {
-          "bundle": "http://cloud-3.steamusercontent.com/ugc/2017090166650141156/BF26D516EA8F33C72822FF9AB369FF7CA444C403/",
-          "secondary": "http://cloud-3.steamusercontent.com/ugc/2017090166650141746/A8FD77EB51C50C64CD924BDAEEDB70D8839E0EF3/"
+          "bundle": "https://steamusercontent-a.akamaihd.net/ugc/2478747809413608082/BD8A164AAD4C70AE2F8CB8165F3D2DC9FD94C778/"
         },
         {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/2017090166650141545/30BEFE4E87E379AA361AFF5FD24A8F5D3F0BA4C0/",

--- a/contrib/cards/Empire/EmpireUnits.json
+++ b/contrib/cards/Empire/EmpireUnits.json
@@ -3,7 +3,7 @@
     {
       "name": "Darth Vader",
       "title": "Dark Lord Of The Sith",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1860546411028298907/73DBC3CC95299DFD1BB13F25C811C77F7C7189C0/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135444419/726425B7C209349209399BDDB87B34BE0B4447AA/",
       "size": "small",
       "type": "Trooper",
       "points": 190,
@@ -20,17 +20,17 @@
       "commands": [
         {
           "name": "Implacable",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1860546411028299041/D4DC7516D17A04AC587D5F44D0CBDDFE2E3D22D5/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135444439/06F119390473A1CAA7F4785636130B4D857A61A8/",
           "pip": 1
         },
         {
           "name": "Vader's Might",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564035874/D411BF35A17D45663A7AE6DB04C4368F69B447EA/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135444550/33DB2D103378C35509E7FEE23A0ACD2BFEE8195E/",
           "pip": 1
         },
         {
           "name": "New Ways To Motivate Them",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564034988/4F888B0F1849EDDA47FA8B635075B011F56B967A/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135444510/952B5595A8E35BF7E2A0B51933DEC0A855D8EBAB/",
           "pip": 2
         },
         {
@@ -40,7 +40,7 @@
         },
         {
           "name": "Master Of Evil",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564033333/3BEA0BC9F2038200FFF56CDD8DA3C67808EB84E6/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135444481/AF8E308CE2EE310C787E53AA0BAC97471DC05621/",
           "pip": 3
         },
         {
@@ -71,73 +71,18 @@
       "commands": [
         {
           "name": "Maximum Firepower",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564036422/34C5A93E3C69A143EB6E537C1D984010996FDDF2/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135449935/27D7D687763686F54338BA5A2848E1B1A65C62A7/",
           "pip": 1
         },
         {
           "name": "Evasive Maneuvers",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564035477/69CEA53CB3D4B9ADDD22B28CA9BC9DDBADB3C706/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135449823/16F99AFAA1AD6647F0B47ED9FBF3EEDF2A034BFE/",
           "pip": 2
         },
         {
           "name": "Imperial Discipline",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564033490/3EB2A5666B5D911D173242DD948521DFC169FE22/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135449883/86FF6A857D6EBD4365D06547285401B3E3D4B79F/",
           "pip": 3
-        }
-      ]
-    },
-    {
-      "name": "Emperor Palpatine",
-      "title": "Ruler Of The Galactic Empire",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1683770969788701664/ABD12EEF236402EDF420F7849146DDEB367FC290/",
-      "size": "small",
-      "type": "Trooper",
-      "points": 190,
-      "speed": 1,
-      "upgrades": {
-        "Force": 3,
-        "Command": 1
-      },
-      "minis": [
-        {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/785234540541565714/71E1936EB657F4BC1074EB740BC9AA0531A130AC/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/785234540541565804/0EB3EBFD318678DBE5B7C83B39A31DC8AB3376B6/"
-        }
-      ],
-      "commands": [
-        {
-          "name": "And Now You Will Die",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564037110/8E3A2FB239539785945D116F85B21B481603690C/",
-          "pip": 1
-        },
-        {
-          "name": "Give In To Your Anger",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564035342/543139C6B87DC74DAA2C0A37E4519EF525E73E8E/",
-          "pip": 2
-        },
-        {
-          "name": "An Entire Legion",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564034291/4E6BD80297A517DC6C92B4874ED945A0171CADC2/",
-          "pip": 3
-        }
-      ]
-    },
-    {
-      "name": "Imperial Officer",
-      "title": "Ruthless Commander",
-      "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384862580/646BACE767C276F5BE4D3CE1DBD707B174491EAE/",
-      "size": "small",
-      "type": "Trooper",
-      "points": 55,
-      "speed": 2,
-      "upgrades": {
-        "Command": 1,
-        "Gear": 1
-      },
-      "minis": [
-        {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/785234540541565898/F06AB6731446249164D34ACA208E4FAE70C6FE00/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/785234540541566011/A7A84EBF79DA5E1D5BCE71E863FC16EC40937F6F/"
         }
       ]
     },
@@ -162,7 +107,7 @@
       "commands": [
         {
           "name": "Voracious Ambition",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564035835/61A0DCFF63E278C4BFE5FA84970D6C8A820647F4/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135450643/8B21E1AC56AE75D2204878EA62E65325AE365494/",
           "pip": 1
         },
         {
@@ -180,7 +125,7 @@
     {
       "name": "Iden Versio",
       "title": "Inferno Squad Leader",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1683770969788701556/6A3390D19B067EAACDF1CADD825D11BBE048DCEA/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135447992/97B7DD726FEB2C4811A53FE5B68FB430713FB9FD/",
       "size": "small",
       "type": "Trooper",
       "points": 100,
@@ -200,69 +145,30 @@
       "commands": [
         {
           "name": "Pulse Scan",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564036274/DF63072DBC71647215D98AC674EA8979DA3C2137/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135447957/DFC97CD26266A0F75601991E627A9A7D88D2DC26/",
           "pip": 1
         },
         {
           "name": "Concussive Blast",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564035579/49CC24C1F86F0BE2CD8324868E3EEFC1AE328E0C/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135447851/69B1F705930944BD26685CDCB3F7A52127D9BF25/",
           "pip": 2
         },
         {
           "name": "Incapacitate",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564035176/6E9CFBF7487DDE5D4940E64762EB72A7D68CE7A2/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135447917/9D2822AF6299DF22D89273129D1E7870430429DF/",
           "pip": 2
         },
         {
           "name": "Tactical Strike",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564032968/40A2C000893514EFDE161EBBF950160618A947DA/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135447971/CD83916F6A11CD5CE3D75CCACA9FA01C248FDF18/",
           "pip": 3
         }
       ]
     },
     {
-      "name": "Agent Kallus",
-      "title": "Hunter Of Spectres",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1683770969788701522/0198EDBE386830FA71A43C6887FD82E0CC28D241/",
-      "size": "small",
-      "type": "Trooper",
-      "points": 90,
-      "speed": 2,
-      "upgrades": {
-        "Command": 1,
-        "Training": 1,
-        "Gear": 1,
-        "Armament": 1,
-        "Flaw": 1
-      },
-      "minis": [
-        {
-          "bundle": "http://cloud-3.steamusercontent.com/ugc/2174736446809185920/1B6637756A8044A1D173F7AD5C1BFD813EC66CCA/"
-        }
-      ],
-      "commands": [
-        {
-          "name": "Face Me!",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564036719/80DA17B10B9444036EB57237E434E28C2B8D9D7F/",
-          "pip": 1
-        },
-        {
-          "name": "ISB Investigation",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564035240/AF545C5C697618B4891784AE68F39CBE906F3FB6/",
-          "pip": 2
-        },
-        {
-          "name": "Ruthless Tactics",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564033151/86AA97C5A365099681E54FA21C2B9D6F08519AB7/",
-          "pip": 3
-        }
-      ],
-      "required": ["Developing Sympathies"]
-    },
-    {
       "name": "Moff Gideon",
       "title": "Long Live the Empire",
-      "image": "http://cloud-3.steamusercontent.com/ugc/5070522239196907351/8433669F28D81BC5196DD4D7DEBE0782C64B8F01/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135445399/8AB358A896676499DDA9B176E90E39AEA6C36DB1/",
       "size": "small",
       "type": "Trooper",
       "points": 100,
@@ -281,12 +187,12 @@
       "commands": [
         {
           "name": "Die at My Hand",
-          "image": "http://cloud-3.steamusercontent.com/ugc/5070522239196907196/DBA2F1E68937EB87615A812B218D74E50E58A95E/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135445379/2E1BA2F22E9816B73C934205D77DDAB726F93D44/",
           "pip": 1
         },
         {
           "name": "You Have Something I Want",
-          "image": "http://cloud-3.steamusercontent.com/ugc/5070522239196907249/AC9853C05AC9350387E7CAE817F8F02A24A6BA5B/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135445472/1CCEC5B09B861DA2530A4F9C5548480F5B9CC7B8/",
           "pip": 2
         },
         {
@@ -366,7 +272,7 @@
     {
       "name": "Darth Vader",
       "title": "The Emperor's Apprentice",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1860546411028298844/F7434FFD1E2C0C0EF4F0AA4F5C6B5EA727CFEDFF/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135453126/1C9CAD022704D64F0B9139865DBEB8BCA11EBFA4/",
       "size": "small",
       "type": "Trooper",
       "points": 175,
@@ -384,17 +290,17 @@
       "commands": [
         {
           "name": "Implacable",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1860546411028299041/D4DC7516D17A04AC587D5F44D0CBDDFE2E3D22D5/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135444439/06F119390473A1CAA7F4785636130B4D857A61A8/",
           "pip": 1
         },
         {
           "name": "Vader's Might",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564035874/D411BF35A17D45663A7AE6DB04C4368F69B447EA/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135444550/33DB2D103378C35509E7FEE23A0ACD2BFEE8195E/",
           "pip": 1
         },
         {
           "name": "New Ways To Motivate Them",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564034988/4F888B0F1849EDDA47FA8B635075B011F56B967A/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135444510/952B5595A8E35BF7E2A0B51933DEC0A855D8EBAB/",
           "pip": 2
         },
         {
@@ -404,7 +310,7 @@
         },
         {
           "name": "Master Of Evil",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564033333/3BEA0BC9F2038200FFF56CDD8DA3C67808EB84E6/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135444481/AF8E308CE2EE310C787E53AA0BAC97471DC05621/",
           "pip": 3
         },
         {
@@ -521,6 +427,45 @@
           "pip": 3
         }
       ]
+    },
+    {
+      "name": "Agent Kallus",
+      "title": "Hunter Of Spectres",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135448854/CC65D752275214DB6D5791534DDEFF4784D6259E/",
+      "size": "small",
+      "type": "Trooper",
+      "points": 90,
+      "speed": 2,
+      "upgrades": {
+        "Command": 1,
+        "Training": 1,
+        "Gear": 1,
+        "Armament": 1,
+        "Flaw": 1
+      },
+      "minis": [
+        {
+          "bundle": "http://cloud-3.steamusercontent.com/ugc/2174736446809185920/1B6637756A8044A1D173F7AD5C1BFD813EC66CCA/"
+        }
+      ],
+      "commands": [
+        {
+          "name": "Face Me!",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135448798/AACA6ECCF1997BBEB2F5A054C4EC8B0D47C2D0C7/",
+          "pip": 1
+        },
+        {
+          "name": "ISB Investigation",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135448812/E8D9B9BDEB69B87FADD3E294851E7AFD6868EB42/",
+          "pip": 2
+        },
+        {
+          "name": "Ruthless Tactics",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135448839/F78FAA7976B9225D466E754C622758F60EE30D5F/",
+          "pip": 3
+        }
+      ],
+      "additionalObjects": ["Victory Token"]
     }
   ],
   "Corps": [

--- a/contrib/cards/Empire/EmpireUnits.json
+++ b/contrib/cards/Empire/EmpireUnits.json
@@ -482,16 +482,13 @@
           "bundle": "https://steamusercontent-a.akamaihd.net/ugc/2478747809413608082/BD8A164AAD4C70AE2F8CB8165F3D2DC9FD94C778/"
         },
         {
-          "bundle": "http://cloud-3.steamusercontent.com/ugc/2017090166650141545/30BEFE4E87E379AA361AFF5FD24A8F5D3F0BA4C0/",
-          "secondary": "http://cloud-3.steamusercontent.com/ugc/2017090166650141746/A8FD77EB51C50C64CD924BDAEEDB70D8839E0EF3/"
+          "bundle": "https://steamusercontent-a.akamaihd.net/ugc/2478747809407737751/27A207BFDA271D2EA267D400CBDF551B11EE093C/"
         },
         {
-          "bundle": "http://cloud-3.steamusercontent.com/ugc/2017090166650141624/1366A6A4D84D9FE597EEA2736AFC187F392418DA/",
-          "secondary": "http://cloud-3.steamusercontent.com/ugc/2017090166650141746/A8FD77EB51C50C64CD924BDAEEDB70D8839E0EF3/"
+          "bundle": "https://steamusercontent-a.akamaihd.net/ugc/2478747809407737751/27A207BFDA271D2EA267D400CBDF551B11EE093C/"
         },
         {
-          "bundle": "http://cloud-3.steamusercontent.com/ugc/2017090166650141692/8E06789B4D2003055108ED85D76E875729254757/",
-          "secondary": "http://cloud-3.steamusercontent.com/ugc/2017090166650141746/A8FD77EB51C50C64CD924BDAEEDB70D8839E0EF3/"
+          "bundle": "https://steamusercontent-a.akamaihd.net/ugc/2478747809407737751/27A207BFDA271D2EA267D400CBDF551B11EE093C/"
         }
       ]
     },

--- a/contrib/cards/Empire/EmpireUnits.json
+++ b/contrib/cards/Empire/EmpireUnits.json
@@ -353,43 +353,6 @@
       "additionalObjects": ["Victory Token"]
     },
     {
-      "name": "IG-11",
-      "title": "Nurse and Protect",
-      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137008859/81A3C1FCE76085D59EE6AC6B2D28D6114E0CFBA2/",
-      "size": "small",
-      "type": "Droid Trooper",
-      "points": 110,
-      "speed": 2,
-      "upgrades": {
-        "Training": 1,
-        "Comms": 1,
-        "Gear": 1
-      },
-      "minis": [
-        {
-          "bundle": "http://cloud-3.steamusercontent.com/ugc/1789640371719058670/9E6B82A0BF8367F2C6D369BD3464DA5E9D0C7917/"
-        }
-      ],
-      "commands": [
-        {
-          "name": "Mechanical Carnage",
-          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137016841/F2528C4F77766BC90F225B6BBB4D3A42BB0EB0C4/",
-          "pip": 1
-        },
-        {
-          "name": "A Machine Made For Killing",
-          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137016998/E6071BE8EDF0A20E6032D047B35D5EF5FC8B7182/",
-          "pip": 2
-        },
-        {
-          "name": "Anti-Capture Protocols",
-          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137016902/C3B4710D3F5ACD27D67CB51B0C6B4E6B229B9BD9/",
-          "pip": 3
-        }
-      ],
-      "additionalObjects": ["Victory Token"]
-    },
-    {
       "content": "contrib/cards/ShadowCollective/DinUnit.json"
     },
     {

--- a/contrib/cards/Empire/EmpireUnits.json
+++ b/contrib/cards/Empire/EmpireUnits.json
@@ -353,6 +353,43 @@
       "additionalObjects": ["Victory Token"]
     },
     {
+      "name": "IG-11",
+      "title": "Nurse and Protect",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137008859/81A3C1FCE76085D59EE6AC6B2D28D6114E0CFBA2/",
+      "size": "small",
+      "type": "Droid Trooper",
+      "points": 110,
+      "speed": 2,
+      "upgrades": {
+        "Training": 1,
+        "Comms": 1,
+        "Gear": 1
+      },
+      "minis": [
+        {
+          "bundle": "http://cloud-3.steamusercontent.com/ugc/1789640371719058670/9E6B82A0BF8367F2C6D369BD3464DA5E9D0C7917/"
+        }
+      ],
+      "commands": [
+        {
+          "name": "Mechanical Carnage",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137016841/F2528C4F77766BC90F225B6BBB4D3A42BB0EB0C4/",
+          "pip": 1
+        },
+        {
+          "name": "A Machine Made For Killing",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137016998/E6071BE8EDF0A20E6032D047B35D5EF5FC8B7182/",
+          "pip": 2
+        },
+        {
+          "name": "Anti-Capture Protocols",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137016902/C3B4710D3F5ACD27D67CB51B0C6B4E6B229B9BD9/",
+          "pip": 3
+        }
+      ],
+      "additionalObjects": ["Victory Token"]
+    },
+    {
       "content": "contrib/cards/ShadowCollective/DinUnit.json"
     },
     {
@@ -497,8 +534,8 @@
       ]
     },
     {
-      "name": "Riot Control Squad",
-      "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384863541/0D08A36869D07A28874A58854BDCF6D87225306D/",
+      "name": "Stormtrooper Riot Squad",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139658813/F6DC48260186CC0283711F9A6E216341F1631319/",
       "size": "small",
       "type": "Trooper",
       "points": 50,
@@ -619,7 +656,7 @@
     },
     {
       "name": "DF-90 Mortar Trooper",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1683770969789216756/D8C157D8B31711EC7076FFF7C39347BC20B0E76A/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139662551/E8496B01C9619FBA2E5EEEBEF285ABEEF95ECF00/",
       "size": "medium",
       "type": "Emplacement Trooper",
       "points": 40,
@@ -644,7 +681,7 @@
   "Special Forces": [
     {
       "name": "Scout Troopers",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1860546411028298945/EF8212952111B1407837754BAEF96F238B718830/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139667737/5A74C7A6641FF79D0BEA098600B7338595160681/",
       "size": "small",
       "type": "Trooper",
       "points": 48,
@@ -700,36 +737,8 @@
       ]
     },
     {
-      "name": "Imperial Royal Guards",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1683770969788701217/89E8CC46981E8C634A4E3D6C4F6EAF343B27C1E2/",
-      "size": "small",
-      "type": "Trooper",
-      "points": 69,
-      "speed": 2,
-      "upgrades": {
-        "Heavy Weapon": 1,
-        "Training": 2,
-        "Gear": 1,
-        "Grenades": 1
-      },
-      "minis": [
-        {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/785234540541911959/D583DF28D96DBDF2F1FE9FB6AAB25809774C46EF/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/785234540541912060/182C0DD6D66EC8DEF075135B872DE26364010E27/"
-        },
-        {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/785234540541912172/73A36C525BC98DD1F4EC7953943FE5F660B0E9D8/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/785234540541912060/182C0DD6D66EC8DEF075135B872DE26364010E27/"
-        },
-        {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/785234540541912365/CB3109223BD5A017AA159066A3B17002B8892047/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/785234540541912060/182C0DD6D66EC8DEF075135B872DE26364010E27/"
-        }
-      ]
-    },
-    {
       "name": "Imperial Death Troopers",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1683770969788701181/DD8B2B7C2D3C3AC66F7D90F738B04BB309A31B46/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139667689/20539A9EAB988308E299A3DE18818D7B9FBA63C9/",
       "size": "small",
       "type": "Trooper",
       "points": 72,
@@ -763,7 +772,7 @@
     },
     {
       "name": "Imperial Special Forces",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1683770969788701129/EDA8288C48AF33A69F22AE18E6CEB1413A0B04F9/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139667628/DC827BC31A0CA433CBACA568292623523896981F/",
       "size": "small",
       "type": "Trooper",
       "points": 68,
@@ -798,7 +807,7 @@
       "name": "Imperial Special Forces",
       "title": "Inferno Squad",
       "displayName": "Inferno Squad",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1683770969788701097/D1043BFA3767D8E5A294ACA112D0E7E9A6B75627/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139667572/5230C0C79688307883294267607D597037641B36/",
       "size": "small",
       "type": "Trooper",
       "points": 34,
@@ -822,7 +831,7 @@
   "Support": [
     {
       "name": "74-Z Speeder Bikes",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1683770969788701072/16EF027E626FA31293F4E88556AF9633F091180D/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139672763/037D15DE4ACD0941BA57FEEBDEBE3F346E04F8BC/",
       "size": "medium",
       "type": "Repulsor Vehicle",
       "points": 70,
@@ -865,7 +874,7 @@
     },
     {
       "name": "Dewback Rider",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1683770969788701014/E1E943B567134E6A946C714BD07233CDC881A7AF/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139672717/75700C648595B7642273964A59B5CDFFBD650014/",
       "size": "large",
       "type": "Creature Trooper",
       "points": 70,
@@ -884,7 +893,7 @@
     },
     {
       "name": "Range Troopers",
-      "image": "http://cloud-3.steamusercontent.com/ugc/2495630600682578473/BF07355370D1E0303B59E0FA2F7439FC22D58941//",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139672651/467BD8F23216F7AE5274DC84837483AE40571B02/",
       "size": "small",
       "type": "Trooper",
       "points": 60,

--- a/contrib/cards/Empire/EmpireUnits.json
+++ b/contrib/cards/Empire/EmpireUnits.json
@@ -181,7 +181,7 @@
       },
       "minis": [
         {
-          "bundle": "http://cloud-3.steamusercontent.com/ugc/5070522239197162593/F42F2D876D0B0BBD8E701D0F813A631E2E0D9E76/"
+          "bundle": "https://steamusercontent-a.akamaihd.net/ugc/2446089105227025807/2E7D8F479762060CAF447A2E5A6C27891C314EA2/"
         }
       ],
       "commands": [
@@ -440,7 +440,7 @@
       },
       "minis": [
         {
-          "bundle": "http://cloud-3.steamusercontent.com/ugc/2174736446809185920/1B6637756A8044A1D173F7AD5C1BFD813EC66CCA/"
+          "bundle": "https://steamusercontent-a.akamaihd.net/ugc/2446089105227059084/0EB4EE32683338BC754DA5EC1F613ABA71048E90/"
         }
       ],
       "commands": [

--- a/contrib/cards/Empire/EmpireUnits.json
+++ b/contrib/cards/Empire/EmpireUnits.json
@@ -213,7 +213,7 @@
     {
       "name": "Boba Fett",
       "title": "Infamous Bounty Hunter",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418867906/44A3AE63815B46C40C081924D1DE38B5ED3B3B99/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137005787/86FC806D7DFDD74A0AB92D0E1B2D4842E84DB677/",
       "size": "small",
       "type": "Trooper",
       "points": 130,
@@ -232,32 +232,27 @@
       "commands": [
         {
           "name": "A Simple Man",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1904476875947527247/05CDA2737D98FB18CACE99E65CE51E5AB24ABA0B/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137003571/5A5FB50BC907A26126D8D458A0A4A3283DFFFEC0/",
           "pip": 1
         },
         {
           "name": "Whipcord Launcher",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564035802/A1AA027AE84C3CF96C2E671C6BFA78E2C94E2741/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137003429/DD564B5EA75537F3EBD45048833E5810DF5B33F5/",
           "pip": 1
         },
         {
           "name": "Making His Way in the Galaxy",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1904476875947527294/F0CD781F4680C3BBBDA58B1CECE1A3FF3B6821FE/",
-          "pip": 2
-        },
-        {
-          "name": "ZX Flame Projector",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564034359/7CC1427FEA79D22D3128A5650F8A93159661A656/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137003517/D14FF44B1B27BEA7A9058101AD2C8B1FB8FAA445/",
           "pip": 2
         },
         {
           "name": "Rule with Respect",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1904476875947527380/9CF23D52011D3B943E8DE565D19E91EC579F5784/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137003465/FB8C27572F44CAC6D4D6222AE11DA7A1EE7E201F/",
           "pip": 3
         },
         {
           "name": "Z-6 Jetpack Rocket",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564032805/D4AEE724FC17B87F391BB7B24A3C8D44B40B704B/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137003593/EDE3AF9DE7EE272F32C187643DFE4A565B205FD6/",
           "pip": 3
         }
       ],
@@ -323,7 +318,7 @@
     {
       "name": "IG-88",
       "title": "Notorious Assassin Droid",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1904476875947527656/131943FCDA732152E47C83B06C416F36E8D92B19/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137009352/1C2EF08C41D85E6F3B214B380DA174D2AADE6BDB/",
       "size": "small",
       "type": "Droid Trooper",
       "points": 110,
@@ -341,17 +336,17 @@
       "commands": [
         {
           "name": "Focused on the Kill",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1883093542256527598/80232945F2FFF7AD739F762446430D62F099D65A/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137026321/D9785EEF3FE2835319A9F3A2FB632A6E68D34371/",
           "pip": 1
         },
         {
           "name": "A Machine Made For Killing",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1883093542256527660/AD18F5D38A427F0CAAEC5F3016FBD31050134B7A/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137016998/E6071BE8EDF0A20E6032D047B35D5EF5FC8B7182/",
           "pip": 2
         },
         {
           "name": "Independent Programming",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1883093542256527538/49D0CD2A0FB411B1377ADB299395E3A3356B492F/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137017800/F888E446D9C374E57E091347F651D30A7CEEC81F/",
           "pip": 2
         }
       ],
@@ -366,7 +361,7 @@
     {
       "name": "Fifth Brother",
       "title": "The Kill is Mine",
-      "image": "http://cloud-3.steamusercontent.com/ugc/2058763770174552333/68E9B4569ABDB27E40706B4271708695BA4BE16F/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137011062/2CD518FAF98E506E8D2316B4A21294FAE1D2DAF8/",
       "size": "small",
       "type": "Trooper",
       "points": 105,
@@ -383,12 +378,12 @@
       "commands": [
         {
           "name": "You Would Question Me?",
-          "image": "http://cloud-3.steamusercontent.com/ugc/2058763770174551893/BAA06C5EE28685252AF55E955DB6FC0754D77EA6/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137018940/87231143078D7F264017F3EF0B7C221098555811/",
           "pip": 2
         },
         {
           "name": "I Care Not for your Struggles",
-          "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384886367/EE0BEDD35252436DE848457522D8D875B7DD4828/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137018989/07882CCD7D056DFFB777074A53C21811352E6844/",
           "pip": 3
         }
       ]
@@ -396,7 +391,7 @@
     {
       "name": "Seventh Sister",
       "title": "Compelled to Inflict Pain",
-      "image": "http://cloud-3.steamusercontent.com/ugc/2058763770174552593/8D3A9E091FD25223A4A113671E62A0C811C341B7/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137011773/5377A3D119B96061C7EFAF2F8469BD5E889F3F13/",
       "size": "small",
       "type": "Trooper",
       "points": 110,
@@ -413,17 +408,17 @@
       "commands": [
         {
           "name": "Come and Prove It",
-          "image": "http://cloud-3.steamusercontent.com/ugc/2058763770174552966/6950B93171AF6A52B7DF49EB2F09478B7DB42D26/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137019689/3B73F5638839DF849BC5921412BCC4ABCC35DAEC/",
           "pip": 1
         },
         {
           "name": "Unexpected, but not Unwelcome",
-          "image": "http://cloud-3.steamusercontent.com/ugc/2058763770174553026/B2B79F911A1A201A793B812B0A8B4881D3FAB80C/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137019893/59EB748713DD2A67E92CCFE9D3243D15C3670FBC/",
           "pip": 2
         },
         {
           "name": "You Hide Your Fear Well",
-          "image": "http://cloud-3.steamusercontent.com/ugc/2058763770174553089/B5C28400319F6E7F0C2B17D94B7859C277DF09B5/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137019788/90EA4637127092D742B503FE3E5DF0F9E96473A0/",
           "pip": 3
         }
       ]

--- a/contrib/cards/Republic/RepublicUnits.json
+++ b/contrib/cards/Republic/RepublicUnits.json
@@ -481,6 +481,10 @@
         {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/1009315641457802621/01F605D855048F823A0ECA6C46D2A62B56C04124/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/773995200348530664/5E248091F8CC37B1023257338D4947E4ADFE48AB/"
+        },
+        {
+          "bundle": "http://cloud-3.steamusercontent.com/ugc/1009315641457799750/AE83DC038BA8AAF48678D07E1F9734D4A9944C1D/",
+          "secondary": "http://cloud-3.steamusercontent.com/ugc/773995200348530664/5E248091F8CC37B1023257338D4947E4ADFE48AB/"
         }
       ]
     },
@@ -537,6 +541,40 @@
         },
         {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/1619598366708043883/1EA1B3C21A50C20D4D168AB91ECFE1C01A4F7DF5/"
+        }
+      ]
+    },
+    {
+      "name": "ARF Troopers",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10803117186606544/094414A06373C4EDD33EB57774F7090EEF175D9E/",
+      "size": "small",
+      "type": "Clone Trooper",
+      "points": 58,
+      "speed": 2,
+      "upgrades": {
+        "Squad Leader": 1,
+        "Heavy Weapon": 1,
+        "Training": 1,
+        "Comms": 1,
+        "Gear": 2,
+        "Grenades": 1
+      },
+      "minis": [
+        {
+          "mesh": "https://steamusercontent-a.akamaihd.net/ugc/16428815149933614/80D6829DB63FAE3328D00AC36F00E5FD71251E69/",
+          "diffuse": "https://steamusercontent-a.akamaihd.net/ugc/16428815149933714/D3FE0C2DEFBE1E78A71A55516DF87199D66DE2AC/"
+        },
+        {
+          "mesh": "https://steamusercontent-a.akamaihd.net/ugc/16428815149643329/8D273B40809BF89188238DE6FC5C207756AA22EF/",
+          "diffuse": "https://steamusercontent-a.akamaihd.net/ugc/16428815149643405/9A3D0A513A31513523E59855980DFCE0A8F0F6E0/"
+        },
+        {
+          "mesh": "https://steamusercontent-a.akamaihd.net/ugc/16428815149932871/EE8DF333D45ED841E9C31625FB4A9385C16B2F49/",
+          "diffuse": "https://steamusercontent-a.akamaihd.net/ugc/16428815149933386/736E0CCF2ADE31D6A9F6BE172B20AEB5420B815E/"
+        },
+        {
+          "mesh": "https://steamusercontent-a.akamaihd.net/ugc/16428815149649053/B24484CFED06020454EE95B663DB3ECE17871D26/",
+          "diffuse": "https://steamusercontent-a.akamaihd.net/ugc/16428815149646949/50B6AA8C2CC5283537DBA2291F9801E7CD5FE77C/"
         }
       ]
     }

--- a/contrib/cards/Republic/RepublicUnits.json
+++ b/contrib/cards/Republic/RepublicUnits.json
@@ -39,7 +39,7 @@
     {
       "name": "Obi-Wan Kenobi",
       "title": "Civilized Warrior",
-      "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384862915/90FD71812614F00A05D66B384E92C67B6C4E7358/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134023515/2C9320594DD79CF3D7FC98C13487A00A2AE28598/",
       "size": "small",
       "type": "Trooper",
       "points": 150,
@@ -58,17 +58,17 @@
       "commands": [
         {
           "name": "Hello There!",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564036592/C0182450268D43C5589930D988CF04ECC4A1C248/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134023412/5FD1AF7B0198FBD887EA7A072F53A8EFE47BA5AD/",
           "pip": 1
         },
         {
           "name": "Knowledge And Defense",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564035139/48E071EA2C88883329D050F338F8947FD2515F6D/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134023462/0B7E151462188D5E5706415F406F0B51892CE553/",
           "pip": 2
         },
         {
           "name": "General Kenobi",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564033710/C8724AA758E97BCBEDA8C66CECDA298AB74EFB05/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134023367/DBEE15E658282BE84E693970FF184CBF515C7DEA/",
           "pip": 3
         }
       ]
@@ -76,7 +76,7 @@
     {
       "name": "Clone Captain Rex",
       "title": "Honorable Soldier",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1683770969788790598/868FE96BEB709EE3A25D7973FF259B8BF7824475/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134020880/7C51F849FFBA45101F85ED56C60A39BC9DCFEA9E/",
       "size": "small",
       "type": "Clone Trooper",
       "points": 95,
@@ -96,17 +96,17 @@
       "commands": [
         {
           "name": "Call Me Captain",
-          "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384868441/FB66196615FD2CFF191D1552B61924A8BFB23428/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134020825/C9D873D723AFC9AFB05A20B57D3335CB5DACC0C1/",
           "pip": 1
         },
         {
           "name": "Take That, Clankers!",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564034598/FAD8628CEF4BC9782992174756FD109E5AD8E949/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134020928/838D3C418B11344945B861E1E17B2259AB7DC9A3/",
           "pip": 2
         },
         {
           "name": "We're Not Programmed",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564032907/37CBE4B02058855DF6EB5B305AEC12DA796E8FDD/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134020977/7375B857CECD3EC04F3DDA22799E789FAF4ABC13/",
           "pip": 3
         }
       ]
@@ -150,7 +150,7 @@
     {
       "name": "Clone Commander",
       "title": "Trained For Leadership",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1683770969788790538/EBB9911B9EB9C0F817370266A8ACB8357BEB3919/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134030932/097AEAB205D99962C4D1BF4136A36D73029A43B2/",
       "size": "small",
       "type": "Clone Trooper",
       "points": 60,
@@ -169,7 +169,7 @@
     {
       "name": "Yoda",
       "title": "Grand Master Of The Jedi Order",
-      "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384864374/1D5F4392DBB420ABB167CE9498C5D07CE85CE31C/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134036684/529CFF85876C6F4710D6E97CBBB99E15323584D4/",
       "size": "small",
       "type": "Trooper",
       "points": 180,
@@ -186,17 +186,17 @@
       "commands": [
         {
           "name": "Size Matters Not",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564036164/6444F2658805AE43ED73CF592F8D9340262E8851/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134037394/0B7834ECF0331C805C27F603B00D6C743B854388/",
           "pip": 1
         },
         {
           "name": "There Is No Try",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564034526/8811897A231A24247FA9120971D4994A45BAE4CD/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134037407/66DFAF805CB1864A8A71CD35B3DCA41F9B213ECA/",
           "pip": 2
         },
         {
           "name": "Luminous Beings Are We",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564033410/83F24DB765D234502B457983834BF25FB5FAB05A/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134037376/DDC7E052702169D9E14A51F886535CF5BD2007C1/",
           "pip": 3
         }
       ]
@@ -204,7 +204,7 @@
     {
       "name": "Wookiee Chieftain",
       "title": "Clan Leader",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1683770969788790478/85E9C624082CA5731008121F45ABFA06CC4583DB/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134052113/10120AB84E10E0EBDFEF30603F2B1EE9FA8382A7/",
       "size": "small",
       "type": "Wookiee Trooper",
       "points": 100,
@@ -223,7 +223,7 @@
     {
       "name": "Chewbacca",
       "title": "Hero Of Kashyyyk",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1683770969788790442/8E99C974FA5AF735BADBABA2CEA6400399908E50/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134028001/43E55FD3A97B6A7800A94B65EA47507F7033CA65/",
       "size": "small",
       "type": "Wookiee Trooper",
       "points": 90,
@@ -252,7 +252,7 @@
     {
       "name": "Clone Commander Cody",
       "title": "Leader of the 212th",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1745728519554830167/CB5BD832D003FF4C5961CBA3E67D7D975C20E11E/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134025861/02F5F0A5209FE1F7F3315632CBDA187666A0258A/",
       "size": "small",
       "type": "Clone Trooper",
       "points": 105,
@@ -270,17 +270,17 @@
       "commands": [
         {
           "name": "Bring it Down!",
-          "image": "http://cloud-3.steamusercontent.com/ugc/2022718494181413653/02DAE10AF010ABE97C2A2EF535CA0072C334CEE0/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134025758/112F3DFC81DC78543EDFE2947CF3F3F007471510/",
           "pip": 1
         },
         {
           "name": "Have I Ever Let you Down?",
-          "image": "http://cloud-3.steamusercontent.com/ugc/2022718494181413715/2F415FFA15FAE4262D1364A5CB46F0D7BDDC166C/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134026057/C02C788C4E22D659C4C1FC71FA93C5CED64C4B87/",
           "pip": 2
         },
         {
           "name": "Combined Arms",
-          "image": "http://cloud-3.steamusercontent.com/ugc/2022718494181413785/93BB691509DA089CF951ACDA474E0E06C3BB0E07/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134025951/456F450F410FB505809E7069B4E5ED4E9CAD8FD9/",
           "pip": 3
         }
       ]

--- a/contrib/cards/Republic/RepublicUnits.json
+++ b/contrib/cards/Republic/RepublicUnits.json
@@ -486,7 +486,7 @@
     },
     {
       "name": "Wookiee Warriors",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1619598366708171464/0A12FC8F203E5376156D3C2A207E33E1F5ACB0B6/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135341447/B0773809842EFD82EFA442C9E918729C2DE3AA1F/",
       "size": "small",
       "type": "Wookiee Trooper",
       "points": 69,
@@ -516,7 +516,7 @@
       "name": "Wookiee Warriors",
       "title": "Kashyyyk Defenders",
       "displayName": "Wookiee Warriors (Defenders)",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1683770969788790192/E7C7082C239E04E3DF76FDFF909EE360D9C25012/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135341419/3EC4467936F4470CD7F7E5BA2E4BE0CD069869AF/",
       "size": "small",
       "type": "Wookiee Trooper",
       "points": 72,
@@ -543,7 +543,7 @@
   "Support": [
     {
       "name": "BARC Speeder",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1683770969788790145/DD6B7ACA36B88E28B4326E7AA96536230B87F01E/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135357592/ED3AA636CBB456AA395C1694D27B84A296DD406B/",
       "size": "large",
       "type": "Repulsor Vehicle",
       "points": 55,
@@ -587,7 +587,7 @@
     {
       "name": "Raddaugh Gnasp Fluttercraft",
       "displayName": "Fluttercraft",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1616219505081189347/2BD4025EABD6F2A919AC40FC4E6D3C8AC4292E86/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135343126/F85A20B8CBAFDED99A98E49A5606034C27863FE8/",
       "size": "huge",
       "type": "Repulsor Vehicle",
       "points": 55,
@@ -634,13 +634,14 @@
     },
     {
       "name": "Clone Commandos",
-      "image": "http://cloud-3.steamusercontent.com/ugc/2495630600682578127/F11181FFD31692CE4180BD0B207040E3684EC947/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135343637/2D368BCB50598F733E54128E5B1BF53CB49F853F/",
       "size": "small",
       "type": "Clone Trooper",
       "points": 75,
       "speed": 2,
       "upgrades": {
         "Training": 1,
+        "Gear": 1,
         "Comms": 1,
         "Armament": 1,
         "Grenades": 1
@@ -667,7 +668,7 @@
     },
     {
       "name": "Clone Commandos Delta Squad",
-      "image": "http://cloud-3.steamusercontent.com/ugc/2474241114696699067/AD85E44AA7E3AA30A65E888C28B3E89CBD3C757F/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135343678/F395BC8F8B88F888355FCFAFA870875613499CD1/",
       "size": "small",
       "type": "Clone Trooper",
       "points": 100,
@@ -751,7 +752,7 @@
     },
     {
       "name": "Infantry Support Platform",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1616219505081189285/5E0D18805F9C4BF8A978A9F1F20CFAE73575D02F/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135344629/540E23C816C00B4B7E086B626329F13633403C9E/",
       "size": "huge",
       "type": "Repulsor Vehicle",
       "points": 65,

--- a/contrib/cards/Republic/RepublicUnits.json
+++ b/contrib/cards/Republic/RepublicUnits.json
@@ -290,7 +290,7 @@
     {
       "name": "R2-D2",
       "title": "Independent Astromech",
-      "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384863170/5912B6F9374EF1314963756E42A9520F4E3D0FB3/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134141698/FAE960D0D49F0061E6FA7755E67185322CF307F0/",
       "size": "small",
       "type": "Droid Trooper",
       "points": 55,
@@ -308,17 +308,17 @@
       "commands": [
         {
           "name": "Blast Off!",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564037063/A7AE3401CB3A51A58A8682BBCD8D6F6C104804AF/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134141577/8D591F13DCEA99113D64D58B6E2D68ED52A08EE7/",
           "pip": 1
         },
         {
           "name": "Impromptu Immolation",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564035209/4C4829AE9D1B01B14F2D4FDE2C6D3935D8055954/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134141630/9373A105353B80AC756D358EBF8F21D63295D45C/",
           "pip": 2
         },
         {
           "name": "Smoke Screen",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564033033/7FC32081CE8646476E7B0C475F452AA629BA7713/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134141746/0599A5682160DFB2D79CCA9577530E15478AAEBD/",
           "pip": 3
         }
       ]
@@ -326,7 +326,7 @@
     {
       "name": "Padme Amidala",
       "title": "Spirited Senator",
-      "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384862963/54D8AE67C1EA8D9E05E8F2CC074E73443D26023F/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134139534/3D7B05D39495FB34AE0D4985A9B7E7771F738CAF/",
       "size": "small",
       "type": "Trooper",
       "points": 60,
@@ -346,17 +346,17 @@
       "commands": [
         {
           "name": "Our Fate Is In Your Hands",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564036311/3A7A61391C83C42A345A3EAB161E6561398BE472/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134139479/047DB4C4D70DEF7A41C639D90C4931DD04C9BD5C/",
           "pip": 1
         },
         {
           "name": "Aggressive Negotiations",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564035707/638FD7106E81C966C44029EE4176F70CC9A2882F/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134139326/7A72415F3906D4A9182818FE7BB25C3F3151E3FB/",
           "pip": 2
         },
         {
           "name": "Diplomatic Cover",
-          "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384885457/E3264D1834CA6EDDF6031B43255A47E33989D5F2/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134139409/0EBF63FE95FD6CCA1E652F1FCF25C048BCB39148/",
           "pip": 3
         }
       ]
@@ -364,7 +364,7 @@
     {
       "name": "The Bad Batch",
       "title": "Clone Force 99",
-      "image": "http://cloud-3.steamusercontent.com/ugc/2475370743175005286/30F19D5EE9144103CCBC9528FBF2F8569874279E/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134145076/BAE80029E18C81D609CE49C8F8DAE0BE2D1FCF4D/",
       "size": "small",
       "type": "Trooper",
       "points": 160,
@@ -380,7 +380,7 @@
       "commands": [
         {
           "name": "We Do What We Do",
-          "image": "http://cloud-3.steamusercontent.com/ugc/2475370743175005491/7273C60F103AD3520287BCD56D2DC53B26498A35/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134148285/8246937579A18E5BE5A53451E49E65028CFC1EA1/",
           "pip": 3
         }
       ]

--- a/contrib/cards/Republic/RepublicUnits.json
+++ b/contrib/cards/Republic/RepublicUnits.json
@@ -486,6 +486,7 @@
     },
     {
       "name": "Wookiee Warriors",
+      "title": "Noble Fighters",
       "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135341447/B0773809842EFD82EFA442C9E918729C2DE3AA1F/",
       "size": "small",
       "type": "Wookiee Trooper",
@@ -703,7 +704,7 @@
   ],
   "Heavy": [
     {
-      "name": "TX-130 Saber-Class Fighter Tank",
+      "name": "Saber-Class Tank",
       "displayName": "Saber Tank",
       "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384863579/ABC4E8CCA9A2C837A86FF23215B5AE4885E2A9DF/",
       "size": "epic",

--- a/contrib/cards/ShadowCollective/BlackSunEnforcersUnit.json
+++ b/contrib/cards/ShadowCollective/BlackSunEnforcersUnit.json
@@ -1,6 +1,6 @@
 {
   "name": "Black Sun Enforcers",
-  "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418867866/DEE290E2C3AB43F0C44735172DFD26002BEF468D/",
+  "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139718139/222491782E56EAECE8B93E78E946F308211DC049/",
   "size": "small",
   "type": "Trooper",
   "points": 50,

--- a/contrib/cards/ShadowCollective/BlackSunVigoUnit.json
+++ b/contrib/cards/ShadowCollective/BlackSunVigoUnit.json
@@ -1,6 +1,6 @@
 {
   "name": "Black Sun Vigo",
-  "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418869531/DBF6D99CAD8725BBC9465C8C2788BB125D3997A6/",
+  "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139718200/725F66281B4596ACF010C38A1E37D169B597D56C/",
   "size": "small",
   "type": "Trooper",
   "points": 50,

--- a/contrib/cards/ShadowCollective/BosskUnit.json
+++ b/contrib/cards/ShadowCollective/BosskUnit.json
@@ -1,7 +1,7 @@
 {
   "name": "Bossk",
   "title": "Trandoshan Terror",
-  "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418867948/20A2EB617A2E756580A6A127046FFC24E28F1157/",
+  "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137006564/2C7F90FF127392A78F71B82EF4E69C35973824AD/",
   "size": "small",
   "type": "Trooper",
   "points": 105,
@@ -19,17 +19,17 @@
   "commands": [
     {
       "name": "Merciless Munitions",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564036341/7FF893D01D2692E537EB6B157DCAB16421438FC4/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137013809/1D7FCC2F2A12F6B09B07345330F840800A846F7C/",
       "pip": 1
     },
     {
       "name": "Reptilian Rampage",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564034734/F11C62C109C1CA7EE490169555DBAE37E4A9B53C/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137013972/29F197704D74AF20E8954F2BE8AC5C9203F9A2E6/",
       "pip": 2
     },
     {
       "name": "Lying In Wait",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564033363/C8D04CF3CEE5DE82C69BAB90B7C61DFA842AE591/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137013903/60F4AC014F68998F8A3587BA0A5389301A0BAA7C/",
       "pip": 3
     }
   ],

--- a/contrib/cards/ShadowCollective/CadBaneUnit.json
+++ b/contrib/cards/ShadowCollective/CadBaneUnit.json
@@ -1,7 +1,7 @@
 {
   "name": "Cad Bane",
   "title": "Needs No Introduction",
-  "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418867666/27A6A224821A974D619C9FE94A1C60AD39F60410/",
+  "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137007196/49655B5A32FFAB3CE31BFCCFEA9811CD4A51B748/",
   "size": "small",
   "type": "Trooper",
   "points": 105,
@@ -22,17 +22,17 @@
   "commands": [
     {
       "name": "I'm Your Worst Nightmare",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564036560/158F834A8FF94206F4F0149EF862D264E3B27804/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137014543/33FE8591FAFD29F8BEAF13D64851772A7FD794FE/",
       "pip": 1
     },
     {
       "name": "I'm In Control",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564035284/D2D4B7D2CE80F63F0D2706764B9B4DB838B23F43/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137014579/D2FC7AF724D1C7527CCDDABF18517E9CB99DF061/",
       "pip": 2
     },
     {
       "name": "I Make The Rules Now",
-      "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384886468/8FB6900E28C31907ECD233F979EF30CFB30DA452/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137014560/4B6E8AF4CB10FFE7EC529D204390FC45291FC962/",
       "pip": 3
     }
   ],

--- a/contrib/cards/ShadowCollective/DinUnit.json
+++ b/contrib/cards/ShadowCollective/DinUnit.json
@@ -15,7 +15,7 @@
   },
   "minis": [
     {
-      "bundle": "http://cloud-3.steamusercontent.com/ugc/1745728519554838224/65D2C0280026A313878AE7D5F38E17A4717584DD/"
+      "bundle": "https://steamusercontent-a.akamaihd.net/ugc/2446089105226763008/9B5002BC5C049F340FF7CDBC875F5053A5DB2574/"
     }
   ],
   "commands": [

--- a/contrib/cards/ShadowCollective/DinUnit.json
+++ b/contrib/cards/ShadowCollective/DinUnit.json
@@ -1,7 +1,7 @@
 {
   "name": "Din Djarin",
   "title": "The Mandalorian",
-  "image": "http://cloud-3.steamusercontent.com/ugc/1904476875947527447/B7A57C2B3327EF48CFB4C9329C7B1042553F03F5/",
+  "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137007934/A7B3E612E6E4A9392C36548BB7B507AFF0D3841D/",
   "size": "small",
   "type": "Trooper",
   "points": 105,
@@ -21,22 +21,22 @@
   "commands": [
     {
       "name": "This is the Way",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1787388827710906494/CCFF32308246D32A4B0B7DDB6BDD756469FEC5D5/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137015239/C47AEAA769E49330AF8A9A18B9E6FBBBC14D411B/",
       "pip": 1
     },
     {
       "name": "I Like Those Odds",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1787388827710906446/8277E4B1E2EE9595FC547A69FD12C911152FFD4A/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137015412/584A22A4135D4349D3D2A2D269F97FAC5F14558C/",
       "pip": 2
     },
     {
       "name": "The Hand Thing",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1787388827710906539/BD2C2A9E435DD031F961B4DB6BFA6C492D84A740/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139777564/741083A5DC7A0B07FE1EFAC37B113604CA918C7F/",
       "pip": 2
     },
     {
       "name": "Whistling Birds",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1904476875947527503/2DF990D405E73D3E4A0F7A7E7AD1F52C6E71296F/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137015298/D63392C36661D3EB8E0376A51A461AA761D5827F/",
       "pip": 3
     }
   ],

--- a/contrib/cards/ShadowCollective/IG11Unit.json
+++ b/contrib/cards/ShadowCollective/IG11Unit.json
@@ -1,37 +1,38 @@
+
 {
   "name": "IG-11",
   "title": "Nurse and Protect",
-  "image": "http://cloud-3.steamusercontent.com/ugc/1904476875947527602/11FA913C55EA6AA321D9D842F96D12967115F6A8/",
+  "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137008859/81A3C1FCE76085D59EE6AC6B2D28D6114E0CFBA2/",
   "size": "small",
-  "type": "Trooper",
-  "points": 105,
+  "type": "Droid Trooper",
+  "points": 110,
   "speed": 2,
   "upgrades": {
     "Training": 1,
     "Comms": 1,
-    "Gear": 1,
-    "Programming": 1
+    "Gear": 1
   },
   "minis": [
     {
-      "bundle": "http://cloud-3.steamusercontent.com/ugc/1745728519554838170/7EDDCC155FD485AB58D07C8350728C0C558D9628/"
+      "bundle": "http://cloud-3.steamusercontent.com/ugc/1789640371719058670/9E6B82A0BF8367F2C6D369BD3464DA5E9D0C7917/"
     }
   ],
   "commands": [
     {
       "name": "Mechanical Carnage",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1883093542256527453/2DBE72FC350AFFE8974D26BC3E61FEE8FB2EA515/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137016841/F2528C4F77766BC90F225B6BBB4D3A42BB0EB0C4/",
       "pip": 1
     },
     {
-      "name": "The Hand Thing",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1787388827710906539/BD2C2A9E435DD031F961B4DB6BFA6C492D84A740/",
+      "name": "A Machine Made For Killing",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137016998/E6071BE8EDF0A20E6032D047B35D5EF5FC8B7182/",
       "pip": 2
     },
     {
       "name": "Anti-Capture Protocols",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1883093542256527714/E9DBCECA0A1B988D8DA4D0C2170EC87A69A5A725/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385137016902/C3B4710D3F5ACD27D67CB51B0C6B4E6B229B9BD9/",
       "pip": 3
     }
-  ]
+  ],
+  "additionalObjects": ["Victory Token"]
 }

--- a/contrib/cards/ShadowCollective/PykeSyndicateCapoUnit.json
+++ b/contrib/cards/ShadowCollective/PykeSyndicateCapoUnit.json
@@ -1,6 +1,6 @@
 {
   "name": "Pyke Syndicate Capo",
-  "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418868012/4A5177B05203B2F76439237143D83ED67C43DAA9/",
+  "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139718883/40D17DA044960A4A34979FBDEAE9296EB1E50346/",
   "size": "small",
   "type": "Trooper",
   "points": 48,

--- a/contrib/cards/ShadowCollective/PykeSyndicateFootSoldiersUnit.json
+++ b/contrib/cards/ShadowCollective/PykeSyndicateFootSoldiersUnit.json
@@ -1,6 +1,6 @@
 {
   "name": "Pyke Syndicate Foot Soldiers",
-  "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418868670/B5F556896A00CC4788A8A071C97476E5AB544C71/",
+  "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139718821/EBC76B7A94A5F3C03B036C17E3C26E0319F1C6EB/",
   "size": "small",
   "type": "Trooper",
   "points": 44,

--- a/contrib/cards/ShadowCollective/ShadowCollectiveUnits.json
+++ b/contrib/cards/ShadowCollective/ShadowCollectiveUnits.json
@@ -3,7 +3,7 @@
     {
       "name": "Gar Saxon",
       "title": "Militant Commando",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418868157/2B2B2A00440F285FF504B91185998FC1F9A842F5/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139719525/A5642D0B10D7426AD751D9428A0C249D5F4BAF2F/",
       "size": "small",
       "type": "Trooper",
       "points": 100,
@@ -22,17 +22,17 @@
       "commands": [
         {
           "name": "Marked for Elimination",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418876685/D3ED3CC8A88D1F2A95E509F2D8D8E0B9B1E324A4/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139734189/BFD230D0FDCC337658C60B4254D6718684F4EF21/",
           "pip": 1
         },
         {
           "name": "Fight Another Day",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418876554/70144F2711BF5050032AF53983EFD7097A815AB7/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139727495/1DCDC03996549F05C8D84E79CCAAC22F9F22CA17/",
           "pip": 2
         },
         {
           "name": "Victory or Death!",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418876867/B888FA6460B95A5FD755E599833A3DC2D441B5F5/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139734267/BE465B62B232B7E2F2992497221C565D00B19CCF/",
           "pip": 3
         }
       ]
@@ -48,7 +48,7 @@
     {
       "name": "Maul",
       "title": "A Rival",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418868421/49BFF5E95CB42CD632E5CB9FA0C887BC50314CD6/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139718510/46475D968DFF923C51695A46BB5A652D2194E600/",
       "size": "small",
       "type": "Trooper",
       "points": 170,
@@ -67,32 +67,32 @@
       "commands": [
         {
           "name": "Witch Magick",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418876925/36A3A5FD30C472A823A487D84B7C358AF99EC1C2/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139732571/7409767511212BC5F60C749EED79FBE45BED8DF2/",
           "pip": 1
         },
         {
           "name": "His Eminence",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418876608/513C47E38F9513066C97A2CA4449351DD9DFF20D/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139727459/C8F9934D8CB1396F2F88743AE2F39A8EFADA20F8/",
           "pip": 2
         },
         {
           "name": "Seize What Power We Can",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418876813/C547DF964CE720D134D78C469FB73D47DDE9A7B0/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139729567/6F123B5506E6F0DC1F04907A2C5285AF180DFD97/",
           "pip": 3
         },
         {
           "name": "Duel of the Fates",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564036827/1967B20CCD59FE2EAECDC15FA5750928F75963E0/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139727558/BA0C0A83F63DD13EC3A4CC073071CA2DB1BEA27E/",
           "pip": 1
         },
         {
           "name": "The Phantom Menace",
-          "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384887593/7CF6854E9CAF545BD9AA314581960571E853CA16/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139729626/683EBFF15A3FBAC43A1DE8EF508DE05ACFEBE1D1/",
           "pip": 2
         },
         {
           "name": "At Last",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564034186/C08B05E1C969B6ADBB158DE85C499CD938FBC8B5/",
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139727404/5C2C80FCCF13A12AB56614E633960DAC3648BCC3/",
           "pip": 3
         }
       ]
@@ -115,7 +115,7 @@
   "Special Forces": [
     {
       "name": "Mandalorian Super Commandos",
-      "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418868324/181FD051CF589A96ADCC0FCB37B41A401BA8D6A8/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139720568/C0F87A2E12C8AE493654F7F4E9F71E16D3FA8BEB/",
       "size": "small",
       "type": "Trooper",
       "points": 70,
@@ -152,7 +152,7 @@
   "Heavy": [
     {
       "name": "A-A5 Speeder Truck",
-      "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384860930/7D4FE55FB3521A15089DD0E8826906D9ED7DA671/",
+      "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139723206/223C60DDB2052576AE1CF777BE23675AA0FF8F2E/",
       "size": "long",
       "type": "Repulsor Vehicle",
       "points": 65,

--- a/contrib/cards/ShadowCollective/SwoopBikeRidersUnit.json
+++ b/contrib/cards/ShadowCollective/SwoopBikeRidersUnit.json
@@ -1,6 +1,6 @@
 {
   "name": "Swoop Bike Riders",
-  "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418948999/222EC37F180DE2339C9F2A3C2B713B64B84E282C/",
+  "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139721420/2BD490189FBB2AF2C7D6AA12EFA6EAA643EA2002/",
   "size": "medium",
   "type": "Repulsor Vehicle",
   "points": 65,

--- a/contrib/cards/official.json
+++ b/contrib/cards/official.json
@@ -281,10 +281,10 @@
       },
       {
         "name": "DC-17m ICWS Config",
-        "image": "http://cloud-3.steamusercontent.com/ugc/2495630600682578404/0907EFC6D9B860E036D95C2204113FA2E80D7483/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135385953/007D0426E485963714BCBE0B74B2B8AE5B7F1869/",
         "flip": {
           "name": "DC-17m ICWS Config",
-          "image": "http://cloud-3.steamusercontent.com/ugc/2495630600682578229/D1B8B22989B7B303FFEE57833D39F8476DEED678/"
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135386003/EB0729A53546B70CB9054BAF5306E3F5368FC9DF/"
         },
         "points": 0,
         "restrictions": {
@@ -528,7 +528,7 @@
       },
       {
         "name": "Gnasp Bombardier",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1616219505081189228/8CCDEE09F1FB60741F7EA11A32F4B2601A5772AF/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135343165/A3E8D964A08B453B9E015137A07E33D8387D1A64/",
         "points": 20,
         "restrictions": {
           "include": {
@@ -538,7 +538,7 @@
       },
       {
         "name": "Gnasp Gunner",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568226311/08FF7D85F3D4B6D5C65D70ADE3EE76524D2E0BB6/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135343200/DEFBD83A9EBBA99252AC71556D2B37557BF9B36B/",
         "points": 15,
         "restrictions": {
           "include": {
@@ -700,7 +700,7 @@
     "Gear": [
       {
         "name": "Katarn Pattern Armor",
-        "image": "http://cloud-3.steamusercontent.com/ugc/2495630600682578301/92CA9E448779AF91300B53D1D77FC3D385141C28/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135343697/9294A833C65D6D3721327C68A057F71D8D920AD7/",
         "points": 0
       },
       {
@@ -936,7 +936,7 @@
       },
       {
         "name": "AT-RT Laser Cannon",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568138277/BF6E7C05171B0D9397AA521903AAB5B47B97CB7B/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135342360/B838498FCDCDCAF1A3E7A36878EE646157FBBE8F/",
         "points": 10,
         "restrictions": {
           "include": {
@@ -1076,7 +1076,7 @@
       },
       {
         "name": "Twin Beam Cannons",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1616219505081189108/F040A172FA29BC024E24EBA875B27A7CE4F48FFC/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135344651/FF1F346F4BC8D5A517747C10951F216DBF84A034/",
         "points": 25,
         "restrictions": {
           "include": {
@@ -1106,7 +1106,7 @@
       },
       {
         "name": "TX-130 Beam Cannon Turret",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568146181/3EFE8D5F3AC5E50248734F4ABF50A175FE76460D/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135344116/6FA72AE219A115A5BA50033ECAF85464EE12FCA8/",
         "points": 15,
         "restrictions": {
           "include": {
@@ -1213,11 +1213,11 @@
       {
         "name": "Battle Shield Wookiee (Offensive)",
         "displayName": "Shield Wookiee (Offensive)",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568138999/81A76F415A7B73A3AEF6B5EEF5DF6F0ABC9C9CF5/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135374023/1CF15E13216F27CF98B3FBC1C6419CF00FA4AB09/",
         "flip": {
           "name": "Battle Shield Wookiee (Defensive)",
           "displayName": "Shield Wookiee (Defensive)",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568138967/E5E495CD6EEFD77393CD99C35CF651BBEDC1210A/"
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135373983/5011312D227028FE696507AD0AE78EACDB2FD951/"
         },
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/1621849308236386933/DCD62751F06157E85CE575C8BB1CCF86379BB7DE/"
@@ -1286,7 +1286,7 @@
       },
       {
         "name": "Bowcaster Wookiee",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568139088/9E0C04EE7D22BAE7023E8C8DB51A30B8877E0EEA/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135341310/D12F81BD3CDBC4B90FFAE066EEDE9578F4522410/",
         "mini": {
           "mesh": "http://cloud-3.steamusercontent.com/ugc/785234540541174665/9E1AA98159F76E271185345E9D347D7453C05D4B/",
           "diffuse": "http://cloud-3.steamusercontent.com/ugc/785234540541174034/90C4A124BB82CCE0B5E38E13860ED49BB9A4973B/"
@@ -1638,7 +1638,7 @@
       },
       {
         "name": "Long Gun Wookiee",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568226123/FC3395575F2DA5995F599877AEF70D14F53400D5/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135341370/B7A9BFBB4B61953A1DD894FF2F63729FCBBAC92B/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/1619598366708042667/2DABB5788E51006EDB3FCB03400ACD4CE07755F3/"
         },

--- a/contrib/cards/official.json
+++ b/contrib/cards/official.json
@@ -435,7 +435,7 @@
       },
       {
         "name": "Iden's ID10 Seeker Droid",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1616219505080628898/0AD977B53010124C73F966F87EC1E3CBB0F18255/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135447894/8F1310249DB7B03175CFEEE485B966D2E228C623/",
         "points": 15,
         "mini": {
           "diffuse": "http://cloud-3.steamusercontent.com/ugc/770611889399999868/37F150131345FF1F47592A96239395A583AAE5EA/",

--- a/contrib/cards/official.json
+++ b/contrib/cards/official.json
@@ -73,10 +73,10 @@
       },
       {
         "name": "E-11D Focused Fire Config",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568140522/E9CFA877ABF3D3AA46EFE9D8D1EB77CF50DCA211/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140103278/AC9A32D518E9E70AF6ABBA41F7E10DF58DADFF20/",
         "flip": {
           "name": "E-11D Grenade Launcher Config",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568140554/DA69AFF0F6A0845BC7F7908386CB946A8D7DD65A/"
+          "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140103366/FB39C5636706702276566978A5EDD34907C1D8DB/"
         },
         "points": 0,
         "restrictions": {
@@ -1360,7 +1360,7 @@
       },
       {
         "name": "DLT-19D Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568140076/8927F1FC730F5790C314E6E3B25BF903587BC4E3/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140102975/2A200DF9EF1BF00105CC7BA834090DB6E0C4EA12/",
         "mini": {
           "mesh": "http://cloud-3.steamusercontent.com/ugc/770610077943650040/CDB9EFD9CB36DE0EB5AB78B22F2B334BDB1E6DFE/",
           "diffuse": "http://cloud-3.steamusercontent.com/ugc/770610077942938053/6187B2D6848EC35010DE6C3EEBB5DF6125D02D45/"
@@ -1374,7 +1374,7 @@
       },
       {
         "name": "DLT-19X Sniper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568140107/A9D503B1ABC7EF7286FBFAA193EE3351651AE68D/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140103101/607C9BEDEB2C3780F1AE58D72DEE649F941A7CAD/",
         "mini": {
           "mesh": "http://cloud-3.steamusercontent.com/ugc/770610077943667377/92306C3BFB675310563691C3C582BF5B9FC9ACD4/",
           "diffuse": "http://cloud-3.steamusercontent.com/ugc/770610077943667167/66F3188269E49FE5DAD649E771D799F2593263FF/"
@@ -1416,7 +1416,7 @@
       },
       {
         "name": "DT-F16",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568140318/4B2F2E13CF6E386B13FA96D61FAFBC6058D92599/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140103189/0A3AA902AA4ADB644B1D83840A96AB041EDE5849/",
         "mini": {
           "mesh": "http://cloud-3.steamusercontent.com/ugc/993513208355174615/DD0DA9DFDBCA621CF297C9A9EB2356279A733158/",
           "diffuse": "http://cloud-3.steamusercontent.com/ugc/951848302305474695/F076E77D0278B10EAE330BC9073B05BC9A3BCD57/"
@@ -1431,7 +1431,7 @@
       },
       {
         "name": "Del Meeko",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568139874/02F137C9987C446562434B6D358B1711E416A002/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140102888/C41E1C0AEAE95F66AE9D450E0EA233B169E5C9EC/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/1618437692581074585/1C74BEB92DC42D3585BFC1185A77DE14EC3249CA/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/1618438238123043414/B7E9660E470DC070545782406C29F1E1356A5685/"
@@ -1565,7 +1565,7 @@
       },
       {
         "name": "Gideon Hask",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568141632/01D01A2179E9AC81ED7BDF348D67E98A015EE52C/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140103438/D7D66F0CFEFC2658BF2FDB33899D5888448353F0/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/1618437692581075349/6265F81E1BAA090FFA813270A8E3126CF8AD6CC5/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/1618438238123043414/B7E9660E470DC070545782406C29F1E1356A5685/"
@@ -1798,7 +1798,7 @@
       },
       {
         "name": "Sonic Charge Saboteur",
-        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384858296/236C14968CC9DE8888C449541E373A447992E159/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140103507/922568C5FAACC25FCE80574BE5459CB511022824/",
         "mini": {
           "mesh": "http://cloud-3.steamusercontent.com/ugc/950714557093539716/6A0D63306F505A074395AFA61EB990280DB8995D/",
           "diffuse": "http://cloud-3.steamusercontent.com/ugc/950714557093539899/FF7A535E91BF79D4C3E0D55E874C1ACEB6FBF434/"
@@ -1827,7 +1827,7 @@
       },
       {
         "name": "T-21 Special Forces Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568145856/2210B593FFE9EA0A6E9B31FF4861C890DE3CD7CF/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140103559/F3FC1C02320B5F60D4A041140E0637BD0C0EE86A/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/1618438238123000906/C64EAD02CA22F8BFB59320925DAD7D89BA1E7AD6/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/1618438238123043414/B7E9660E470DC070545782406C29F1E1356A5685/"

--- a/contrib/cards/official.json
+++ b/contrib/cards/official.json
@@ -2234,7 +2234,7 @@
         }
       },
       {
-        "name": "Hunter (The Bad Batch)",
+        "name": "Hunter",
         "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134145162/59CF94272440AA250AFA7883ADC169BA9F1EDBEF/",
         "leader": true,
         "points": 0,
@@ -3640,7 +3640,7 @@
         "points": 6
       },
       {
-        "name": "Hunter",
+        "name": "On the Hunt",
         "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568142636/489DEDF6E445694D94ED3E8CA238B0B0DE4B1DE6/",
         "points": 6
       },

--- a/contrib/cards/official.json
+++ b/contrib/cards/official.json
@@ -1346,7 +1346,7 @@
       },
       {
         "name": "DLT-19 Stormtrooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568140049/9DA8A6B2DF19484212DC2516D345CE713F9D0F5E/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140097118/D6AB525C9958181EA70DE91A813AEB1CC758D896/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/2017090166650141001/FF62545FC3DEF499BA8A0C04F07917C6CAA9E30D/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/2017090166650141746/A8FD77EB51C50C64CD924BDAEEDB70D8839E0EF3/"
@@ -1551,7 +1551,7 @@
       },
       {
         "name": "Flametrooper",
-        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384856563/6A7AE5C7F2EF0D2D36392003251F456F8F432239/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140097285/FCD736B27C338F603E13D0B1FA8FA3E10D1CE1FA/",
         "mini": {
           "mesh": "http://cloud-3.steamusercontent.com/ugc/785234540541801931/BDE907EBE0BFC0DC4180C76AFEA3F8667013FF3B/",
           "diffuse": "http://cloud-3.steamusercontent.com/ugc/785234540541802054/044AD0961CD1485A61AC3B6CB3669FD8AA5A0FEB/"
@@ -1585,7 +1585,7 @@
       },
       {
         "name": "HH-12 Stormtrooper",
-        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384856773/E0A74297AEB51D3DFF351126F84C0B626A16D090/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140097369/5299C4869B939C8673F1B0BD1A28398C4287BFF9/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/2017090166650141088/7342269A721DF49D0C38F1469E8463093734EF66/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/2017090166650141746/A8FD77EB51C50C64CD924BDAEEDB70D8839E0EF3/"
@@ -1710,7 +1710,7 @@
       },
       {
         "name": "RT-97C Stormtrooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568145178/E34FCDD3060A28ED28C91966A004D3CB7DD6C62F/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140097529/6BD2F13FA6AB3A56E258254420005E9EB38C7C0B/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/2017090166650141221/5D4DAEED517F52EE2ECBC631301C97422F519AB9/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/2017090166650141746/A8FD77EB51C50C64CD924BDAEEDB70D8839E0EF3/"
@@ -1813,7 +1813,7 @@
       },
       {
         "name": "T-21 Stormtrooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568145912/C6F9E9EDA22CB6B40D955AE391F14227D648AF3B/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140098050/4A82E8EF8A7B04EFF91757E70C88282919912093/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/2017090166650141339/1EB723D5FCF6655CFFF7EF700EE7108274E1A6C7/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/2017090166650141746/A8FD77EB51C50C64CD924BDAEEDB70D8839E0EF3/"
@@ -1855,7 +1855,7 @@
       },
       {
         "name": "T-7 Ion Snowtrooper",
-        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384858483/D7093B50A0312E7F2A8B3A4C8C0F423B9CEBEEF0/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140097979/9F3CCF24FCF1D8F02F5B9CEEF9B8B4B157295F2F/",
         "mini": {
           "mesh": "http://cloud-3.steamusercontent.com/ugc/785234540541802160/69A03779E6B67F6F547C2FBD70ACDFC39281387D/",
           "diffuse": "http://cloud-3.steamusercontent.com/ugc/785234540541802252/037749C730FACCA3361B041BCB3C68E7E19DCDF8/"
@@ -2274,7 +2274,7 @@
       },
       {
         "name": "Stormtrooper Marksman",
-        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384858363/F0205B68198DAF7822B30F8A8CE687367431E3EA/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140177027/4884AC61C97A4ACD22A03F85D95CA468DE75886E/",
         "mini": {
           "bundle": "https://steamusercontent-a.akamaihd.net/ugc/2491137781649838294/7197479F9D7ADF9DB1287E740A469A0E5C28F2ED/",
           "secondary": "https://steamusercontent-a.akamaihd.net/ugc/2491137781649821736/A6557A52AB579A320023B7028C55A38815DC566E/"
@@ -2288,7 +2288,7 @@
       },
       {
         "name": "KX-Series Security Droids",
-        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384856910/4D9E28D75F17823F2BFB0656F2661D73514F0BDD/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140176950/CCE38141C12BFD65899FE18BF929C8BF0E2E1C57/",
         "minis": [
           {
             "mesh": "http://cloud-3.steamusercontent.com/ugc/773996263557000439/C9EA2A27264C73E42C016FE26E665CBB75F8E7DE/",
@@ -2657,7 +2657,7 @@
       },
       {
         "name": "FX-9 Medical Droid",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568141540/B2FECAE0481CC646596F372DA153E0216EE90A2A/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140097235/1B7C3623EF5EA7A2F7AB4123AF617CA73B851E05/",
         "mini": {
           "mesh": "http://cloud-3.steamusercontent.com/ugc/949599512594268065/7B4874981CECB7BB80D5BC54F60F1939B9A9DAB1/",
           "diffuse": "http://cloud-3.steamusercontent.com/ugc/949599512594268174/00246DE6DCE285206330C43B8049B19FFDF5BB41/"
@@ -2685,7 +2685,7 @@
       },
       {
         "name": "Imperial Comms Technician",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568142962/ABB4FE6D2C8D0A65384BC0CB85B2A05CB5CA9A15/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140097427/A759E82138BD75F9641E42316D314BCA9D70CF33/",
         "mini": {
           "mesh": "http://cloud-3.steamusercontent.com/ugc/949599512594268417/62CC1D5BCBD1EE294C72781B03AB972B3ED5AD12/",
           "diffuse": "http://cloud-3.steamusercontent.com/ugc/949599512594268526/CA2596C0B2D7DF68D794B2A7880F34B5459F1206/"
@@ -2699,7 +2699,7 @@
       },
       {
         "name": "Imperial Officer",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568143040/BC1F5D5F046DE97E7D046534D9810655A049FDC4/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140097483/145E74D65EDF1283F5CD01FA06655B2974624922/",
         "mini": {
           "mesh": "http://cloud-3.steamusercontent.com/ugc/785234540541565898/F06AB6731446249164D34ACA208E4FAE70C6FE00/",
           "diffuse": "http://cloud-3.steamusercontent.com/ugc/785234540541566011/A7A84EBF79DA5E1D5BCE71E863FC16EC40937F6F/"
@@ -3041,7 +3041,7 @@
       
       {
         "name": "Stormtrooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568145641/67887DD2E968766C0268BB4629E1EEA9CF54DFDC/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140097931/DB288D0B28104E95465A3ED5D12C65D527876F54/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/2017090166650140825/D8AE1D1F27B97F359916236DA163DA7EC4B517C1/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/2017090166650141746/A8FD77EB51C50C64CD924BDAEEDB70D8839E0EF3/"
@@ -3055,7 +3055,7 @@
       },
       {
         "name": "Stormtrooper Squad",
-        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384858433/8834A0455083F03C9C17B4A3B6CE67BD349EBF90/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140097883/0F0DF0E194F55384AE82D7F9A1CEA4EC7597CF42/",
         "minis": [
           {
             "bundle": "http://cloud-3.steamusercontent.com/ugc/2017090166650141545/30BEFE4E87E379AA361AFF5FD24A8F5D3F0BA4C0/",
@@ -3087,7 +3087,7 @@
       },
       {
         "name": "Snowtrooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568145489/3D4F0A2826C4DE7A61CB0CC895D2E3495DE91DAB/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140097669/E2D49A07E0E56FD07EC247313240A3D7C6ABE50D/",
         "mini": {
           "mesh": "http://cloud-3.steamusercontent.com/ugc/785234540541801717/EDEA1301FC55A6970D5FBCF0A9F10456E4C2EE40/",
           "diffuse": "http://cloud-3.steamusercontent.com/ugc/785234540541801215/595165C57A67BF2BD505BE6F0DF8F11AD4EA55D2/"
@@ -3101,7 +3101,7 @@
       },
       {
         "name": "Snowtrooper Squad",
-        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384858227/A2DD159803E85A5524E3BA6C4ED0BA54FF2BA33E/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140097587/A54CEC5E18DF9FB2F3C6A5B01DD6D2043D4BE27B/",
         "minis": [
           {
             "mesh": "http://cloud-3.steamusercontent.com/ugc/785234540541801837/D52F333945BF667A37E06611977C36186CEFC7B6/",
@@ -3133,7 +3133,7 @@
       },
       {
         "name": "Stormtrooper Captain",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568145556/326ED56BBF68B291DF37555D6155DD013F1E646A/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140097752/7B066902F66EB65B14B17D9170987270B5C9B0BA/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/2017090166650140913/ADEED3994E6F70777B939A89B18FF520765DCDC4/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/2017090166650141746/A8FD77EB51C50C64CD924BDAEEDB70D8839E0EF3/"
@@ -3148,7 +3148,7 @@
       },
       {
         "name": "Stormtrooper Specialist",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568145600/9F5038BBE19D0970091F9C1946001A4E825C22A1/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140097824/D6788FE32981247191B9A68F92DA96DAFDC3B47E/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/2017090166650141284/6D59924E68B2B1640C0AC479B8DE95F434056650/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/2017090166650141746/A8FD77EB51C50C64CD924BDAEEDB70D8839E0EF3/"

--- a/contrib/cards/official.json
+++ b/contrib/cards/official.json
@@ -3892,7 +3892,7 @@
     "Republic": [
       {
         "name": "Synchronized Offensive",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564036052/B952054E6772C522A8DDBA3C3104B9FE566A7B5D/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385135269254/75501E93209B73709745D7E629DBE9389A2984A8/",
         "pip": 1
       },
       {
@@ -3902,7 +3902,7 @@
       },
       {
         "name": "Air Support",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564035656/7903FA16377B9A65289123A1E422D50CC26DD83F/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134030778/90E5CEF9833FED1C5F926FB8878BDBCD5B5099F6/",
         "pip": 2
       },
       {
@@ -3922,7 +3922,7 @@
       },
       {
         "name": "AttacK Of the Clones",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865564034137/F1FFFF3A77BAAE6DB629082F50AC6B5AE9DEB6A7/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134033797/3AA33B36A7B9EAAC8444A6CAC176F2130EE30E6C/",
         "pip": 3
       },
       {

--- a/contrib/cards/official.json
+++ b/contrib/cards/official.json
@@ -1516,7 +1516,7 @@
       },
       {
         "name": "Echo, ARC Marksman",
-        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384856262/4BA95B3B0F7BC73BCC660FCD1A06755AEC65F72C/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139963016/7EFE284DE80081B2F8F535F53CB84469E2E2B1EF/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/1009315641457801321/CED1CD80F307683E79B9A4ED87CECAED7C070EBF/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/773995200348530664/5E248091F8CC37B1023257338D4947E4ADFE48AB/"
@@ -2245,8 +2245,8 @@
         }
       },
       {
-        "name": "Echo (The Bad Batch)",
-        "image": "http://cloud-3.steamusercontent.com/ugc/2475370743175005176/8F6AB3A73A2E006D0D8BD2840C192BC10D91E14A/",
+        "name": "Echo, Clone Force 99",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139963062/CC0A09363EDC2A36A670D71ABCFA34048B44B32F/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/2475370743175243825/0B07462AB1D02ACB64262C1E875E9DC5E3719850/"
         },

--- a/contrib/cards/official.json
+++ b/contrib/cards/official.json
@@ -200,7 +200,7 @@
         }
       },
       {
-        "name": "Saxon's Z-3X Jetpack Rockets",
+        "name": "Saxon's Jetpack Rockets",
         "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418868950/6FF2ED19A5AF3DDB0B20A1CC70775823D0C25DFB/",
         "points": 10,
         "restrictions": {

--- a/contrib/cards/official.json
+++ b/contrib/cards/official.json
@@ -498,7 +498,7 @@
       },
       {
         "name": "BARC RPS-6 Gunner",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568138675/9DB09C4307B16C289B8E4518D40177CF6122CE20/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140038100/7C11EBB315EC571301B50C93DFD2004930FB5A91/",
         "points": 21,
         "restrictions": {
           "include": {
@@ -508,7 +508,7 @@
       },
       {
         "name": "BARC Twin Laser Gunner",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568138722/946FBD11C5776F89102F92D94087A9DA81FABA87/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140038185/13E6A7A923E183A77BFC9704B86D6A36BD5921AD/",
         "points": 18,
         "restrictions": {
           "include": {
@@ -742,16 +742,6 @@
         "name": "Grappling Hooks",
         "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568141742/DA7EFC4BC5B4AC25BDB4AE6C3A084A9B10F66A8D/",
         "points": 2
-      },
-      {
-        "name": "JT-12 Jetpacks",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568143399/3D728D8253711B25C2DE4E1177D8B08A115A2746/",
-        "points": 10,
-        "restrictions": {
-          "include": {
-            "unit": ["Clone Captain Rex", "ARC Troopers"]
-          }
-        }
       },
       {
         "name": "Personal Combat Shield",
@@ -1110,7 +1100,7 @@
         "points": 15,
         "restrictions": {
           "include": {
-            "unit": ["TX-130 Saber-Class Fighter Tank"]
+            "unit": ["Saber-Class Tank"]
           }
         }
       },
@@ -1120,7 +1110,7 @@
         "points": 14,
         "restrictions": {
           "include": {
-            "unit": ["TX-130 Saber-Class Fighter Tank"]
+            "unit": ["Saber-Class Tank"]
           }
         }
       }
@@ -1556,21 +1546,6 @@
         "restrictions": {
           "include": {
             "unit": ["Imperial Royal Guards"]
-          }
-        }
-      },
-      {
-        "name": "Fives",
-        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384856467/9C8FFFD42DF5BCF0EE31E9CA9DABFE1B68235EE6/",
-        "mini": {
-          "bundle": "http://cloud-3.steamusercontent.com/ugc/1009315641457802221/506D704E232C1BFD85F063A24EBF24C5914C2C40/",
-          "secondary": "http://cloud-3.steamusercontent.com/ugc/773995200348530664/5E248091F8CC37B1023257338D4947E4ADFE48AB/"
-        },
-        "leader": true,
-        "points": 40,
-        "restrictions": {
-          "include": {
-            "type": ["Clone Trooper"]
           }
         }
       },
@@ -2307,7 +2282,7 @@
         "points": 30,
         "restrictions": {
           "include": {
-            "unit": ["Riot Control Squad"]
+            "unit": ["Stormtrooper Riot Squad"]
           }
         }
       },
@@ -2327,7 +2302,7 @@
         "points": 30,
         "restrictions": {
           "include": {
-            "unit": ["Riot Control Squad"]
+            "unit": ["Stromtrooper Riot Squad"]
           }
         }
       },
@@ -2349,7 +2324,7 @@
     "Squad Leader": [
       {
         "name": "Jedi Guardian",
-        "image": "https://steamusercontent-a.akamaihd.net/ugc/59215140638617630/9AB204944DB662D2D15FC2FA5E50F02138AD1FD6/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10803117186606641/15A4615ADD75A243A356670FC9AC6CAF270796F3/",
         "mini": {
           "mesh": "https://steamusercontent-a.akamaihd.net/ugc/16426912929621400/CC4D94EDC24D933D7333F5A35308606846A9B550/",
           "diffuse": "https://steamusercontent-a.akamaihd.net/ugc/16426912929621469/4B200440B54994D37A5B3667E04769CD92DE4F32/"
@@ -2375,7 +2350,94 @@
             "faction": ["Republic"]
           }
         }
-      } 
+      },
+      {
+        "name": "Clone Medic",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384855671/3D1C3D57159E59D347D6CC09FAC4718A4F1A7225/",
+        "mini": {
+          "bundle": "http://cloud-3.steamusercontent.com/ugc/2174736446809184711/BC2EE95F62E043F83A352F825B6A041AC6D59959/"
+        },
+        "points": 15,
+        "restrictions": {
+          "include": {
+            "type": ["Clone Trooper"]
+          }
+        }
+      },
+      {
+        "name": "Boil",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384855244/C0B4D4133262EB7AAA1DD3133545D5D4257ACE29/",
+        "mini": {
+          "bundle": "http://cloud-3.steamusercontent.com/ugc/2174736446813135454/32F343B3295B563DF3041AF5F433E151F88C66B6/"
+        },
+        "leader": true,
+        "points": 15,
+        "restrictions": {
+          "include": {
+            "type": ["Clone Trooper"],
+            "rank": ["Corps"]
+          }
+        }
+      },
+      {
+        "name": "Clone Captain",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384855290/1D4BC397E7FC6FD99DFE4A8B2B3799AB2CDDBC3D/",
+        "mini": {
+          "mesh": "http://cloud-3.steamusercontent.com/ugc/767228764785646423/F890985F1B31042E0BC10996930089A3A22BE5C5/",
+          "diffuse": "http://cloud-3.steamusercontent.com/ugc/767228764785647603/8F9ADBD1429C1AF247858C877548E15E5996F4A9/"
+        },
+        "leader": true,
+        "points": 22,
+        "restrictions": {
+          "include": {
+            "unit": ["Clone Trooper Infantry"]
+          }
+        }
+      },
+      {
+        "name": "Clone Commander",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384855406/77E62A8F0A3DA3E38BB66B8DFC270F600086A2BD/",
+        "mini": {
+          "bundle": "http://cloud-3.steamusercontent.com/ugc/2174736446809186354/387C36C2BB545E6CC882A05C0D81F5BE164166B7/"
+        },
+        "leader": true,
+        "points": 18,
+        "restrictions": {
+          "include": {
+            "type": ["Clone Trooper"]
+          }
+        }
+      },
+      {
+        "name": "Fives",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384856467/9C8FFFD42DF5BCF0EE31E9CA9DABFE1B68235EE6/",
+        "mini": {
+          "bundle": "http://cloud-3.steamusercontent.com/ugc/1009315641457802221/506D704E232C1BFD85F063A24EBF24C5914C2C40/",
+          "secondary": "http://cloud-3.steamusercontent.com/ugc/773995200348530664/5E248091F8CC37B1023257338D4947E4ADFE48AB/"
+        },
+        "leader": true,
+        "points": 40,
+        "restrictions": {
+          "include": {
+            "type": ["Clone Trooper"]
+          }
+        }
+      },
+      {
+        "name": "Waxer",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384858645/C13E3786197044E433A4CB9852C603CD7B4FC206/",
+        "mini": {
+          "bundle": "http://cloud-3.steamusercontent.com/ugc/2174736446813135349/81275DD398B659088A018A09394B7FD6E5C3B279/"
+        },
+        "leader": true,
+        "points": 20,
+        "restrictions": {
+          "include": {
+            "type": ["Clone Trooper"],
+            "rank": ["Corps"]
+          }
+        }
+      }
     ],
     "Ordnance": [
       {
@@ -2554,20 +2616,6 @@
         }
       },
       {
-        "name": "Clone Commander",
-        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384855406/77E62A8F0A3DA3E38BB66B8DFC270F600086A2BD/",
-        "mini": {
-          "bundle": "http://cloud-3.steamusercontent.com/ugc/2174736446809186354/387C36C2BB545E6CC882A05C0D81F5BE164166B7/"
-        },
-        "leader": true,
-        "points": 18,
-        "restrictions": {
-          "include": {
-            "type": ["Clone Trooper"]
-          }
-        }
-      },
-      {
         "name": "Clone Comms Technician",
         "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384855468/B256FB44C0E0DF5D2B60342F59729EA6EEBB6083/",
         "mini": {
@@ -2587,19 +2635,6 @@
           "bundle": "http://cloud-3.steamusercontent.com/ugc/2174736446809184624/F2826DD52329584D1C3B3795B0E55948EA96B467/"
         },
         "points": 14,
-        "restrictions": {
-          "include": {
-            "type": ["Clone Trooper"]
-          }
-        }
-      },
-      {
-        "name": "Clone Medic",
-        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384855671/3D1C3D57159E59D347D6CC09FAC4718A4F1A7225/",
-        "mini": {
-          "bundle": "http://cloud-3.steamusercontent.com/ugc/2174736446809184711/BC2EE95F62E043F83A352F825B6A041AC6D59959/"
-        },
-        "points": 15,
         "restrictions": {
           "include": {
             "type": ["Clone Trooper"]
@@ -2691,21 +2726,6 @@
           }
         },
         "leader": true
-      },
-      {
-        "name": "Clone Captain",
-        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384855290/1D4BC397E7FC6FD99DFE4A8B2B3799AB2CDDBC3D/",
-        "mini": {
-          "mesh": "http://cloud-3.steamusercontent.com/ugc/767228764785646423/F890985F1B31042E0BC10996930089A3A22BE5C5/",
-          "diffuse": "http://cloud-3.steamusercontent.com/ugc/767228764785647603/8F9ADBD1429C1AF247858C877548E15E5996F4A9/"
-        },
-        "leader": true,
-        "points": 22,
-        "restrictions": {
-          "include": {
-            "unit": ["Clone Trooper Infantry"]
-          }
-        }
       },
       {
         "name": "Clone Specialist",
@@ -3224,36 +3244,6 @@
         }
       },
       {
-        "name": "Boil",
-        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384855244/C0B4D4133262EB7AAA1DD3133545D5D4257ACE29/",
-        "mini": {
-          "bundle": "http://cloud-3.steamusercontent.com/ugc/2174736446813135454/32F343B3295B563DF3041AF5F433E151F88C66B6/"
-        },
-        "leader": true,
-        "points": 15,
-        "restrictions": {
-          "include": {
-            "type": ["Clone Trooper"],
-            "rank": ["Corps"]
-          }
-        }
-      },
-      {
-        "name": "Waxer",
-        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384858645/C13E3786197044E433A4CB9852C603CD7B4FC206/",
-        "mini": {
-          "bundle": "http://cloud-3.steamusercontent.com/ugc/2174736446813135349/81275DD398B659088A018A09394B7FD6E5C3B279/"
-        },
-        "leader": true,
-        "points": 20,
-        "restrictions": {
-          "include": {
-            "type": ["Clone Trooper"],
-            "rank": ["Corps"]
-          }
-        }
-      },
-      {
         "name": "Imperial Dark Trooper",
         "image": "http://cloud-3.steamusercontent.com/ugc/2004698291313161746/1247297ABF21E0A03C9611713FA91D8D0882BF73/",
         "mini": {
@@ -3313,7 +3303,7 @@
         "points": 5,
         "restrictions": {
           "include": {
-            "unit": ["TX-130 Saber-Class Fighter Tank"]
+            "unit": ["Saber-Class Tank"]
           }
         }
       },
@@ -3463,7 +3453,7 @@
         "points": 9,
         "restrictions": {
           "include": {
-            "unit": ["TX-130 Saber-Class Fighter Tank"]
+            "unit": ["Saber-Class Tank"]
           }
         }
       },
@@ -3515,7 +3505,7 @@
         "points": 7,
         "restrictions": {
           "include": {
-            "unit": ["TX-130 Saber-Class Fighter Tank"]
+            "unit": ["Saber-Class Tank"]
           }
         }
       },

--- a/contrib/cards/official.json
+++ b/contrib/cards/official.json
@@ -24,20 +24,6 @@
         }
       },
       {
-        "name": "A-300 Long Range Config",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568137867/156C35C00A49AC23AE84E5ACCF35ADD6D7CBD820/",
-        "flip": {
-          "name": "A-300 Short Range Config",
-          "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568137938/8B2FA2C71505CA93AB086154658132C221BEBE1D/"
-        },
-        "points": 0,
-        "restrictions": {
-          "include": {
-            "unit": ["Rebel Pathfinders"]
-          }
-        }
-      },
-      {
         "name": "A280-CFE Sniper Config",
         "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568137831/63A163395CE6017A0EB530C2B68DA6539467AFA9/",
         "flip": {
@@ -53,7 +39,7 @@
       },
       {
         "name": "CR-24 Flame Rifle",
-        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384856022/F63CC44EB26ABD405BE2D653EB86E9D6C3F3FAC7/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140106922/DC1ED64816ECD4A7AB128F05D70EF97408305AAF/",
         "points": 10,
         "restrictions": {
           "include": {
@@ -87,7 +73,7 @@
       },
       {
         "name": "Electro Gauntlets",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568140666/E94C606161E8FA9736C7483B6A8314F76599D114/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148639059/89380FD599DD6819950BB21C5F940A9074C34A51/",
         "points": 10,
         "restrictions": {
           "include": {
@@ -151,7 +137,7 @@
       },
       {
         "name": "RT-97C Blaster Rifle",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568145098/F1FA0599FBE1CF545924E0DF1295FBCEDC4C1E31/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140107008/1524B081B7155F22B18F85E7789813478AE6EA3C/",
         "points": 5,
         "restrictions": {
           "include": {
@@ -161,7 +147,7 @@
       },
       {
         "name": "T-21 Blaster Rifle",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568145823/450F63D2D6AF6226A4CCFC77A02ADAE0F501D74E/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140107073/9B787B4695966A18D0659B28A979EBEFFA1C29BD/",
         "points": 5,
         "restrictions": {
           "include": {
@@ -201,7 +187,7 @@
       },
       {
         "name": "Saxon's Jetpack Rockets",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418868950/6FF2ED19A5AF3DDB0B20A1CC70775823D0C25DFB/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148638324/2B2554057A17324B946ADF61B44CFB94081A770D/",
         "points": 10,
         "restrictions": {
           "include": {
@@ -211,7 +197,7 @@
       },
       {
         "name": "Saxon's Galar-90 Rifle",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418868898/8A5057542AE7DB2E45E127DF0510423EA839BD4B/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148638360/9640DCEEFC8C952C5828F120F9527886B6AD1AEB/",
         "points": 15,
         "restrictions": {
           "include": {
@@ -221,7 +207,7 @@
       },
       {
         "name": "Saxon's ZX Flame Projector",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418868841/07EFB6B5703BB6979CD5569E8CBB619AAE9EE68D/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148638292/3120A41DA39C3D76C2B2584CB20390E4D8FE90D4/",
         "points": 5,
         "restrictions": {
           "include": {
@@ -231,7 +217,7 @@
       },
       {
         "name": "The Darksaber (Maul)",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418868072/6318F3683F1BAB3C5503116F4FFD42994980C329/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148637945/3B49E86E68EBCB65154B12ECD4336463F7400B95/",
         "points": 10,
         "restrictions": {
           "include": {
@@ -241,7 +227,7 @@
       },
       {
         "name": "Super Commando Jetpack Rockets",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418869197/CA87526A2FF3014B51B50A251256128036C456B8/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148638126/810C46F8A1B873A7CFFBDC1DDDEE400DFC3AF388/",
         "points": 8,
         "restrictions": {
           "include": {
@@ -251,7 +237,7 @@
       },
       {
         "name": "Din's Amban Rifle",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1904476875947527123/B78DE61B41F9665BD772F28F218BBAA87D37F1A4/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148639183/C2D75F184A5F66EA154C4DF44AADA7A9443A9468/",
         "points": 10,
         "restrictions": {
           "include": {
@@ -261,7 +247,7 @@
       },
       {
         "name": "Beskar Spear",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1787388827710906626/DF09FB811E1E1B773A2681089D13ADD21A9A488B/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148639488/EDE8AA68D0589BFB956D68E2A08B31715C5F9D61/",
         "points": 15,
         "restrictions": {
           "include": {
@@ -518,7 +504,7 @@
       },
       {
         "name": "Backworld Medic",
-        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384855077/2BE9A9EFF901897C3C6080EE3375637D83A5C391/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148639527/67E63647F6AA6084064CE8960AE4DD49094F213E/",
         "points": 12,
         "restrictions": {
           "include": {
@@ -568,7 +554,7 @@
       },
       {
         "name": "Unorthodox Tactician",
-        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384858591/61BE5EFE62BA638E68E63DF6112441E3CB718082/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148637911/5E0AD27637C0A160099F5D36889082BD84E94BB1/",
         "points": 16,
         "restrictions": {
           "include": {
@@ -578,7 +564,7 @@
       },
       {
         "name": "Unstable R5 Astromech",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568146312/15D87007EAFBBAAF2EE385C446C0287163D47BEB/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148637860/93B0991DD63C226FA855DA5D2320F2372792BD7C/",
         "points": 6,
         "restrictions": {
           "include": {
@@ -775,7 +761,7 @@
       },
       {
         "name": "Saxon's Combat Shield",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418869001/DB608296AFAC9362F7134DABAC6468F3A6147B89/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148638398/E7F27B6FC186179E16B72827C7E7C6B67C53E233/",
         "points": 10,
         "restrictions": {
           "include": {
@@ -785,7 +771,7 @@
       },
       {
         "name": "Super Commando Combat Shields",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418869253/B3156081A7C9FD8C32A205074E9275D69E55AF40/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148638051/2EB1F2BA6DC3BB022D0E9D04FAA77BEF7DE474E9/",
         "points": 10,
         "restrictions": {
           "include": {
@@ -800,7 +786,7 @@
       },
       {
         "name": "Din's Flame Projector",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1787388827710906580/1EC967CC4F871D07D3F419B4CF574394D289DBB6/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148639154/CADD313D51F397A3004E77A7381CE0689F17A440/",
         "points": 8,
         "restrictions": {
           "include": {
@@ -809,8 +795,8 @@
         }
       },
       {
-        "name": "The Mando's Jetpack",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1745728519554809657/3764760A87911D68177CFFC7A20496C62F595F6A/",
+        "name": "Din's Jetpack",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148639132/7B4DCC45594881429C69D3D0AB70CEDF61F543B4/",
         "points": 15,
         "restrictions": {
           "include": {
@@ -820,7 +806,7 @@
       },
       {
         "name": "Boba's Flame Projector",
-        "image": "http://cloud-3.steamusercontent.com/ugc/5070522239150798336/0990097AEA89A53AEBCB2E6B284C942F94E6D29D/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148639345/522E39430567071F6AB7C73BCC5C8270B3652384/",
         "points": 5,
         "restrictions": {
           "include": {
@@ -875,8 +861,8 @@
     ],
     "Hardpoint": [
       {
-        "name": "88 Twin Light Blaster Cannon",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568137716/C3D031A467025443C0F4B4490623F5D84A3D15A2/",
+        "name": "88i Twin Light Blaster",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148691925/3E5BD15301BBACDB13D110B2284E17980F052601/",
         "points": 10,
         "restrictions": {
           "include": {
@@ -906,7 +892,7 @@
       },
       {
         "name": "AG-2G Quad Laser",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568138060/2F0A343971984B412473C58FD82F4922B7399B1A/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148639560/6A39AE6CE8A42E8B04D4C5F128F5386A7DBF6CA8/",
         "points": 28,
         "restrictions": {
           "include": {
@@ -946,7 +932,7 @@
       },
       {
         "name": "AT-ST Mortar Launcher",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568138347/BC6154F6C5F0552679C8C9402DBA5AF2851378AF/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148692069/D79A2F7BF496B1EFCF593CB54F929F68B047A8F9/",
         "points": 5,
         "restrictions": {
           "include": {
@@ -965,8 +951,8 @@
         }
       },
       {
-        "name": "DLT-19 Rifle Pintle",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568140009/5BBDBCA0A1A79D898C63B099429F778FD978C993/",
+        "name": "Pintle-Mounted DLT-19",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148691806/1D3A6A70D19D4C84286B171457623AA3119A2C03/",
         "points": 18,
         "restrictions": {
           "include": {
@@ -975,8 +961,8 @@
         }
       },
       {
-        "name": "DW-3 Concussion Grenade Launcher",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568140401/EB45423FD61A806271D849371554698856203F35/",
+        "name": "DW-3 Grenade Launcher",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148690988/9E08D059DB9C6A383AFD15329511C04A96215DA1/",
         "points": 8,
         "restrictions": {
           "include": {
@@ -986,7 +972,7 @@
       },
       {
         "name": "Heavy Laser Retrofit",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568141789/1466FB973611960CE6C870F27FE8D1735671048B/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148638934/56D0602972CB54B152705C5A6ECB19C2761A6C65/",
         "points": 16,
         "restrictions": {
           "include": {
@@ -1055,8 +1041,8 @@
         }
       },
       {
-        "name": "RT-97C Rifle Pintle",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568145142/326682328F95F04A5229510F832857C4392032D4/",
+        "name": "Pintle-Mounted RT-97C",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148692381/4CDBE4E62F256CAFC40FEBE392F64789B73B5BC1/",
         "points": 14,
         "restrictions": {
           "include": {
@@ -1146,7 +1132,7 @@
       },
       {
         "name": "T-21A Range Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/2495630600682578710/13027CE8B24DC2CB5822CE42A7AA586D5379CB56/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148701863/275BF33D3FD2CC6BCE759757AB74CEB8C940788F/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/2495630600682669896/C2F5892D64B3B5CE33A83A3F874C1A66594F6412/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/2495630600682582649/F03C73249983DDC1178314FD61C7D53DA27840EE/"
@@ -1160,7 +1146,7 @@
       },
       {
         "name": "DLT-20A Range Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/2495630600682578524/371C5FC0CE0B3AF9BB38051C9C1FC353113C493F/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148698292/C6A146809D4BE1EBF289B7217AA7995C4828A731/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/2495630600682669844/3306C99E1B2A23502CA35EEB63FC842EA7FB4E3A/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/2495630600682582649/F03C73249983DDC1178314FD61C7D53DA27840EE/"
@@ -1924,7 +1910,7 @@
       },
       {
         "name": "Rook Kast",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418868786/3A9F4271A4AB786FD93CFEFCBF41BC18B930BB0F/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148638438/ECEE74FD265762CEC44438C9D0C5FF263009C3F2/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/1789640371719006177/3A456EB29012BFBE4322E020CBC08CF6F915BBF3/"
         },
@@ -1938,7 +1924,7 @@
       },
       {
         "name": "Mandalorian Super Commando",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418869300/DE8184C6612CB3692648B62D2B0A00DB66227658/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148638743/16D7B984EB6DA1BE6AF202D902459EE20DD03050/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/1856061112420143500/4BDEA7F5B523FC06641B3D71D1E112DC14BD7F81/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/1789640371717200823/B886D3157AA2F2528F4E5F76F26DF44A41496615/"
@@ -1952,7 +1938,7 @@
       },
       {
         "name": "Super Commando Gunslinger",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418868228/FC69830397335680A33E25E45AE19D006FA27D54/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148638185/062D34CA1E85F91921AE17FA20FADC622E3F1591/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/1856061112420143366/41AB7DFFD2FCF20E2BCC3F899F728863C30F6343/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/1789640371717200823/B886D3157AA2F2528F4E5F76F26DF44A41496615/"
@@ -1980,7 +1966,7 @@
       },
       {
         "name": "Electro-Whip Soldier",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418868613/D7093F36FCB71E5551D1FC1A93EF501BDE89E9C6/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148639043/A6DFE4AD6FFFB452A302B6731A9F7667F7A0667E/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/1745728387706845513/BB3CD9624D6F43250D0406D099819E497A1A70BE/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/1856061112420143543/CBAC94E0D1731CB8D1034D24F58987E854A8596A/"
@@ -1994,7 +1980,7 @@
       },
       {
         "name": "P13-M Disruptor Soldier",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418868532/C68FB885715CDCFC65D52035ED7D020A77B6D63B/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148638629/3C20733912FB63D65394756509211C5CF6C39CDA/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/1745728387706845607/4B1530CF96F9DB8F172B02676F1D8B347CFD862A/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/1856061112420143543/CBAC94E0D1731CB8D1034D24F58987E854A8596A/"
@@ -2008,7 +1994,7 @@
       },
       {
         "name": "Mag-Det Enforcer",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418867767/CA0A4DC9D0EC4E7D77E7A2F881E4B9C589E47D49/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148638823/D41C1DD1A9B63A173D667167C2CA1E79D0BA2F1E/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/1856061112420143649/BBBA0D26FB46EAD96421C4B77FE779B5F0F848AA/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/1856061112420143328/3D6F3C2E8DFB78B9B748FFC8F339B9C568D7408E/"
@@ -2022,7 +2008,7 @@
       },
       {
         "name": "Scatter Gun Enforcer",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418869073/87B7CB8609CEF373FD8294E16F972F3B753FC473/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148638229/542B7031B727D74585CE7FA38EEA086252152001/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/1856061112420143685/C75388115AFCF42ACC79E2C16FEF36755C975AA0/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/1856061112420143328/3D6F3C2E8DFB78B9B748FFC8F339B9C568D7408E/"
@@ -2036,7 +2022,7 @@
       },
       {
         "name": "XS-IV Assault Cannon",
-        "image": "http://cloud-3.steamusercontent.com/ugc/2004698291313161848/274FD9DA145A86F77F5F76459CB5A4486634809F/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148692176/FE7C110B78061106AA1471FE6B6EE3BD5F645AE2/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/2004698291313160948/23CA698C8F2AF1C08D2DED3564B138E72E2ABCBF/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/2004698291313176203/E77892ADB668EA0CB548F6ED71BE44CA3FB730E7/"
@@ -2050,7 +2036,7 @@
       },
       {
         "name": "SM-9 Frag Launcher",
-        "image": "http://cloud-3.steamusercontent.com/ugc/2004698291313161941/15469090E692070F2CF4C9DB77BFF86C785D7170/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148692274/A56AA57889F61A9BDE9C1C7338B023C30BF7108B/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/2004698291313161010/1873BCD554A553BC2FF25A2BE16116EDEBFDCEF4/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/2004698291313176203/E77892ADB668EA0CB548F6ED71BE44CA3FB730E7/"
@@ -2064,7 +2050,7 @@
       },
       {
         "name": "Mertalizer",
-        "image": "http://cloud-3.steamusercontent.com/ugc/2004698291313161801/E99B9E5D5C85437D03F94FAB91EFDFC94942A8FD/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148691701/24C8FA07250A2FF8E6E94EC79E6B3F87145E7D5A/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/2004698291313161066/7BD340C7AAB594CDA1644D900F606FEC8A0165A1/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/2004698291313176203/E77892ADB668EA0CB548F6ED71BE44CA3FB730E7/"
@@ -2493,7 +2479,7 @@
       },
       {
         "name": "Range Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/2495630600682578626/9EF5E8D52EF570E3EC76FCEEA8034A877760E02E/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385140107049/41E44A7B3EEAA1EAC25BB17B1565C80E1C84C1D9/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/2495630600682669758/7E6C79BDA776AD0618FF66FCD961C59DD6B0F4F1/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/2495630600682582649/F03C73249983DDC1178314FD61C7D53DA27840EE/"
@@ -3189,7 +3175,7 @@
       },
       {
         "name": "Black Sun Enforcer",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418867712/6051FD1EF409CBB0A7757160F09AC78B72BEC3A4/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148639440/31A3527F3D9D8579BDBD433D5F30F1EF973A47C8/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/1856061112420143724/48B5A35E10B4977E255D889A8FCAEA8C980A11A9/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/1856061112420143328/3D6F3C2E8DFB78B9B748FFC8F339B9C568D7408E/"
@@ -3203,7 +3189,7 @@
       },
       {
         "name": "Black Sun Vigo",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418867819/727372941AE48218A0802978D1BDDF4F31C913C2/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148639389/E73718337CFAD8FD65CD341B6CF649BA181707AD/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/1856061112420143763/E93BA6716A05CA95AE2EA3B7C0DFD8AF145D5C22/"
         },
@@ -3217,7 +3203,7 @@
       },
       {
         "name": "Pyke Syndicate Foot Soldier",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418868575/B028852AE9F715AD7187417FFE4FF2C0080B4CFB/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148638523/E0BF45AC2918D78E53F39A4EB61372E0FBD24AF5/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/1745728387706845389/0D7DFE0C5BF5CDD527A619B75A25A2177D417BD0/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/1856061112420143543/CBAC94E0D1731CB8D1034D24F58987E854A8596A/"
@@ -3231,7 +3217,7 @@
       },
       {
         "name": "Pyke Syndicate Capo",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418868470/E65DC0B54E38107176D824D62358DD8C7C58E626/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148638580/65166B7E91103AD7B1F26E197338FD01B98E7591/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/1856061112420351237/706DEA645FEE2EC9787F05F4FF2926632E2C4894/"
         },
@@ -3245,7 +3231,7 @@
       },
       {
         "name": "Imperial Dark Trooper",
-        "image": "http://cloud-3.steamusercontent.com/ugc/2004698291313161746/1247297ABF21E0A03C9611713FA91D8D0882BF73/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148691379/518F04086F72215062FDD24016FE412B7F0F9106/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/1785135125810942938/E77EC5970DA310A2E1D96F796E98D82813AE0891/",
           "secondary": "http://cloud-3.steamusercontent.com/ugc/2004698291313176203/E77892ADB668EA0CB548F6ED71BE44CA3FB730E7/"
@@ -3309,7 +3295,7 @@
       },
       {
         "name": "Baron Rudor",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568138757/0E1640674CF5C8E3653FCBF2F4D80A5114A39721/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148690870/A59A9EC3A2ED826D0BBE1CC6B2573483C238EB2E/",
         "points": 8,
         "restrictions": {
           "include": {
@@ -3342,7 +3328,7 @@
       },
       {
         "name": "First Sergeant Arbmab",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568141090/740EAB2F18C57EDA5B5B68F65A450C3818C501D4/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148691104/395E3C391D3513EC8CCD4D6220372B8793EAA936/",
         "points": 5,
         "restrictions": {
           "include": {
@@ -3353,7 +3339,7 @@
       },
       {
         "name": "General Weiss",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568141576/6F1DDB015ACC524050345200BB4AB1253B0A2831/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148691201/0F949459DDCA1EAFC03EC7145C7402A636C9C4BE/",
         "points": 5,
         "restrictions": {
           "include": {
@@ -3364,7 +3350,7 @@
       },
       {
         "name": "Governor Pryce",
-        "image": "https://steamusercontent-a.akamaihd.net/ugc/2495640747384856727/19928811CEFD0110E7AF7ECD130F8E14FF3D2FBE/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148691269/0E980DEE7A89F49805E303D9A4BD5D4CF4CC2CA5/",
         "points": 5,
         "restrictions": {
           "include": {
@@ -3396,7 +3382,7 @@
       },
       {
         "name": "Imperial Hammers Elite Armor Pilot",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568142993/63E86E72153D62F5E106D1E99D7F8782F681087C/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148691474/7EFEFFFDE5EF5899C5E3F3F06C855D794B67E7F7/",
         "points": 10,
         "restrictions": {
           "include": {
@@ -3407,7 +3393,7 @@
       },
       {
         "name": "Imperial TIE Pilot",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1680393865568143081/BA4178196976FBEDBDF44E41564A943FCCBB3CDD/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148691580/FB3F0FA888AD2792554DBEBC95A8509790A299BD/",
         "points": 8,
         "restrictions": {
           "include": {
@@ -3522,7 +3508,7 @@
       },
       {
         "name": "Frenzied Gunner",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418868113/EE013C9F47F1AF5892B7E5925B21FBE257F543C1/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148638994/BB7B0FF17AF90112CFE43A75F5762598858400DB/",
         "points": 5,
         "restrictions": {
           "include": {
@@ -3532,7 +3518,7 @@
       },
       {
         "name": "Raiding Party Leader",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418868737/F0450E81A685273C219EDD3A9748DC9C1DB72CF0/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148638497/FA19544838EC45188131DAA0750684C57267D3B9/",
         "points": 10,
         "restrictions": {
           "include": {
@@ -3574,7 +3560,7 @@
       },
       {
         "name": "\"Nanny\" Programming",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1904476875947527805/6FBD0F57EA4E387AB50CB6336F964AF0D7F3629E/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148638679/4804577A9E8C3C865E84CEECED87D0E1E113316E/",
         "points": 5,
         "restrictions": {
           "include": {
@@ -3585,7 +3571,7 @@
       },
       {
         "name": "\"Bounty\" Programming",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1883093542262844219/53CD038C2ED3712A10B665C0E7B58A981A8201C8/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148639304/9F41559BA60B2818CC2EEF4A560273B136B987D0/",
         "points": 5,
         "restrictions": {
           "include": {
@@ -3595,7 +3581,7 @@
       },
       {
         "name": "Programmed Loyalty",
-        "image": "http://cloud-3.steamusercontent.com/ugc/2004698291313161889/3CCEE804F4975D6583244F6AF9BA4EB3FB78B945/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148692470/2BD6DDB57A0387833FB43044131859D281EBD909/",
         "points": 5,
         "restrictions": {
           "include": {
@@ -3751,7 +3737,7 @@
       },
       {
         "name": "Ploy",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418876724/E501DA3A7FFF7E1FF23619021C675C1074A2B32D/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385148677058/419EFF83F969C131102CF0C1B4407F7F9920EF30/",
         "pip": 1
       },
       {
@@ -3761,7 +3747,7 @@
       },
       {
         "name": "Aggression",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418876447/C6682AF02659DF16F123CBC996B76AFEE220997D/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139727645/6DE7757843A4090ABC83D7A4A2A69526B8FEEA5D/",
         "pip": 2
       },
       {
@@ -3771,7 +3757,7 @@
       },
       {
         "name": "Discretion",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1856061112418876505/D29A1F76745E04544109A595E4BC32B117A29DE2/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385139727608/7FBDB2A3BEECFA85A5AB92E6D6DEC029E779DB31/",
         "pip": 3
       },
       {

--- a/contrib/cards/official.json
+++ b/contrib/cards/official.json
@@ -421,7 +421,7 @@
     "Counterpart": [
       {
         "name": "C-3PO",
-        "image": "http://cloud-3.steamusercontent.com/ugc/1616219505080628828/F6A01DB4DFDB1A518FC4E373D72237AB1B31300B/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134141499/36DA30FD99788C7127DCADE11325FDBC09B16747/",
         "points": 15,
         "mini": {
           "mesh": "http://cloud-3.steamusercontent.com/ugc/776232727456807069/DE7E32B39455DB5111769436FD0C5BFDA3841268/",
@@ -2235,7 +2235,7 @@
       },
       {
         "name": "Hunter (The Bad Batch)",
-        "image": "http://cloud-3.steamusercontent.com/ugc/2475370743175005230/53DDE7626A5573411C2116565252DBB566D42E57/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134145162/59CF94272440AA250AFA7883ADC169BA9F1EDBEF/",
         "leader": true,
         "points": 0,
         "restrictions": {
@@ -2259,7 +2259,7 @@
       },
       {
         "name": "Tech",
-        "image": "http://cloud-3.steamusercontent.com/ugc/2475370743175005546/E5F647B0415410E8715ED04BF37452E949115B9C/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134145194/EA026AF5A84A9F1E34CCC601A39DF61B36D664CA/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/2475370743175244098/67CBDAB9CA48B24940FC743CEB778A526C990993/"
         },
@@ -2272,7 +2272,7 @@
       },
       {
         "name": "Wrecker",
-        "image": "http://cloud-3.steamusercontent.com/ugc/2475370743175005604/3FB4414E24AD04E6ACB6A1845E4E9484E0F62018/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134145231/9FC3E238C50C89E5B4036AC1275370BAEF3B3944/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/2475370743175244156/4986205CB2289E6CF72269D9A17E6B2D405968DA/"
         },
@@ -2285,7 +2285,7 @@
       },
       {
         "name": "Crosshair",
-        "image": "http://cloud-3.steamusercontent.com/ugc/2475370743175005095/75BB087312B198ADA7A069E7E861D44654529734/",
+        "image": "https://steamusercontent-a.akamaihd.net/ugc/10804385134145124/0F6E5EBD2C22692BF7E757F46293934D4552CA6A/",
         "mini": {
           "bundle": "http://cloud-3.steamusercontent.com/ugc/2475370743175244300/863B36B154CA2A32E4C36B9CFBC47984846ECE3C/"
         },


### PR DESCRIPTION
Added Bad Batch, Chewbacca, Commander Cody, Clone Commander, Wokiee Chieftain, Obi Wan, Padme, R2-D2, Captain Rex, and Yoda Unit and Command Cards. Added C3PO and BB upgrades minus Echo.