### PR TITLE
Add macOS and Linux support to the dev symlink helpers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,25 +103,31 @@ export async function compileSaveFile(
   }
 }
 
+function defaultTTSHomeDir(): string {
+  const platform = os.platform();
+  if (platform === 'win32') {
+    return steam.homeDir.win32(process.env);
+  }
+  if (platform === 'darwin') {
+    return path.join(os.homedir(), 'Library', 'Tabletop Simulator');
+  }
+  if (platform === 'linux') {
+    return path.join(os.homedir(), '.local', 'share', 'Tabletop Simulator');
+  }
+  throw new Error(`Unsupported platform: ${platform}`);
+}
+
 export async function destroySymlink(homeDir?: string): Promise<void> {
-  // TODO: Add non-win32 support.
   if (!homeDir) {
-    if (os.platform() !== 'win32') {
-      throw new Error(`Unsupported platform: ${os.platform()}`);
-    }
-    homeDir = steam.homeDir.win32(process.env);
+    homeDir = defaultTTSHomeDir();
   }
   const from = path.join(homeDir, 'Saves', 'TTSDevLink');
   return fs.remove(from);
 }
 
 export async function createSymlink(homeDir?: string): Promise<string> {
-  // TODO: Add non-win32 support.
   if (!homeDir) {
-    if (os.platform() !== 'win32') {
-      throw new Error(`Unsupported platform: ${os.platform()}`);
-    }
-    homeDir = steam.homeDir.win32(process.env);
+    homeDir = defaultTTSHomeDir();
   }
   await destroySymlink(homeDir);
   const from = path.join(homeDir, 'Saves', 'TTSDevLink');


### PR DESCRIPTION
`createSymlink` and `destroySymlink` throw on anything that is not Windows,
under a `// TODO: Add non-win32 support.` that has been there since #230 in
February 2021.

`npm start` calls `createSymlink()` right away, so on macOS the repo's own
working command stops before doing anything. Contributors on a Mac cannot use
the documented workflow at all.

This adds the missing platforms:

- `defaultTTSHomeDir()` holds the per-platform location in one place
- macOS: `~/Library/Tabletop Simulator`
- Linux: `~/.local/share/Tabletop Simulator`
- anything else still throws, with the same message

**Windows is untouched.** It goes through the same `steam.homeDir.win32(process.env)`
call as before; the only change on that path is that it now lives in one function
instead of being duplicated in two.

Tested on macOS: `createSymlink()` creates `~/Library/Tabletop Simulator/Saves/TTSDevLink`
pointing at `dist`, and `destroySymlink()` removes it. I have not been able to
test the Linux path on a real Linux install, so treat that one line as
best-effort; it is the standard TTS data directory there.

For context, this same change is also carried inside #600, which is about the
macOS shader bundles. It has nothing to do with that work and needs no decision
from you, so it seemed better to offer it on its own. If you take it here, I will
rebase #600 on top and drop it from there.
